### PR TITLE
feat: add quality of life scripts for mac users

### DIFF
--- a/run-saturn.sh
+++ b/run-saturn.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Check if API key is already set
+if [ -z "$OPENROUTER_API_KEY" ]; then
+    echo "🪐 Saturn - Your personal swarm of employees"
+    echo "=========================================="
+    echo ""
+    echo "No OpenRouter API key found in environment."
+    echo ""
+    echo "To get an API key:"
+    echo "1. Go to https://openrouter.ai/"
+    echo "2. Sign up or log in"
+    echo "3. Get your API key from the dashboard"
+    echo ""
+    read -p "Enter your OpenRouter API key: " -s api_key
+    echo ""
+    
+    if [ -z "$api_key" ]; then
+        echo "❌ No API key provided. Exiting."
+        exit 1
+    fi
+    
+    export OPENROUTER_API_KEY="$api_key"
+    echo "✅ API key set for this session"
+    echo ""
+fi
+
+echo "🚀 Launching Saturn..."
+echo ""
+
+# Run Saturn
+cd /Users/jlee/projects/_tools_/Saturn
+dotnet run --project Saturn

--- a/setup-saturn.sh
+++ b/setup-saturn.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+echo "🪐 Saturn Setup Wizard"
+echo "====================="
+echo ""
+echo "This will set up Saturn and save your API key permanently."
+echo ""
+echo "To get an OpenRouter API key:"
+echo "1. Go to https://openrouter.ai/"
+echo "2. Sign up or log in"
+echo "3. Get your API key from the dashboard"
+echo ""
+
+read -p "Enter your OpenRouter API key: " -s api_key
+echo ""
+
+if [ -z "$api_key" ]; then
+    echo "❌ No API key provided. Setup cancelled."
+    exit 1
+fi
+
+# Add to .zshrc
+echo "" >> ~/.zshrc
+echo "# Saturn - OpenRouter API Key" >> ~/.zshrc
+echo "export OPENROUTER_API_KEY=\"$api_key\"" >> ~/.zshrc
+
+echo "✅ API key saved to ~/.zshrc"
+echo ""
+
+# Set for current session
+export OPENROUTER_API_KEY="$api_key"
+
+# Optional: Install as global tool
+echo "Would you like to install Saturn as a global .NET tool?"
+echo "This will allow you to run 'saturn' from anywhere."
+read -p "Install globally? (y/n): " install_global
+
+if [ "$install_global" = "y" ] || [ "$install_global" = "Y" ]; then
+    echo ""
+    echo "📦 Installing Saturn as global tool..."
+    cd /Users/jlee/projects/_tools_/Saturn
+    dotnet pack -c Release
+    dotnet tool install --global --add-source ./nupkg SaturnAgent
+    echo "✅ Saturn installed globally! You can now run 'saturn' from anywhere."
+else
+    echo "⏭️  Skipping global installation."
+fi
+
+echo ""
+echo "🎉 Setup complete!"
+echo ""
+echo "To run Saturn:"
+echo "  - If installed globally: just type 'saturn'"
+echo "  - Otherwise: run './run-saturn.sh' from the Saturn directory"
+echo ""
+echo "Note: You'll need to restart your terminal or run 'source ~/.zshrc'"
+echo "for the API key to be available in new sessions."


### PR DESCRIPTION
- Run Saturn script
- Setup Saturn installs and configures OpenRouter API key globally for Mac users

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an interactive Setup Wizard script to configure the OpenRouter API key, persist it to your shell profile, and optionally install Saturn as a global .NET tool. Includes silent input, clear instructions, and emoji-enhanced prompts.
  * Added a Run script that checks for an API key, guides you to provide it if missing, exports it for the session, and launches Saturn with status feedback and friendly messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->