### PR TITLE
Fix/clean UI warning text

### DIFF
--- a/Saturn.Tests/Tools/ApplyDiffToolTests.cs
+++ b/Saturn.Tests/Tools/ApplyDiffToolTests.cs
@@ -565,7 +565,7 @@ Content C");
         public void Description_ReturnsNonEmptyDescription()
         {
             _tool.Description.Should().NotBeNullOrWhiteSpace();
-            _tool.Description.Should().Contain("changes to files");
+            _tool.Description.Should().Contain("file changes");
         }
 
         [Fact]

--- a/Tools/ApplyDiffTool.cs
+++ b/Tools/ApplyDiffTool.cs
@@ -12,61 +12,46 @@ namespace Saturn.Tools
     public class ApplyDiffTool : ToolBase
     {
         public override string Name => "apply_diff";
-        
-        public override string Description => @"Use this tool to make changes to files - adding, updating, or deleting. This is your primary tool for modifying code and text files.
 
-When to use:
-- Making code changes, fixes, or improvements
-- Adding new files or features
-- Removing outdated or unnecessary files
-- Updating configuration files
-- Applying any text modifications
+        public override string Description => @"Apply targeted file changes (add, update, delete) encoded as
+patch blocks. Use this tool for precise, small edits rather than large rewrites.
 
-How to use:
-1. ALWAYS read the file first with read_file tool (for updates)
-2. Create a patch with clear context and changes
-3. Use unique context lines to identify where changes go
+Supported operations:
+- Add file:    '*** Add File: path/to/file' followed by lines prefixed with '+'.
+- Update file: '*** Update File: path/to/file' followed by hunks starting with
+  '@@ context @@' and lines prefixed with ' ' (keep), '-' (remove), '+' (add).
+- Delete file: '*** Delete File: path/to/file' (no body required).
 
-Patch format examples:
+Rules and guidance:
+- **ALWAYS** read the the target file before attempting any actions.
+- Context lines inside '@@ ... @@' must be unique in the target file and match the
+  file content exactly (trimmed) to locate the hunk position reliably.
+- Keep hunks small and well-scoped. Prefer multiple targeted hunks over large
+  ambiguous changes.
+- Use dryRun=true to validate the patch and preview statistics without writing
+  files.
+- This tool enforces path security and will reject attempts at path traversal or
+  edits outside the working directory.";
 
-Adding a new file:
-*** Add File: src/NewFeature.cs
-+using System;
-+
-+public class NewFeature
-+{
-+    public void Method() { }
-+}
-
-Updating existing file:
-*** Update File: src/Existing.cs
-@@ public void ExistingMethod() @@
- {
--    var old = true;
-+    var updated = false;
-+    var newLine = GetValue();
- }
-
-Deleting a file:
-*** Delete File: src/OldFile.cs
-
-Important: The context line (@@ ... @@) must be unique in the file!";
-        
         protected override Dictionary<string, object> GetParameterProperties()
         {
             return new Dictionary<string, object>
             {
-                { "patchText", new Dictionary<string, object>
-                    {
-                        { "type", "string" },
-                        { "description", "The full patch text that describes all changes to be made. Use the format described in the tool description." }
-                    }
+                ["patchText"] = new Dictionary<string, object>
+                {
+                    ["type"] = "string",
+                    ["description"] = "Patch text describing one or more file operations using " +
+                             "the tool's patch format. Required. Format examples:\n" +
+                             "  Add:    '*** Add File: path' then lines starting with '+'\n" +
+                             "  Update: '*** Update File: path' then '@@ context @@' hunks " +
+                             "and lines starting with ' ', '-' or '+'\n" +
+                             "  Delete: '*** Delete File: path' (no body)"
                 },
-                { "dryRun", new Dictionary<string, object>
-                    {
-                        { "type", "boolean" },
-                        { "description", "If true, validates the patch and shows what would be changed without actually modifying files. Default is false." }
-                    }
+                ["dryRun"] = new Dictionary<string, object>
+                {
+                   ["type"] = "boolean",
+                   ["description"] = "If true, validate the patch and return what would be " +
+                             "changed without modifying files. Defaults to false."
                 }
             };
         }

--- a/Tools/DeleteFileTool.cs
+++ b/Tools/DeleteFileTool.cs
@@ -11,64 +11,44 @@ namespace Saturn.Tools
     public class DeleteFileTool : ToolBase
     {
         public override string Name => "delete_file";
-        
-        public override string Description => @"Safely delete files or directories with optional backup.
 
-When to use:
-- Removing obsolete source files
-- Cleaning up temporary files
-- Deleting generated artifacts
-- Removing test outputs
-- Cleaning build directories
+        public override string Description => @"Safely delete files or directories inside the
+working directory. Supports glob filtering, recursive deletion,
+read-only override, and dry-run (no changes). Prevents path
+traversal and operations outside the working directory.";
 
-How to use:
-- Set 'path' to file or directory to delete
-- Use 'recursive' for directory deletion
-- Use 'pattern' for selective deletion in directories
-- Set 'force' to delete read-only items
-
-Safety features:
-- Prevents deletion outside working directory
-- Confirmation for large deletions
-- Detailed operation logging";
-        
         protected override Dictionary<string, object> GetParameterProperties()
         {
             return new Dictionary<string, object>
             {
-                { "path", new Dictionary<string, object>
-                    {
-                        { "type", "string" },
-                        { "description", "Path to file or directory to delete" }
-                    }
+                ["path"] = new Dictionary<string, object>
+                {
+                    ["type"] = "string",
+                    ["description"] = "Required. File or directory to delete."
                 },
-                { "recursive", new Dictionary<string, object>
-                    {
-                        { "type", "boolean" },
-                        { "description", "Delete directories recursively (default: false)" }
-                    }
+                ["recursive"] = new Dictionary<string, object>
+                {
+                    ["type"] = "boolean",
+                    ["description"] = "If true, delete directories and contents recursively."
                 },
-                { "pattern", new Dictionary<string, object>
-                    {
-                        { "type", "string" },
-                        { "description", "File pattern to match for selective deletion (e.g., *.tmp)" }
-                    }
+                ["pattern"] = new Dictionary<string, object>
+                {
+                    ["type"] = "string",
+                    ["description"] = "Optional glob (e.g. '*.tmp') to filter files in a directory."
                 },
-                { "force", new Dictionary<string, object>
-                    {
-                        { "type", "boolean" },
-                        { "description", "Force deletion of read-only items (default: false)" }
-                    }
+                ["force"] = new Dictionary<string, object>
+                {
+                    ["type"] = "boolean",
+                    ["description"] = "If true, clear read-only attribute before deleting."
                 },
-                { "dryRun", new Dictionary<string, object>
-                    {
-                        { "type", "boolean" },
-                        { "description", "Show what would be deleted without actually deleting (default: false)" }
-                    }
+                ["dryRun"] = new Dictionary<string, object>
+                {
+                    ["type"] = "boolean",
+                    ["description"] = "If true, simulate deletion and return a report."
                 }
             };
         }
-        
+
         protected override string[] GetRequiredParameters()
         {
             return new[] { "path" };

--- a/Tools/ExecuteCommandTool.cs
+++ b/Tools/ExecuteCommandTool.cs
@@ -37,35 +37,30 @@ namespace Saturn.Tools
         {
             return new Dictionary<string, object>
             {
-                { "command", new Dictionary<string, object>
-                    {
-                        { "type", "string" },
-                        { "description", "The system command to execute" }
-                    }
+                ["command"] = new Dictionary<string, object>
+                {
+                    ["type"] = "string",
+                    ["description"] = "The system command to execute"
                 },
-                { "workingDirectory", new Dictionary<string, object>
-                    {
-                        { "type", "string" },
-                        { "description", "The working directory for command execution. Defaults to current directory" }
-                    }
+                ["workingDirectory"] = new Dictionary<string, object>
+                {
+                    ["type"] = "string",
+                    ["description"] = "The working directory for command execution. Defaults to current directory"
                 },
-                { "timeout", new Dictionary<string, object>
-                    {
-                        { "type", "integer" },
-                        { "description", "Command timeout in seconds. Default is 30 seconds" }
-                    }
+                ["timeout"] = new Dictionary<string, object>
+                {
+                    ["type"] = "integer",
+                    ["description"] = "Command timeout in seconds. Default is 30 seconds"
                 },
-                { "captureOutput", new Dictionary<string, object>
-                    {
-                        { "type", "boolean" },
-                        { "description", "Whether to capture command output. Default is true" }
-                    }
+                ["captureOutput"] = new Dictionary<string, object>
+                {
+                    ["type"] = "boolean",
+                    ["description"] = "Whether to capture command output. Default is true"
                 },
-                { "runAsShell", new Dictionary<string, object>
-                    {
-                        { "type", "boolean" },
-                        { "description", "Whether to run command through shell. Default is true" }
-                    }
+                ["runAsShell"] = new Dictionary<string, object>
+                {
+                    ["type"] = "boolean",
+                    ["description"] = "Whether to run command through shell. Default is true"
                 }
             };
         }

--- a/Tools/GlobTool.cs
+++ b/Tools/GlobTool.cs
@@ -13,96 +13,65 @@ namespace Saturn.Tools
     public class GlobTool : ToolBase
     {
         public override string Name => "glob";
-        
-        public override string Description => @"Use this tool to find files by name patterns. This is your tool for discovering file locations and understanding project structure.
 
-When to use:
-- Finding all files of a certain type (e.g., all .cs files)
-- Locating specific files when you know part of the name
-- Discovering project structure and organization
-- Finding test files, configuration files, or documentation
-- Checking if certain files exist in the project
+        public override string Description => @"Find files/dirs by glob(s) inside the working directory. Supports multiple
+includes (',' or ';'), '!' negation, extra excludes, base path, case
+sensitivity, depth limit, symlink handling, compact output, and max results.";
 
-How to use:
-- Set 'pattern' to your glob pattern (supports *, ?, ** wildcards)
-- Use 'path' to search from a specific directory (optional)
-- Set 'includeDirectories' to true to also list folders
-- Use 'exclude' array to filter out unwanted results
-- Set 'caseSensitive' based on your needs
-- Use 'compactOutput' for just file paths
-- Set 'maxDepth' to limit recursion depth
-
-Examples:
-- Find all C# files: pattern='**/*.cs'
-- Find test files: pattern='**/*Test.cs' or pattern='**/test/**/*'
-- Find config files: pattern='**/*.{json,xml,config}'
-- Find specific file: pattern='**/UserService.cs'
-- Find all in folder: pattern='src/models/**/*'
-
-Note: Use this before grep when you need to find files first, then search within them.";
-        
         protected override Dictionary<string, object> GetParameterProperties()
         {
             return new Dictionary<string, object>
             {
-                { "pattern", new Dictionary<string, object>
-                    {
-                        { "type", "string" },
-                        { "description", "Glob pattern to match file names. Use * for any characters, ** for recursive directories, ? for single character" }
-                    }
+                ["pattern"] = new Dictionary<string, object>
+                {
+                    ["type"] = "string",
+                    ["description"] = "Required. Include glob(s). Supports *, ?, **; separate with ',' or ';'. " +
+                                     "Prefix with '!' to negate."
                 },
-                { "path", new Dictionary<string, object>
-                    {
-                        { "type", "string" },
-                        { "description", "Base directory to search from (defaults to current directory)" }
-                    }
+                ["path"] = new Dictionary<string, object>
+                {
+                    ["type"] = "string",
+                    ["description"] = "Search root (default: current directory)."
                 },
-                { "includeDirectories", new Dictionary<string, object>
-                    {
-                        { "type", "boolean" },
-                        { "description", "Include directories in results (default: false)" }
-                    }
+                ["includeDirectories"] = new Dictionary<string, object>
+                {
+                    ["type"] = "boolean",
+                    ["description"] = "Include directories in results."
                 },
-                { "caseSensitive", new Dictionary<string, object>
-                    {
-                        { "type", "boolean" },
-                        { "description", "Case-sensitive matching (default: false)" }
-                    }
+                ["caseSensitive"] = new Dictionary<string, object>
+                {
+                    ["type"] = "boolean",
+                    ["description"] = "Case-sensitive matching."
                 },
-                { "maxResults", new Dictionary<string, object>
-                    {
-                        { "type", "integer" },
-                        { "description", "Maximum number of results to return (default: 1000)" }
-                    }
+                ["maxResults"] = new Dictionary<string, object>
+                {
+                    ["type"] = "integer",
+                    ["description"] = "Maximum results to return (default: 1000)."
                 },
-                { "exclude", new Dictionary<string, object>
-                    {
-                        { "type", "array" },
-                        { "items", new Dictionary<string, object> { { "type", "string" } } },
-                        { "description", "Patterns to exclude from results" }
-                    }
+                ["exclude"] = new Dictionary<string, object>
+                {
+                    ["type"] = "array",
+                    ["items"] = new Dictionary<string, object> { ["type"] = "string" },
+                    ["description"] = "Additional exclude patterns."
                 },
-                { "compactOutput", new Dictionary<string, object>
-                    {
-                        { "type", "boolean" },
-                        { "description", "Show only file paths without size/date info (default: false)" }
-                    }
+                ["compactOutput"] = new Dictionary<string, object>
+                {
+                    ["type"] = "boolean",
+                    ["description"] = "Only output paths (no size/date)."
                 },
-                { "maxDepth", new Dictionary<string, object>
-                    {
-                        { "type", "integer" },
-                        { "description", "Maximum directory depth for recursive search (default: unlimited)" }
-                    }
+                ["maxDepth"] = new Dictionary<string, object>
+                {
+                    ["type"] = "integer",
+                    ["description"] = "Max directory depth (-1 = unlimited)."
                 },
-                { "followSymlinks", new Dictionary<string, object>
-                    {
-                        { "type", "boolean" },
-                        { "description", "Follow symbolic links (default: false)" }
-                    }
+                ["followSymlinks"] = new Dictionary<string, object>
+                {
+                    ["type"] = "boolean",
+                    ["description"] = "Follow symbolic links."
                 }
             };
         }
-        
+
         protected override string[] GetRequiredParameters()
         {
             return new[] { "pattern" };

--- a/Tools/GrepTool.cs
+++ b/Tools/GrepTool.cs
@@ -39,41 +39,35 @@ Examples:
         {
             return new Dictionary<string, object>
             {
-                { "pattern", new Dictionary<string, object>
-                    {
-                        { "type", "string" },
-                        { "description", "The regular expression pattern to search for" }
-                    }
+                ["pattern"] = new Dictionary<string, object>
+                {
+                    ["type"] = "string",
+                    ["description"] = "The regular expression pattern to search for"
                 },
-                { "path", new Dictionary<string, object>
-                    {
-                        { "type", "string" },
-                        { "description", "File or directory path to search in" }
-                    }
+                ["path"] = new Dictionary<string, object>
+                {
+                    ["type"] = "string",
+                    ["description"] = "File or directory path to search in"
                 },
-                { "recursive", new Dictionary<string, object>
-                    {
-                        { "type", "boolean" },
-                        { "description", "Search recursively in subdirectories" }
-                    }
+                ["recursive"] = new Dictionary<string, object>
+                {
+                    ["type"] = "boolean",
+                    ["description"] = "Search recursively in subdirectories"
                 },
-                { "filePattern", new Dictionary<string, object>
-                    {
-                        { "type", "string" },
-                        { "description", "File name pattern to filter which files to search in. Default is * for all files" }
-                    }
+                ["filePattern"] = new Dictionary<string, object>
+                {
+                    ["type"] = "string",
+                    ["description"] = "File name pattern to filter which files to search in. Default is * for all files"
                 },
-                { "ignoreCase", new Dictionary<string, object>
-                    {
-                        { "type", "boolean" },
-                        { "description", "Perform case-insensitive search" }
-                    }
+                ["ignoreCase"] = new Dictionary<string, object>
+                {
+                    ["type"] = "boolean",
+                    ["description"] = "Perform case-insensitive search"
                 },
-                { "maxResults", new Dictionary<string, object>
-                    {
-                        { "type", "integer" },
-                        { "description", "Maximum number of results to return" }
-                    }
+                ["maxResults"] = new Dictionary<string, object>
+                {
+                    ["type"] = "integer",
+                    ["description"] = "Maximum number of results to return"
                 }
             };
         }

--- a/Tools/ReadFileTool.cs
+++ b/Tools/ReadFileTool.cs
@@ -40,41 +40,35 @@ Examples:
         {
             return new Dictionary<string, object>
             {
-                { "path", new Dictionary<string, object>
-                    {
-                        { "type", "string" },
-                        { "description", "File path to read. Must be an absolute or relative path to an existing file" }
-                    }
+                ["path"] = new Dictionary<string, object>
+                {
+                    ["type"] = "string",
+                    ["description"] = "File path to read. Must be an absolute or relative path to an existing file"
                 },
-                { "startLine", new Dictionary<string, object>
-                    {
-                        { "type", "integer" },
-                        { "description", "Starting line number to read from (1-based). Default reads from beginning" }
-                    }
+                ["startLine"] = new Dictionary<string, object>
+                {
+                    ["type"] = "integer",
+                    ["description"] = "Starting line number to read from (1-based). Default reads from beginning"
                 },
-                { "endLine", new Dictionary<string, object>
-                    {
-                        { "type", "integer" },
-                        { "description", "Ending line number to read to (inclusive). Default reads to end of file" }
-                    }
+                ["endLine"] = new Dictionary<string, object>
+                {
+                    ["type"] = "integer",
+                    ["description"] = "Ending line number to read to (inclusive). Default reads to end of file"
                 },
-                { "encoding", new Dictionary<string, object>
-                    {
-                        { "type", "string" },
-                        { "description", "Text encoding to use. Options: utf8, utf16, utf32, ascii, unicode. Default is utf8" }
-                    }
+                ["encoding"] = new Dictionary<string, object>
+                {
+                    ["type"] = "string",
+                    ["description"] = "Text encoding to use. Options: utf8, utf16, utf32, ascii, unicode. Default is utf8"
                 },
-                { "includeLineNumbers", new Dictionary<string, object>
-                    {
-                        { "type", "boolean" },
-                        { "description", "Include line numbers in output. Default is true" }
-                    }
+                ["includeLineNumbers"] = new Dictionary<string, object>
+                {
+                    ["type"] = "boolean",
+                    ["description"] = "Include line numbers in output. Default is true"
                 },
-                { "includeMetadata", new Dictionary<string, object>
-                    {
-                        { "type", "boolean" },
-                        { "description", "Include file metadata like size, dates, and encoding. Default is true" }
-                    }
+                ["includeMetadata"] = new Dictionary<string, object>
+                {
+                    ["type"] = "boolean",
+                    ["description"] = "Include file metadata like size, dates, and encoding. Default is true"
                 }
             };
         }

--- a/Tools/SearchAndReplaceTool.cs
+++ b/Tools/SearchAndReplaceTool.cs
@@ -45,66 +45,56 @@ Safety features:
         {
             return new Dictionary<string, object>
             {
-                { "searchPattern", new Dictionary<string, object>
-                    {
-                        { "type", "string" },
-                        { "description", "Text or regex pattern to search for" }
-                    }
+                ["searchPattern"] = new Dictionary<string, object>
+                {
+                    ["type"] = "string",
+                    ["description"] = "Text or regex pattern to search for"
                 },
-                { "replacement", new Dictionary<string, object>
-                    {
-                        { "type", "string" },
-                        { "description", "Replacement text (supports regex groups like $1)" }
-                    }
+                ["replacement"] = new Dictionary<string, object>
+                {
+                    ["type"] = "string",
+                    ["description"] = "Replacement text (supports regex groups like $1)"
                 },
-                { "filePattern", new Dictionary<string, object>
-                    {
-                        { "type", "string" },
-                        { "description", "Glob pattern for files to process (e.g., **/*.cs)" }
-                    }
+                ["filePattern"] = new Dictionary<string, object>
+                {
+                    ["type"] = "string",
+                    ["description"] = "Glob pattern for files to process (e.g., **/*.cs)"
                 },
-                { "path", new Dictionary<string, object>
-                    {
-                        { "type", "string" },
-                        { "description", "Base directory to search from (default: current)" }
-                    }
+                ["path"] = new Dictionary<string, object>
+                {
+                    ["type"] = "string",
+                    ["description"] = "Base directory to search from (default: current)"
                 },
-                { "regex", new Dictionary<string, object>
-                    {
-                        { "type", "boolean" },
-                        { "description", "Use regex for search pattern (default: false)" }
-                    }
+                ["regex"] = new Dictionary<string, object>
+                {
+                    ["type"] = "boolean",
+                    ["description"] = "Use regex for search pattern (default: false)"
                 },
-                { "caseSensitive", new Dictionary<string, object>
-                    {
-                        { "type", "boolean" },
-                        { "description", "Case-sensitive search (default: true)" }
-                    }
+                ["caseSensitive"] = new Dictionary<string, object>
+                {
+                    ["type"] = "boolean",
+                    ["description"] = "Case-sensitive search (default: true)"
                 },
-                { "wholeWord", new Dictionary<string, object>
-                    {
-                        { "type", "boolean" },
-                        { "description", "Match whole words only (default: false)" }
-                    }
+                ["wholeWord"] = new Dictionary<string, object>
+                {
+                    ["type"] = "boolean",
+                    ["description"] = "Match whole words only (default: false)"
                 },
-                { "exclude", new Dictionary<string, object>
-                    {
-                        { "type", "array" },
-                        { "items", new Dictionary<string, object> { { "type", "string" } } },
-                        { "description", "Patterns to exclude from search" }
-                    }
+                ["exclude"] = new Dictionary<string, object>
+                {
+                    ["type"] = "array",
+                    ["items"] = new Dictionary<string, object> { ["type"] = "string" },
+                    ["description"] = "Patterns to exclude from search"
                 },
-                { "dryRun", new Dictionary<string, object>
-                    {
-                        { "type", "boolean" },
-                        { "description", "Preview changes without applying (default: false)" }
-                    }
+                ["dryRun"] = new Dictionary<string, object>
+                {
+                    ["type"] = "boolean",
+                    ["description"] = "Preview changes without applying (default: false)"
                 },
-                { "maxFiles", new Dictionary<string, object>
-                    {
-                        { "type", "integer" },
-                        { "description", "Maximum files to process (default: 1000)" }
-                    }
+                ["maxFiles"] = new Dictionary<string, object>
+                {
+                    ["type"] = "integer",
+                    ["description"] = "Maximum files to process (default: 1000)"
                 }
             };
         }

--- a/Tools/WebFetchTool.cs
+++ b/Tools/WebFetchTool.cs
@@ -54,48 +54,41 @@ When to use:
         {
             return new Dictionary<string, object>
             {
-                { "url", new Dictionary<string, object>
-                    {
-                        { "type", "string" },
-                        { "description", "The URL to fetch content from" }
-                    }
+                ["url"] = new Dictionary<string, object>
+                {
+                    ["type"] = "string",
+                    ["description"] = "The URL to fetch content from"
                 },
-                { "extractionMode", new Dictionary<string, object>
-                    {
-                        { "type", "string" },
-                        { "enum", new[] { "full", "article", "text", "markdown" } },
-                        { "description", "Content extraction mode: full (entire page), article (main content), text (plain text), markdown (formatted). Default: markdown" }
-                    }
+                ["extractionMode"] = new Dictionary<string, object>
+                {
+                    ["type"] = "string",
+                    ["enum"] = new[] { "full", "article", "text", "markdown" },
+                    ["description"] = "Content extraction mode: full (entire page), article (main content), text (plain text), markdown (formatted). Default: markdown"
                 },
-                { "maxLength", new Dictionary<string, object>
-                    {
-                        { "type", "integer" },
-                        { "description", "Maximum content length in characters. Default: 50000" }
-                    }
+                ["maxLength"] = new Dictionary<string, object>
+                {
+                    ["type"] = "integer",
+                    ["description"] = "Maximum content length in characters. Default: 50000"
                 },
-                { "includeMetadata", new Dictionary<string, object>
-                    {
-                        { "type", "boolean" },
-                        { "description", "Include page metadata (title, description, og:tags). Default: true" }
-                    }
+                ["includeMetadata"] = new Dictionary<string, object>
+                {
+                    ["type"] = "boolean",
+                    ["description"] = "Include page metadata (title, description, og:tags). Default: true"
                 },
-                { "selector", new Dictionary<string, object>
-                    {
-                        { "type", "string" },
-                        { "description", "CSS selector to extract specific content" }
-                    }
+                ["selector"] = new Dictionary<string, object>
+                {
+                    ["type"] = "string",
+                    ["description"] = "CSS selector to extract specific content"
                 },
-                { "headers", new Dictionary<string, object>
-                    {
-                        { "type", "object" },
-                        { "description", "Custom HTTP headers as key-value pairs" }
-                    }
+                ["headers"] = new Dictionary<string, object>
+                {
+                    ["type"] = "object",
+                    ["description"] = "Custom HTTP headers as key-value pairs"
                 },
-                { "useCache", new Dictionary<string, object>
-                    {
-                        { "type", "boolean" },
-                        { "description", "Use cached content if available. Default: true" }
-                    }
+                ["useCache"] = new Dictionary<string, object>
+                {
+                    ["type"] = "boolean",
+                    ["description"] = "Use cached content if available. Default: true"
                 }
             };
         }

--- a/Tools/WriteFileTool.cs
+++ b/Tools/WriteFileTool.cs
@@ -38,35 +38,30 @@ Safety features:
         {
             return new Dictionary<string, object>
             {
-                { "path", new Dictionary<string, object>
-                    {
-                        { "type", "string" },
-                        { "description", "Path where the file should be created" }
-                    }
+                ["path"] = new Dictionary<string, object>
+                {
+                    ["type"] = "string",
+                    ["description"] = "Path where the file should be created"
                 },
-                { "content", new Dictionary<string, object>
-                    {
-                        { "type", "string" },
-                        { "description", "Content to write to the file" }
-                    }
+                ["content"] = new Dictionary<string, object>
+                {
+                    ["type"] = "string",
+                    ["description"] = "Content to write to the file"
                 },
-                { "overwrite", new Dictionary<string, object>
-                    {
-                        { "type", "boolean" },
-                        { "description", "Overwrite if file exists (default: false)" }
-                    }
+                ["overwrite"] = new Dictionary<string, object>
+                {
+                    ["type"] = "boolean",
+                    ["description"] = "Overwrite if file exists (default: false)"
                 },
-                { "createDirectories", new Dictionary<string, object>
-                    {
-                        { "type", "boolean" },
-                        { "description", "Create parent directories if they don't exist (default: true)" }
-                    }
+                ["createDirectories"] = new Dictionary<string, object>
+                {
+                    ["type"] = "boolean",
+                    ["description"] = "Create parent directories if they don't exist (default: true)"
                 },
-                { "encoding", new Dictionary<string, object>
-                    {
-                        { "type", "string" },
-                        { "description", "File encoding: UTF8, ASCII, Unicode, UTF32 (default: UTF8)" }
-                    }
+                ["encoding"] = new Dictionary<string, object>
+                {
+                    ["type"] = "string",
+                    ["description"] = "File encoding: UTF8, ASCII, Unicode, UTF32 (default: UTF8)"
                 }
             };
         }

--- a/build.sh
+++ b/build.sh
@@ -100,6 +100,24 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 PROJECT_PATH="$SCRIPT_DIR"
 CSPROJ_PATH="$PROJECT_PATH/Saturn.csproj"
 
+# Check for .NET 8 SDK (required for Saturn)
+if [ -d "/opt/homebrew/opt/dotnet@8/libexec" ]; then
+    # Use .NET 8 if available via Homebrew
+    export PATH="/opt/homebrew/opt/dotnet@8/libexec:$PATH"
+    print_success "Using .NET 8 SDK from Homebrew"
+fi
+
+# Verify .NET SDK version
+DOTNET_VERSION=$(dotnet --version 2>/dev/null || echo "not found")
+if [[ "$DOTNET_VERSION" == "not found" ]]; then
+    print_error ".NET SDK not found. Please install .NET 8 SDK."
+    exit 1
+elif [[ ! "$DOTNET_VERSION" =~ ^8\. ]]; then
+    print_error "Saturn requires .NET 8 SDK. Found: $DOTNET_VERSION"
+    echo "Please install .NET 8 SDK via: brew install dotnet@8"
+    exit 1
+fi
+
 # Check if project exists
 if [ ! -f "$CSPROJ_PATH" ]; then
     print_error "Project file not found: $CSPROJ_PATH"


### PR DESCRIPTION
Clean up tool logging/warnings flooding UI
No functional code changes; fixes local/CI test invocation reliability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - ApplyDiffTool: Added dry-run mode to validate patch blocks without applying changes.

- Bug Fixes
  - Graceful fallback when a provider rejects streaming, with a minimal in-app notice and automatic switch to non-streaming.

- Documentation
  - Refreshed, concise descriptions and clearer parameter guidance for file and search tools (ApplyDiff, DeleteFile, Glob, Grep, ListFiles, ReadFile, SearchAndReplace, ExecuteCommand, WebFetch).

- Chores
  - Build script now verifies .NET 8 SDK availability and version, with helpful guidance and PATH setup on macOS (Homebrew).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->