### PR TITLE
Add multi-provider support: OpenRouter + LM Studio, hot-swappable at runtime

### DIFF
--- a/Agents/Core/AgentBase.cs
+++ b/Agents/Core/AgentBase.cs
@@ -13,6 +13,7 @@ using Saturn.OpenRouter;
 using Saturn.OpenRouter.Models.Api.Chat;
 using Saturn.OpenRouter.Models.Api.Common;
 using Saturn.OpenRouter.Services;
+using Saturn.Providers;
 using Saturn.Tools.Core;
 
 namespace Saturn.Agents.Core
@@ -283,6 +284,10 @@ namespace Saturn.Agents.Core
 
         protected async Task<AssistantMessageResponse> ExecuteWithTools(List<Message> initialMessages)
         {
+            // Resolve once per turn so a provider swap mid-stream never splits a single
+            // tool-calling loop across two backends.
+            var client = Configuration.ClientSource.Current;
+
             AssistantMessageResponse responseMessage = null;
             var currentMessages = initialMessages;
             bool continueProcessing = true;
@@ -291,33 +296,13 @@ namespace Saturn.Agents.Core
             {
                 if (!ValidateToolMessageSequence(currentMessages))
                 {
-                    
+
                     currentMessages = CleanupInvalidToolMessages(currentMessages);
                 }
-                
-                var request = new ChatCompletionRequest
-                {
-                    Model = Configuration.Model,
-                    Messages = currentMessages.ToArray(),
-                    Temperature = Configuration.Temperature,
-                    MaxTokens = Configuration.MaxTokens,
-                    TopP = Configuration.TopP,
-                    FrequencyPenalty = Configuration.FrequencyPenalty,
-                    PresencePenalty = Configuration.PresencePenalty,
-                    Stop = Configuration.StopSequences,
-                    Transforms = new string[] { "middle-out" },
-                    ToolChoice = ToolChoice.Auto(),
-                    Usage = new UsageOption { Include = true }
-                };
 
-                if (Configuration.EnableTools)
-                {
-                    request.Tools = (Configuration.ToolNames != null && Configuration.ToolNames.Count > 0)
-                        ? ToolRegistry.Instance.GetOpenRouterToolDefinitions(Configuration.ToolNames.ToArray()).ToArray()
-                        : ToolRegistry.Instance.GetOpenRouterToolDefinitions().ToArray();
-                }
+                var request = BuildRequest(client, currentMessages);
 
-                var response = await Configuration.Client.Chat.CreateAsync(request);
+                var response = await client.ChatAsync(request);
                 responseMessage = response?.Choices?.FirstOrDefault()?.Message;
 
                 if (responseMessage?.ToolCalls != null && responseMessage.ToolCalls.Length > 0)
@@ -635,6 +620,8 @@ namespace Saturn.Agents.Core
             Func<StreamChunk, Task> onChunk,
             CancellationToken cancellationToken)
         {
+            var client = Configuration.ClientSource.Current;
+
             AssistantMessageResponse finalResponse = null;
             var currentMessages = initialMessages;
             bool continueProcessing = true;
@@ -648,34 +635,14 @@ namespace Saturn.Agents.Core
                     currentMessages = CleanupInvalidToolMessages(currentMessages);
                 }
 
-                var request = new ChatCompletionRequest
-                {
-                    Model = Configuration.Model,
-                    Messages = currentMessages.ToArray(),
-                    Temperature = Configuration.Temperature,
-                    MaxTokens = Configuration.MaxTokens,
-                    TopP = Configuration.TopP,
-                    FrequencyPenalty = Configuration.FrequencyPenalty,
-                    PresencePenalty = Configuration.PresencePenalty,
-                    Stop = Configuration.StopSequences,
-                    Transforms = new string[] { "middle-out" },
-                    ToolChoice = ToolChoice.Auto(),
-                    Stream = true,
-                    Usage = new UsageOption { Include = true }
-                };
-
-                if (Configuration.EnableTools)
-                {
-                    request.Tools = (Configuration.ToolNames != null && Configuration.ToolNames.Count > 0)
-                        ? ToolRegistry.Instance.GetOpenRouterToolDefinitions(Configuration.ToolNames.ToArray()).ToArray()
-                        : ToolRegistry.Instance.GetOpenRouterToolDefinitions().ToArray();
-                }
+                var request = BuildRequest(client, currentMessages);
+                request.Stream = true;
 
                 try
                 {
                     var tokenIndex = 0;
 
-                    await foreach (var chunk in Configuration.Client.ChatStreaming.StreamAsync(request, cancellationToken))
+                    await foreach (var chunk in client.StreamChatAsync(request, cancellationToken))
                     {
                         if (cancellationToken.IsCancellationRequested)
                             break;
@@ -939,6 +906,46 @@ namespace Saturn.Agents.Core
             return finalResponse;
         }
 
+        /// <summary>
+        /// Builds a chat request shaped to what the active provider understands.
+        /// Extension fields (transforms, usage accounting) stay off the wire for
+        /// providers that don't declare support for them.
+        /// </summary>
+        private ChatCompletionRequest BuildRequest(ILlmClient client, List<Message> currentMessages)
+        {
+            var capabilities = client.Capabilities;
+
+            var request = new ChatCompletionRequest
+            {
+                Model = Configuration.Model,
+                Messages = currentMessages.ToArray(),
+                Temperature = Configuration.Temperature,
+                MaxTokens = Configuration.MaxTokens,
+                TopP = Configuration.TopP,
+                FrequencyPenalty = Configuration.FrequencyPenalty,
+                PresencePenalty = Configuration.PresencePenalty,
+                Stop = Configuration.StopSequences,
+                Transforms = capabilities.SupportsTransforms ? new string[] { "middle-out" } : null,
+                Usage = capabilities.SupportsUsageInclude ? new UsageOption { Include = true } : null
+            };
+
+            if (Configuration.EnableTools)
+            {
+                request.Tools = (Configuration.ToolNames != null && Configuration.ToolNames.Count > 0)
+                    ? ToolRegistry.Instance.GetOpenRouterToolDefinitions(Configuration.ToolNames.ToArray()).ToArray()
+                    : ToolRegistry.Instance.GetOpenRouterToolDefinitions().ToArray();
+
+                // tool_choice without a tools array is rejected by some OpenAI-compatible
+                // backends, so it is only sent when tools are attached.
+                if (capabilities.SupportsToolChoice)
+                {
+                    request.ToolChoice = ToolChoice.Auto();
+                }
+            }
+
+            return request;
+        }
+
         protected static JsonElement JString(string value)
         {
             return JsonDocument.Parse(JsonSerializer.Serialize(value ?? string.Empty)).RootElement;
@@ -1173,6 +1180,11 @@ namespace Saturn.Agents.Core
 
         private JsonElement CreateCachedContent(string text)
         {
+            if (!ProviderSupportsCaching())
+            {
+                return JString(text);
+            }
+
             var contentParts = new[]
             {
                 new TextContentPart
@@ -1185,6 +1197,19 @@ namespace Saturn.Agents.Core
 
             var json = JsonSerializer.Serialize(contentParts);
             return JsonDocument.Parse(json).RootElement;
+        }
+
+        private bool ProviderSupportsCaching()
+        {
+            try
+            {
+                return Configuration.ClientSource.Current.Capabilities.SupportsCaching;
+            }
+            catch (InvalidOperationException)
+            {
+                // No provider connected yet; emit plain string content.
+                return false;
+            }
         }
 
         public void Dispose()

--- a/Agents/Core/AgentBase.cs
+++ b/Agents/Core/AgentBase.cs
@@ -316,7 +316,12 @@ namespace Saturn.Agents.Core
                         continueProcessing = false;
                         continue;
                     }
-                    
+
+                    foreach (var toolCall in validToolCalls)
+                    {
+                        toolCall.Function!.Arguments = EnsureValidJsonArguments(toolCall.Function.Arguments);
+                    }
+
                     string? assistantMessageId = null;
                     var assistantToolCallsPreview = validToolCalls
                         .Select(tc => new ToolCallRequest
@@ -732,6 +737,17 @@ namespace Saturn.Agents.Core
 
                         if (!string.IsNullOrEmpty(choice?.FinishReason))
                         {
+                            if (string.Equals(choice.FinishReason, "length", StringComparison.OrdinalIgnoreCase))
+                            {
+                                // Deliberately not added to contentBuffer: it is UI
+                                // feedback, not part of the assistant's message.
+                                await onChunk(new StreamChunk
+                                {
+                                    Content = "\n[Response truncated: max token limit reached. Consider raising Max Tokens, especially for reasoning models.]\n",
+                                    Role = "assistant"
+                                });
+                            }
+
                             finalResponse = new AssistantMessageResponse
                             {
                                 Role = "assistant",
@@ -954,6 +970,32 @@ namespace Saturn.Agents.Core
             return request;
         }
 
+        /// <summary>
+        /// Tool-call arguments are echoed back to the provider in the conversation on
+        /// every later request. Arguments that aren't valid JSON — empty or truncated
+        /// when generation hits the token limit — can crash strict chat templates
+        /// server-side and poison the whole session, so they are replaced with an empty
+        /// object; the tool then fails with a normal validation error the model can
+        /// react to.
+        /// </summary>
+        private static string EnsureValidJsonArguments(string? arguments)
+        {
+            if (string.IsNullOrWhiteSpace(arguments))
+            {
+                return "{}";
+            }
+
+            try
+            {
+                using var _ = JsonDocument.Parse(arguments);
+                return arguments;
+            }
+            catch (JsonException)
+            {
+                return "{}";
+            }
+        }
+
         private static Message StripCacheControl(Message message)
         {
             if (message.Content.ValueKind != JsonValueKind.Array)
@@ -1020,12 +1062,9 @@ namespace Saturn.Agents.Core
                 {
                     continue;
                 }
-                
-                if (toolCall.Function.Arguments == null)
-                {
-                    toolCall.Function.Arguments = "{}";
-                }
-                
+
+                toolCall.Function.Arguments = EnsureValidJsonArguments(toolCall.Function.Arguments);
+
                 validatedCalls.Add(toolCall);
             }
             

--- a/Agents/Core/AgentBase.cs
+++ b/Agents/Core/AgentBase.cs
@@ -915,10 +915,18 @@ namespace Saturn.Agents.Core
         {
             var capabilities = client.Capabilities;
 
+            // History written under a caching provider carries cache_control content
+            // parts; after a provider swap those must not reach a backend that never
+            // declared support for them. Sanitized copies only — the history itself is
+            // left intact for a potential swap back.
+            var messages = capabilities.SupportsCaching
+                ? currentMessages.ToArray()
+                : currentMessages.Select(StripCacheControl).ToArray();
+
             var request = new ChatCompletionRequest
             {
                 Model = Configuration.Model,
-                Messages = currentMessages.ToArray(),
+                Messages = messages,
                 Temperature = Configuration.Temperature,
                 MaxTokens = Configuration.MaxTokens,
                 TopP = Configuration.TopP,
@@ -944,6 +952,44 @@ namespace Saturn.Agents.Core
             }
 
             return request;
+        }
+
+        private static Message StripCacheControl(Message message)
+        {
+            if (message.Content.ValueKind != JsonValueKind.Array)
+            {
+                return message;
+            }
+
+            var hasCacheControl = false;
+            var texts = new List<string>();
+            foreach (var part in message.Content.EnumerateArray())
+            {
+                if (part.ValueKind != JsonValueKind.Object || !part.TryGetProperty("text", out var textProp))
+                {
+                    // Not a pure text-part array (e.g. images); leave it untouched.
+                    return message;
+                }
+                if (part.TryGetProperty("cache_control", out _))
+                {
+                    hasCacheControl = true;
+                }
+                texts.Add(textProp.GetString() ?? string.Empty);
+            }
+
+            if (!hasCacheControl)
+            {
+                return message;
+            }
+
+            return new Message
+            {
+                Role = message.Role,
+                Content = JString(string.Join("", texts)),
+                Name = message.Name,
+                ToolCallId = message.ToolCallId,
+                ToolCalls = message.ToolCalls
+            };
         }
 
         protected static JsonElement JString(string value)

--- a/Agents/Core/AgentConfiguration.cs
+++ b/Agents/Core/AgentConfiguration.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using Saturn.OpenRouter;
+using Saturn.Providers;
 
 namespace Saturn.Agents.Core
 {
@@ -8,7 +8,7 @@ namespace Saturn.Agents.Core
     {
         public required string Name { get; set; }
         public required string SystemPrompt { get; set; }
-        public required OpenRouterClient Client { get; set; }
+        public required ILlmClientSource ClientSource { get; set; }
         public string Model { get; set; } = "anthropic/claude-sonnet-4";
         public double? Temperature { get; set; }
         public int? MaxTokens { get; set; }
@@ -25,8 +25,8 @@ namespace Saturn.Agents.Core
         public bool RequireCommandApproval { get; set; } = true;
         public bool EnableUserRules { get; set; } = true;
         public Guid? CurrentModeId { get; set; }
-        
-        public static AgentConfiguration FromMode(Mode mode, OpenRouterClient client)
+
+        public static AgentConfiguration FromMode(Mode mode, ILlmClientSource clientSource)
         {
             string systemPrompt;
             if (!string.IsNullOrWhiteSpace(mode.SystemPromptOverride))
@@ -37,12 +37,12 @@ namespace Saturn.Agents.Core
             {
                 systemPrompt = "You are a helpful assistant.";
             }
-            
+
             var config = new AgentConfiguration
             {
                 Name = mode.AgentName,
                 SystemPrompt = systemPrompt,
-                Client = client,
+                ClientSource = clientSource,
                 Model = mode.Model,
                 Temperature = mode.Temperature,
                 MaxTokens = mode.MaxTokens,
@@ -57,7 +57,7 @@ namespace Saturn.Agents.Core
                 EnableTools = mode.ToolNames?.Count > 0,
                 CurrentModeId = mode.Id
             };
-            
+
             return config;
         }
     }

--- a/Agents/MultiAgent/AgentManager.cs
+++ b/Agents/MultiAgent/AgentManager.cs
@@ -10,8 +10,8 @@ using Saturn.Agents.Core;
 using Saturn.Agents.MultiAgent.Objects;
 using Saturn.Config;
 using Saturn.Data;
-using Saturn.OpenRouter;
 using Saturn.OpenRouter.Models.Api.Chat;
+using Saturn.Providers;
 
 namespace Saturn.Agents.MultiAgent
 {
@@ -22,9 +22,10 @@ namespace Saturn.Agents.MultiAgent
         private readonly ConcurrentDictionary<string, AgentTaskResult> _completedTasks;
         private readonly ConcurrentDictionary<string, ReviewerContext> _reviewers;
         private readonly SemaphoreSlim _reviewerSemaphore = new SemaphoreSlim(25);
-        private OpenRouterClient _client = null!;
+        private ILlmClientSource _clientSource = null!;
         private const int MaxConcurrentAgents = 25;
         private string? _parentSessionId;
+        private string? _parentModel;
         private bool _parentEnableUserRules = true;
         
         public static AgentManager Instance => _instance ??= new AgentManager();
@@ -40,17 +41,22 @@ namespace Saturn.Agents.MultiAgent
             _reviewers = new ConcurrentDictionary<string, ReviewerContext>();
         }
         
-        public void Initialize(OpenRouterClient client)
+        public void Initialize(ILlmClientSource clientSource)
         {
             if (_instance != null)
             {
-                _instance._client = client;
+                _instance._clientSource = clientSource;
             }
         }
         
         public void SetParentSessionId(string? sessionId)
         {
             _parentSessionId = sessionId;
+        }
+
+        public void SetParentModel(string? model)
+        {
+            _parentModel = model;
         }
         
         public void SetParentEnableUserRules(bool enableUserRules)
@@ -85,7 +91,11 @@ namespace Saturn.Agents.MultiAgent
             }
             
             var agentId = $"agent_{Guid.NewGuid():N}".Substring(0, 12);
-            
+
+            // Requested model ids are often written for one provider (e.g. OpenRouter
+            // slugs); substitute something the active provider actually serves.
+            model = await ModelCatalog.ResolveModelAsync(_clientSource, model, _parentModel);
+
             var systemPrompt = systemPromptOverride ?? $@"You are a specialized sub-agent named {name}.
 Your purpose: {purpose}
 You work as part of a larger system and should focus on your specific task.
@@ -95,7 +105,7 @@ Report your progress clearly and concisely.";
             {
                 Name = name,
                 SystemPrompt = await SystemPrompt.Create(systemPrompt, includeDirectories: true, includeUserRules: includeUserRules ?? _parentEnableUserRules),
-                Client = _client,
+                ClientSource = _clientSource,
                 Model = model,
                 Temperature = temperature ?? 0.3,
                 MaxTokens = maxTokens ?? 4096,
@@ -413,12 +423,14 @@ DECISION REQUIRED:
 
 Your decision:";
 
+                var reviewerModel = await ModelCatalog.ResolveModelAsync(_clientSource, prefs.ReviewerModel, _parentModel);
+
                 var reviewerConfig = new AgentConfiguration
                 {
                     Name = $"Reviewer for {subAgentContext.Name}",
                     SystemPrompt = await SystemPrompt.Create("You are a specialized quality assurance reviewer. Be thorough but fair in your assessments.", includeDirectories: true, includeUserRules: false),
-                    Client = _client,
-                    Model = prefs.ReviewerModel,
+                    ClientSource = _clientSource,
+                    Model = reviewerModel,
                     Temperature = 0.2,
                     MaxTokens = 2048,
                     TopP = 0.95,

--- a/Configuration/ConfigurationManager.cs
+++ b/Configuration/ConfigurationManager.cs
@@ -94,9 +94,20 @@ namespace Saturn.Configuration
 
             // System.Text.Json deserializes dictionaries with the default case-sensitive
             // comparer; rebuild so "LMStudio" and "lmstudio" cannot become separate keys.
-            config.Providers = config.Providers == null
-                ? new Dictionary<string, PersistedProviderConfiguration>(StringComparer.OrdinalIgnoreCase)
-                : new Dictionary<string, PersistedProviderConfiguration>(config.Providers, StringComparer.OrdinalIgnoreCase);
+            // Collisions collapse (first entry wins) instead of throwing — a hand-edited
+            // file must not abort the whole config load.
+            var rebuilt = new Dictionary<string, PersistedProviderConfiguration>(StringComparer.OrdinalIgnoreCase);
+            if (config.Providers != null)
+            {
+                foreach (var kvp in config.Providers)
+                {
+                    if (!rebuilt.ContainsKey(kvp.Key))
+                    {
+                        rebuilt[kvp.Key] = kvp.Value;
+                    }
+                }
+            }
+            config.Providers = rebuilt;
 
             if (!config.Providers.TryGetValue(config.ActiveProvider, out var providerConfig))
             {
@@ -110,6 +121,19 @@ namespace Saturn.Configuration
         public static async Task SaveConfigurationAsync(PersistedAgentConfiguration config)
         {
             await SaveLock.WaitAsync();
+            try
+            {
+                await SaveConfigurationLockedAsync(config);
+            }
+            finally
+            {
+                SaveLock.Release();
+            }
+        }
+
+        /// <summary>Performs the actual save. Callers must hold <see cref="SaveLock"/>.</summary>
+        private static async Task SaveConfigurationLockedAsync(PersistedAgentConfiguration config)
+        {
             try
             {
                 // Most call sites build the persisted object from the live agent
@@ -148,11 +172,7 @@ namespace Saturn.Configuration
             }
             catch (Exception ex)
             {
-
-            }
-            finally
-            {
-                SaveLock.Release();
+                Console.Error.WriteLine($"Failed to save configuration: {ex.Message}");
             }
         }
 
@@ -161,6 +181,21 @@ namespace Saturn.Configuration
         /// connected with and, when known, the model to use on that provider.
         /// </summary>
         public static async Task SaveProviderSelectionAsync(string providerName, ProviderSettings settings, string? model = null)
+        {
+            // Load-mutate-write must all happen under the lock, or a concurrent save
+            // could interleave and clobber the provider changes.
+            await SaveLock.WaitAsync();
+            try
+            {
+                await SaveProviderSelectionLockedAsync(providerName, settings, model);
+            }
+            finally
+            {
+                SaveLock.Release();
+            }
+        }
+
+        private static async Task SaveProviderSelectionLockedAsync(string providerName, ProviderSettings settings, string? model)
         {
             var config = await LoadConfigurationAsync() ?? new PersistedAgentConfiguration();
 
@@ -203,7 +238,7 @@ namespace Saturn.Configuration
                 config.Model = model;
             }
 
-            await SaveConfigurationAsync(config);
+            await SaveConfigurationLockedAsync(config);
         }
 
         public static ProviderSettings GetProviderSettings(PersistedAgentConfiguration? config, string providerName)

--- a/Configuration/ConfigurationManager.cs
+++ b/Configuration/ConfigurationManager.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Threading;
 using System.Threading.Tasks;
 using Saturn.Agents.Core;
 using Saturn.Configuration.Objects;
@@ -26,6 +28,10 @@ namespace Saturn.Configuration
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
             Converters = { new JsonStringEnumConverter() }
         };
+
+        // Saves are read-modify-write; serialize them so two in-flight saves cannot
+        // interleave and drop each other's provider fields.
+        private static readonly SemaphoreSlim SaveLock = new(1, 1);
 
         public static async Task<PersistedAgentConfiguration?> LoadConfigurationAsync()
         {
@@ -70,7 +76,12 @@ namespace Saturn.Configuration
         private static void MigrateLegacyProviderFields(PersistedAgentConfiguration config)
         {
             config.ActiveProvider ??= "openrouter";
-            config.Providers ??= new Dictionary<string, PersistedProviderConfiguration>(StringComparer.OrdinalIgnoreCase);
+
+            // System.Text.Json deserializes dictionaries with the default case-sensitive
+            // comparer; rebuild so "LMStudio" and "lmstudio" cannot become separate keys.
+            config.Providers = config.Providers == null
+                ? new Dictionary<string, PersistedProviderConfiguration>(StringComparer.OrdinalIgnoreCase)
+                : new Dictionary<string, PersistedProviderConfiguration>(config.Providers, StringComparer.OrdinalIgnoreCase);
 
             if (!config.Providers.TryGetValue(config.ActiveProvider, out var providerConfig))
             {
@@ -83,6 +94,7 @@ namespace Saturn.Configuration
 
         public static async Task SaveConfigurationAsync(PersistedAgentConfiguration config)
         {
+            await SaveLock.WaitAsync();
             try
             {
                 // Most call sites build the persisted object from the live agent
@@ -112,12 +124,20 @@ namespace Saturn.Configuration
                     Directory.CreateDirectory(AppDataPath);
                 }
 
+                // Write-then-rename so a crash mid-write can never leave a truncated
+                // config that a later load would silently treat as "no config".
                 var json = JsonSerializer.Serialize(config, JsonOptions);
-                await File.WriteAllTextAsync(ConfigFilePath, json);
+                var tempPath = ConfigFilePath + ".tmp";
+                await File.WriteAllTextAsync(tempPath, json);
+                File.Move(tempPath, ConfigFilePath, overwrite: true);
             }
             catch (Exception ex)
             {
 
+            }
+            finally
+            {
+                SaveLock.Release();
             }
         }
 
@@ -138,7 +158,30 @@ namespace Saturn.Configuration
                 config.Providers[providerName] = providerConfig;
             }
 
-            providerConfig.Settings = new Dictionary<string, string?>(settings.Values, StringComparer.OrdinalIgnoreCase);
+            // Secret values that merely mirror the environment variable are not
+            // persisted: writing them would store the key in plaintext for no benefit
+            // and shadow the env var if it is later rotated.
+            var toPersist = new Dictionary<string, string?>(settings.Values, StringComparer.OrdinalIgnoreCase);
+            if (ProviderRegistry.TryGet(providerName, out var provider))
+            {
+                foreach (var descriptor in provider.SettingDescriptors)
+                {
+                    if (descriptor.Kind != ProviderSettingKind.Secret ||
+                        string.IsNullOrWhiteSpace(descriptor.EnvironmentVariable))
+                    {
+                        continue;
+                    }
+
+                    var envValue = Environment.GetEnvironmentVariable(descriptor.EnvironmentVariable);
+                    if (toPersist.TryGetValue(descriptor.Key, out var saved) &&
+                        !string.IsNullOrEmpty(saved) &&
+                        string.Equals(saved, envValue, StringComparison.Ordinal))
+                    {
+                        toPersist.Remove(descriptor.Key);
+                    }
+                }
+            }
+            providerConfig.Settings = toPersist;
             if (!string.IsNullOrWhiteSpace(model))
             {
                 providerConfig.Model = model;

--- a/Configuration/ConfigurationManager.cs
+++ b/Configuration/ConfigurationManager.cs
@@ -14,12 +14,27 @@ namespace Saturn.Configuration
 {
     public class ConfigurationManager
     {
-        private static readonly string AppDataPath = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-            "Saturn"
-        );
+        /// <summary>
+        /// Config directory: SATURN_CONFIG_DIR when set (portable installs, tests),
+        /// otherwise %APPDATA%\Saturn. Resolved per access so the override can change.
+        /// </summary>
+        private static string AppDataPath
+        {
+            get
+            {
+                var overrideDir = Environment.GetEnvironmentVariable("SATURN_CONFIG_DIR");
+                if (!string.IsNullOrWhiteSpace(overrideDir))
+                {
+                    return overrideDir;
+                }
 
-        private static readonly string ConfigFilePath = Path.Combine(AppDataPath, "agent-config.json");
+                return Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                    "Saturn");
+            }
+        }
+
+        private static string ConfigFilePath => Path.Combine(AppDataPath, "agent-config.json");
 
         private static readonly JsonSerializerOptions JsonOptions = new JsonSerializerOptions
         {

--- a/Configuration/ConfigurationManager.cs
+++ b/Configuration/ConfigurationManager.cs
@@ -1,10 +1,12 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Saturn.Agents.Core;
 using Saturn.Configuration.Objects;
+using Saturn.Providers;
 
 namespace Saturn.Configuration
 {
@@ -14,9 +16,9 @@ namespace Saturn.Configuration
             Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
             "Saturn"
         );
-        
+
         private static readonly string ConfigFilePath = Path.Combine(AppDataPath, "agent-config.json");
-        
+
         private static readonly JsonSerializerOptions JsonOptions = new JsonSerializerOptions
         {
             WriteIndented = true,
@@ -36,17 +38,22 @@ namespace Saturn.Configuration
 
                 var json = await File.ReadAllTextAsync(ConfigFilePath);
                 var config = JsonSerializer.Deserialize<PersistedAgentConfiguration>(json, JsonOptions);
-                
+
                 if (config != null && config.RequireCommandApproval == null)
                 {
                     config.RequireCommandApproval = true;
                 }
-                
+
                 if (config != null && config.EnableUserRules == null)
                 {
                     config.EnableUserRules = true;
                 }
-                
+
+                if (config != null)
+                {
+                    MigrateLegacyProviderFields(config);
+                }
+
                 return config;
             }
             catch (Exception ex)
@@ -56,10 +63,50 @@ namespace Saturn.Configuration
             }
         }
 
+        /// <summary>
+        /// Configs written before provider support carry only the flat Model field and
+        /// implicitly targeted OpenRouter. Fold them into the per-provider shape.
+        /// </summary>
+        private static void MigrateLegacyProviderFields(PersistedAgentConfiguration config)
+        {
+            config.ActiveProvider ??= "openrouter";
+            config.Providers ??= new Dictionary<string, PersistedProviderConfiguration>(StringComparer.OrdinalIgnoreCase);
+
+            if (!config.Providers.TryGetValue(config.ActiveProvider, out var providerConfig))
+            {
+                providerConfig = new PersistedProviderConfiguration();
+                config.Providers[config.ActiveProvider] = providerConfig;
+            }
+
+            providerConfig.Model ??= config.Model;
+        }
+
         public static async Task SaveConfigurationAsync(PersistedAgentConfiguration config)
         {
             try
             {
+                // Most call sites build the persisted object from the live agent
+                // configuration, which knows nothing about providers. Carry the provider
+                // fields over from the file on disk so those saves don't wipe them.
+                if (config.ActiveProvider == null || config.Providers == null)
+                {
+                    var existing = await LoadConfigurationAsync();
+                    config.ActiveProvider ??= existing?.ActiveProvider;
+                    config.Providers ??= existing?.Providers;
+                }
+
+                // Keep per-provider model memory in sync with the flat model field.
+                if (!string.IsNullOrWhiteSpace(config.ActiveProvider) && !string.IsNullOrWhiteSpace(config.Model))
+                {
+                    config.Providers ??= new Dictionary<string, PersistedProviderConfiguration>(StringComparer.OrdinalIgnoreCase);
+                    if (!config.Providers.TryGetValue(config.ActiveProvider, out var providerConfig))
+                    {
+                        providerConfig = new PersistedProviderConfiguration();
+                        config.Providers[config.ActiveProvider] = providerConfig;
+                    }
+                    providerConfig.Model = config.Model;
+                }
+
                 if (!Directory.Exists(AppDataPath))
                 {
                     Directory.CreateDirectory(AppDataPath);
@@ -72,6 +119,66 @@ namespace Saturn.Configuration
             {
 
             }
+        }
+
+        /// <summary>
+        /// Persists the provider choice made in the UI along with the settings it was
+        /// connected with and, when known, the model to use on that provider.
+        /// </summary>
+        public static async Task SaveProviderSelectionAsync(string providerName, ProviderSettings settings, string? model = null)
+        {
+            var config = await LoadConfigurationAsync() ?? new PersistedAgentConfiguration();
+
+            config.ActiveProvider = providerName;
+            config.Providers ??= new Dictionary<string, PersistedProviderConfiguration>(StringComparer.OrdinalIgnoreCase);
+
+            if (!config.Providers.TryGetValue(providerName, out var providerConfig))
+            {
+                providerConfig = new PersistedProviderConfiguration();
+                config.Providers[providerName] = providerConfig;
+            }
+
+            providerConfig.Settings = new Dictionary<string, string?>(settings.Values, StringComparer.OrdinalIgnoreCase);
+            if (!string.IsNullOrWhiteSpace(model))
+            {
+                providerConfig.Model = model;
+                config.Model = model;
+            }
+
+            await SaveConfigurationAsync(config);
+        }
+
+        public static ProviderSettings GetProviderSettings(PersistedAgentConfiguration? config, string providerName)
+        {
+            var settings = new ProviderSettings();
+            if (config?.Providers != null &&
+                config.Providers.TryGetValue(providerName, out var providerConfig) &&
+                providerConfig.Settings != null)
+            {
+                foreach (var kvp in providerConfig.Settings)
+                {
+                    settings.Values[kvp.Key] = kvp.Value;
+                }
+            }
+            return settings;
+        }
+
+        public static string? GetProviderModel(PersistedAgentConfiguration? config, string providerName)
+        {
+            if (config?.Providers != null &&
+                config.Providers.TryGetValue(providerName, out var providerConfig) &&
+                !string.IsNullOrWhiteSpace(providerConfig.Model))
+            {
+                return providerConfig.Model;
+            }
+
+            // Fall back to the flat model only when it belonged to this provider.
+            if (string.Equals(config?.ActiveProvider, providerName, StringComparison.OrdinalIgnoreCase))
+            {
+                return config?.Model;
+            }
+
+            return null;
         }
 
         public static PersistedAgentConfiguration FromAgentConfiguration(AgentConfiguration agentConfig)

--- a/Configuration/Objects/PersistedAgentConfiguration.cs
+++ b/Configuration/Objects/PersistedAgentConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -20,5 +20,21 @@ namespace Saturn.Configuration.Objects
         public List<string>? ToolNames { get; set; }
         public bool? RequireCommandApproval { get; set; }
         public bool? EnableUserRules { get; set; }
+
+        /// <summary>Registry name of the provider to connect at startup (e.g. "openrouter", "lmstudio").</summary>
+        public string? ActiveProvider { get; set; }
+
+        /// <summary>
+        /// Per-provider settings and model memory, keyed by provider registry name.
+        /// Kept separately from the flat <see cref="Model"/> so switching back and forth
+        /// between providers restores the model used on each side.
+        /// </summary>
+        public Dictionary<string, PersistedProviderConfiguration>? Providers { get; set; }
+    }
+
+    public class PersistedProviderConfiguration
+    {
+        public Dictionary<string, string?>? Settings { get; set; }
+        public string? Model { get; set; }
     }
 }

--- a/Core/Agents/AgentPoolManager.cs
+++ b/Core/Agents/AgentPoolManager.cs
@@ -8,7 +8,7 @@ using AsyncKeyedLock;
 using Saturn.Agents;
 using Saturn.Agents.Core;
 using Saturn.Core.Sessions;
-using Saturn.OpenRouter;
+using Saturn.Providers;
 
 namespace Saturn.Core.Agents
 {
@@ -17,24 +17,34 @@ namespace Saturn.Core.Agents
         private readonly ConcurrentDictionary<string, AgentPoolEntry> _agentPool = new();
         private readonly ConcurrentDictionary<string, string> _sessionAgentMapping = new();
         private readonly AsyncKeyedLocker<string> _sessionLocks = new();
-        private readonly OpenRouterClient _client;
+        private readonly ILlmClientSource _clientSource;
         private readonly Timer _cleanupTimer;
         private readonly AgentPoolConfiguration _configuration;
-        
-        private static readonly Lazy<AgentPoolManager> _instance = new(() => 
-            new AgentPoolManager(new OpenRouterClient(new OpenRouterOptions())));
-        
-        public static AgentPoolManager Instance => _instance.Value;
-        
+
+        private static AgentPoolManager? _instance;
+
+        /// <summary>
+        /// The shared pool. Must be initialized with a client source at startup; a pool
+        /// that silently constructed its own client would bypass provider selection.
+        /// </summary>
+        public static AgentPoolManager Instance =>
+            _instance ?? throw new InvalidOperationException(
+                "AgentPoolManager is not initialized. Call AgentPoolManager.Initialize at startup.");
+
+        public static void Initialize(ILlmClientSource clientSource, AgentPoolConfiguration? configuration = null)
+        {
+            _instance ??= new AgentPoolManager(clientSource, configuration);
+        }
+
         public event EventHandler<AgentPoolEventArgs>? AgentCreated;
         public event EventHandler<AgentPoolEventArgs>? AgentRecycled;
         public event EventHandler<AgentPoolEventArgs>? AgentDestroyed;
-        
-        public AgentPoolManager(OpenRouterClient client, AgentPoolConfiguration? configuration = null)
+
+        public AgentPoolManager(ILlmClientSource clientSource, AgentPoolConfiguration? configuration = null)
         {
-            _client = client;
+            _clientSource = clientSource;
             _configuration = configuration ?? new AgentPoolConfiguration();
-            _cleanupTimer = new Timer(CleanupIdleAgents, null, 
+            _cleanupTimer = new Timer(CleanupIdleAgents, null,
                 _configuration.CleanupInterval, _configuration.CleanupInterval);
         }
         
@@ -87,7 +97,7 @@ namespace Saturn.Core.Agents
         
         private async Task<Agent> CreateNewAgent(AgentConfiguration configuration)
         {
-            configuration.Client = _client;
+            configuration.ClientSource = _clientSource;
             
             if (configuration.EnableUserRules && _configuration.InheritUserRules)
             {

--- a/Program.cs
+++ b/Program.cs
@@ -3,8 +3,7 @@ using Saturn.Agents.Core;
 using Saturn.Agents.MultiAgent;
 using Saturn.Configuration;
 using Saturn.Core;
-using Saturn.OpenRouter;
-using Saturn.OpenRouter.Models.Api.Chat;
+using Saturn.Providers;
 using Saturn.UI;
 using System;
 using System.Collections.Generic;
@@ -54,34 +53,44 @@ namespace Saturn
         }
         
 
-        static async Task<(Agent, OpenRouterClient)> CreateAgent()
+        static async Task<(Agent, ILlmClientSource)> CreateAgent()
         {
-            var apiKey = Environment.GetEnvironmentVariable("OPENROUTER_API_KEY");
-            if (string.IsNullOrWhiteSpace(apiKey))
-            {
-                throw new InvalidOperationException("OPENROUTER_API_KEY environment variable is not set. Please set it before running the application.");
-            }
-            
-            OpenRouterOptions options = new OpenRouterOptions()
-            {
-                ApiKey = apiKey,
-                Referer = "https://github.com/xyOz-dev/Saturn",
-                Title = "Saturn"
-            };
-
-            var client = new OpenRouterClient(options);
-            
-            AgentManager.Instance.Initialize(client);
+            ProviderRegistry.Register(new OpenRouterProvider());
+            ProviderRegistry.Register(new LMStudioProvider());
 
             var persistedConfig = await ConfigurationManager.LoadConfigurationAsync();
-            
-            var model = "anthropic/claude-sonnet-4";
+
+            // Provider resolution: environment beats saved config beats the historical default.
+            var providerName = Environment.GetEnvironmentVariable("SATURN_PROVIDER");
+            if (string.IsNullOrWhiteSpace(providerName))
+            {
+                providerName = persistedConfig?.ActiveProvider;
+            }
+            if (string.IsNullOrWhiteSpace(providerName))
+            {
+                providerName = OpenRouterProvider.ProviderName;
+            }
+
+            var manager = LlmClientManager.Instance;
+            var providerSettings = ConfigurationManager.GetProviderSettings(persistedConfig, providerName);
+            var swap = await manager.SwapAsync(providerName, providerSettings);
+            if (!swap.Success)
+            {
+                throw new InvalidOperationException(swap.Error);
+            }
+
+            AgentManager.Instance.Initialize(manager);
+            Saturn.Core.Agents.AgentPoolManager.Initialize(manager);
+
+            var capabilities = manager.Current.Capabilities;
+            var model = await ResolveStartupModelAsync(manager, persistedConfig, providerName);
+
             var temperature = 0.15;
             if (model.Contains("gpt-5", StringComparison.OrdinalIgnoreCase))
             {
                 temperature = 1.0;
             }
-            
+
             // Determine EnableUserRules from persisted config or default to true
             bool enableUserRules = persistedConfig?.EnableUserRules ?? true;
             
@@ -192,7 +201,7 @@ Operating Principles
    - Monitor agent status to avoid resource exhaustion.
    - Avoid redundant work - if a sub-agent did it, it's done.
    - Efficiency means trusting delegation, not redoing completed tasks.", includeDirectories: true, includeUserRules: enableUserRules),
-                Client = client,
+                ClientSource = manager,
                 Model = model,
                 Temperature = temperature,
                 MaxTokens = 4096,
@@ -215,19 +224,68 @@ Operating Principles
             if (persistedConfig != null)
             {
                 ConfigurationManager.ApplyToAgentConfiguration(agentConfig, persistedConfig);
+
+                // The flat persisted model may belong to a different provider; the
+                // per-provider resolution above is authoritative.
+                agentConfig.Model = model;
             }
             else
             {
                 await ConfigurationManager.SaveConfigurationAsync(
                     ConfigurationManager.FromAgentConfiguration(agentConfig));
             }
-            
+
+            await ConfigurationManager.SaveProviderSelectionAsync(providerName, providerSettings, model);
+
             if (agentConfig.Model.Contains("gpt-5", StringComparison.OrdinalIgnoreCase))
             {
                 agentConfig.Temperature = 1.0;
             }
 
-            return (new Agent(agentConfig), client);
+            return (new Agent(agentConfig), manager);
+        }
+
+        /// <summary>
+        /// Picks the model for the connected provider: the model remembered for it,
+        /// else the provider default, else the first available model (preferring ones
+        /// already loaded on local servers).
+        /// </summary>
+        static async Task<string> ResolveStartupModelAsync(
+            ILlmClientSource manager,
+            Saturn.Configuration.Objects.PersistedAgentConfiguration? persistedConfig,
+            string providerName)
+        {
+            var capabilities = manager.Current.Capabilities;
+
+            var model = ConfigurationManager.GetProviderModel(persistedConfig, providerName);
+            if (string.IsNullOrWhiteSpace(model))
+            {
+                model = capabilities.DefaultModel;
+            }
+
+            if (string.IsNullOrWhiteSpace(model))
+            {
+                var models = await manager.Current.ListModelsAsync();
+                model = models.FirstOrDefault(m => m.IsLoaded == true)?.Id ?? models.FirstOrDefault()?.Id;
+                if (string.IsNullOrWhiteSpace(model))
+                {
+                    throw new InvalidOperationException(
+                        $"{capabilities.ProviderName} reports no available models. Load a model and try again.");
+                }
+                Console.WriteLine($"No model configured for {capabilities.ProviderName}; using '{model}'.");
+            }
+            else if (string.IsNullOrWhiteSpace(capabilities.DefaultModel))
+            {
+                // Local providers: the remembered model may have been deleted since last run.
+                var resolved = await ModelCatalog.ResolveModelAsync(manager, model);
+                if (!string.Equals(resolved, model, StringComparison.OrdinalIgnoreCase))
+                {
+                    Console.WriteLine($"Model '{model}' is not available on {capabilities.ProviderName}; using '{resolved}'.");
+                    model = resolved;
+                }
+            }
+
+            return model;
         }
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -71,9 +71,17 @@ namespace Saturn
                 providerName = OpenRouterProvider.ProviderName;
             }
 
+            // Canonicalize the name (env vars arrive in any casing) so it is a stable
+            // config key; unknown names fail here with the list of registered providers.
+            providerName = ProviderRegistry.Get(providerName.Trim()).Name;
+
             var manager = LlmClientManager.Instance;
             var providerSettings = ConfigurationManager.GetProviderSettings(persistedConfig, providerName);
-            var swap = await manager.SwapAsync(providerName, providerSettings);
+
+            // Install the client without a liveness probe: a transient network blip or a
+            // provider outage should degrade to per-request errors, not refuse to launch.
+            // Client construction still fails hard on unusable settings (e.g. missing key).
+            var swap = await manager.SwapAsync(providerName, providerSettings, requireValidation: false);
             if (!swap.Success)
             {
                 throw new InvalidOperationException(swap.Error);
@@ -83,6 +91,14 @@ namespace Saturn
             Saturn.Core.Agents.AgentPoolManager.Initialize(manager);
 
             var capabilities = manager.Current.Capabilities;
+
+            if (!await manager.Current.ValidateConnectionAsync())
+            {
+                Console.WriteLine($"Warning: could not verify the connection to {capabilities.ProviderName}. " +
+                    "Starting anyway; requests will fail until it is reachable. " +
+                    "You can switch providers from Agent -> Provider... in the UI.");
+            }
+
             var model = await ResolveStartupModelAsync(manager, persistedConfig, providerName);
 
             var temperature = 0.15;
@@ -265,7 +281,20 @@ Operating Principles
 
             if (string.IsNullOrWhiteSpace(model))
             {
-                var models = await manager.Current.ListModelsAsync();
+                List<ModelInfo> models;
+                try
+                {
+                    models = await manager.Current.ListModelsAsync();
+                }
+                catch
+                {
+                    // Provider unreachable at startup; leave the model unset and let the
+                    // user pick one from the UI once it comes back.
+                    Console.WriteLine($"Warning: could not list models from {capabilities.ProviderName}. " +
+                        "Select a model via Agent -> Select Model... once the provider is reachable.");
+                    return string.Empty;
+                }
+
                 model = models.FirstOrDefault(m => m.IsLoaded == true)?.Id ?? models.FirstOrDefault()?.Id;
                 if (string.IsNullOrWhiteSpace(model))
                 {

--- a/Providers/Core/ILlmClient.cs
+++ b/Providers/Core/ILlmClient.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Saturn.OpenRouter.Models.Api.Chat;
+
+namespace Saturn.Providers
+{
+    /// <summary>
+    /// A connected chat-completions backend. All providers speak the OpenAI-compatible
+    /// dialect, so the request/response DTOs from the OpenRouter SDK serve as the shared
+    /// wire format; providers that don't understand an extension field simply never
+    /// receive it (see <see cref="LlmClientCapabilities"/>).
+    /// </summary>
+    public interface ILlmClient : IDisposable
+    {
+        LlmClientCapabilities Capabilities { get; }
+
+        Task<ChatCompletionResponse?> ChatAsync(ChatCompletionRequest request, CancellationToken cancellationToken = default);
+
+        IAsyncEnumerable<ChatCompletionChunk> StreamChatAsync(ChatCompletionRequest request, CancellationToken cancellationToken = default);
+
+        Task<List<ModelInfo>> ListModelsAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>Cheap liveness/auth probe. Returns false rather than throwing on failure.</summary>
+        Task<bool> ValidateConnectionAsync(CancellationToken cancellationToken = default);
+    }
+}

--- a/Providers/Core/ILlmClientSource.cs
+++ b/Providers/Core/ILlmClientSource.cs
@@ -1,0 +1,58 @@
+using System;
+
+namespace Saturn.Providers
+{
+    /// <summary>
+    /// How consumers obtain the currently active client. Nothing outside the provider
+    /// layer should hold an <see cref="ILlmClient"/> across turns; resolving through
+    /// this source is what makes providers hot-swappable mid-session.
+    /// </summary>
+    public interface ILlmClientSource
+    {
+        /// <summary>The active client. Throws if no provider has been connected yet.</summary>
+        ILlmClient Current { get; }
+
+        bool IsConnected { get; }
+
+        /// <summary>Registry name of the active provider (e.g. "openrouter"), or empty when disconnected.</summary>
+        string ActiveProviderName { get; }
+
+        event EventHandler<ProviderChangedEventArgs>? ProviderChanged;
+    }
+
+    public sealed class ProviderChangedEventArgs : EventArgs
+    {
+        public ProviderChangedEventArgs(string previousProviderName, string newProviderName, ILlmClient newClient)
+        {
+            PreviousProviderName = previousProviderName;
+            NewProviderName = newProviderName;
+            NewClient = newClient;
+        }
+
+        public string PreviousProviderName { get; }
+        public string NewProviderName { get; }
+        public ILlmClient NewClient { get; }
+    }
+
+    /// <summary>Fixed, non-swappable source wrapping a single client. Useful for tests.</summary>
+    public sealed class StaticClientSource : ILlmClientSource
+    {
+        private readonly ILlmClient _client;
+
+        public StaticClientSource(ILlmClient client, string providerName = "static")
+        {
+            _client = client ?? throw new ArgumentNullException(nameof(client));
+            ActiveProviderName = providerName;
+        }
+
+        public ILlmClient Current => _client;
+        public bool IsConnected => true;
+        public string ActiveProviderName { get; }
+
+        public event EventHandler<ProviderChangedEventArgs>? ProviderChanged
+        {
+            add { }
+            remove { }
+        }
+    }
+}

--- a/Providers/Core/ILlmProvider.cs
+++ b/Providers/Core/ILlmProvider.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Saturn.Providers
+{
+    /// <summary>
+    /// The plugin contract: describes a provider and constructs connected clients for it.
+    /// Register implementations with <see cref="ProviderRegistry"/> at startup.
+    /// </summary>
+    public interface ILlmProvider
+    {
+        /// <summary>Stable lowercase identifier used in config files and SATURN_PROVIDER (e.g. "lmstudio").</summary>
+        string Name { get; }
+
+        string DisplayName { get; }
+
+        IReadOnlyList<ProviderSettingDescriptor> SettingDescriptors { get; }
+
+        /// <summary>
+        /// Builds an unvalidated client from the given settings. Throws with an actionable
+        /// message when a required setting is missing.
+        /// </summary>
+        Task<ILlmClient> CreateClientAsync(ProviderSettings settings, CancellationToken cancellationToken = default);
+    }
+}

--- a/Providers/Core/LlmClientCapabilities.cs
+++ b/Providers/Core/LlmClientCapabilities.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+
+namespace Saturn.Providers
+{
+    /// <summary>
+    /// Static traits of a connected LLM client. Request builders and UI consult these
+    /// instead of branching on provider names, so new providers only need to describe
+    /// themselves accurately to get correct behavior everywhere.
+    /// </summary>
+    public sealed class LlmClientCapabilities
+    {
+        /// <summary>Display name shown in the status bar and dialogs (e.g. "OpenRouter", "LM Studio").</summary>
+        public string ProviderName { get; init; } = string.Empty;
+
+        public bool RequiresApiKey { get; init; }
+
+        /// <summary>Supports the OpenRouter "transforms" request extension (e.g. middle-out compression).</summary>
+        public bool SupportsTransforms { get; init; }
+
+        /// <summary>Supports the OpenRouter "usage": {"include": true} request extension.</summary>
+        public bool SupportsUsageInclude { get; init; }
+
+        /// <summary>Safe to send "tool_choice" alongside a tools array.</summary>
+        public bool SupportsToolChoice { get; init; } = true;
+
+        /// <summary>Model listings carry pricing information worth displaying.</summary>
+        public bool SupportsPricing { get; init; }
+
+        /// <summary>Supports Anthropic-style cache_control content parts.</summary>
+        public bool SupportsCaching { get; init; }
+
+        /// <summary>Model used when nothing is configured or the configured model is unavailable.</summary>
+        public string DefaultModel { get; init; } = string.Empty;
+
+        /// <summary>
+        /// How long a fetched model list stays fresh. Local providers should keep this short:
+        /// their list changes whenever the user loads or unloads a model.
+        /// </summary>
+        public TimeSpan ModelListCacheDuration { get; init; } = TimeSpan.FromMinutes(30);
+
+        /// <summary>Models offered when the live listing cannot be fetched. Empty for local providers.</summary>
+        public IReadOnlyList<ModelInfo> FallbackModels { get; init; } = Array.Empty<ModelInfo>();
+    }
+}

--- a/Providers/Core/LlmClientManager.cs
+++ b/Providers/Core/LlmClientManager.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Saturn.Providers
+{
+    public sealed class SwapResult
+    {
+        private SwapResult(bool success, string? error, ILlmClient? client)
+        {
+            Success = success;
+            Error = error;
+            Client = client;
+        }
+
+        public bool Success { get; }
+        public string? Error { get; }
+        public ILlmClient? Client { get; }
+
+        public static SwapResult Ok(ILlmClient client) => new(true, null, client);
+        public static SwapResult Failed(string error) => new(false, error, null);
+    }
+
+    /// <summary>
+    /// The swap engine. Builds and validates a candidate client before touching the
+    /// active one, so a failed connect leaves the session exactly where it was. The
+    /// replaced client is disposed after a grace period because in-flight requests
+    /// that resolved it before the swap may still be streaming on it.
+    /// </summary>
+    public sealed class LlmClientManager : ILlmClientSource, IDisposable
+    {
+        private static readonly TimeSpan RetiredClientGracePeriod = TimeSpan.FromMinutes(10);
+
+        private readonly object _swapLock = new();
+        private ILlmClient? _current;
+        private string _activeProviderName = string.Empty;
+        private ProviderSettings _activeSettings = new();
+
+        public static LlmClientManager Instance { get; } = new();
+
+        public ILlmClient Current =>
+            _current ?? throw new InvalidOperationException(
+                "No LLM provider is connected. Connect one via LlmClientManager.SwapAsync before creating agents.");
+
+        public bool IsConnected => _current != null;
+
+        public string ActiveProviderName => _activeProviderName;
+
+        /// <summary>Settings the active client was built with; used to prefill the provider dialog.</summary>
+        public ProviderSettings ActiveSettings => _activeSettings.Clone();
+
+        public event EventHandler<ProviderChangedEventArgs>? ProviderChanged;
+
+        public async Task<SwapResult> SwapAsync(string providerName, ProviderSettings settings, CancellationToken cancellationToken = default)
+        {
+            ILlmProvider provider;
+            try
+            {
+                provider = ProviderRegistry.Get(providerName);
+            }
+            catch (InvalidOperationException ex)
+            {
+                return SwapResult.Failed(ex.Message);
+            }
+
+            settings ??= new ProviderSettings();
+
+            ILlmClient candidate;
+            try
+            {
+                candidate = await provider.CreateClientAsync(settings, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                return SwapResult.Failed(ex.Message);
+            }
+
+            bool reachable;
+            try
+            {
+                reachable = await candidate.ValidateConnectionAsync(cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                SafeDispose(candidate);
+                return SwapResult.Failed($"Could not connect to {provider.DisplayName}: {ex.Message}");
+            }
+
+            if (!reachable)
+            {
+                SafeDispose(candidate);
+                return SwapResult.Failed($"Could not connect to {provider.DisplayName}. Check the provider settings and that the service is reachable.");
+            }
+
+            ILlmClient? retired;
+            string previousName;
+            lock (_swapLock)
+            {
+                retired = _current;
+                previousName = _activeProviderName;
+                _current = candidate;
+                _activeProviderName = provider.Name;
+                _activeSettings = settings.Clone();
+            }
+
+            if (retired != null)
+            {
+                RetireClient(retired);
+            }
+
+            ProviderChanged?.Invoke(this, new ProviderChangedEventArgs(previousName, provider.Name, candidate));
+            return SwapResult.Ok(candidate);
+        }
+
+        private static void RetireClient(ILlmClient client)
+        {
+            _ = Task.Delay(RetiredClientGracePeriod).ContinueWith(_ => SafeDispose(client));
+        }
+
+        private static void SafeDispose(ILlmClient client)
+        {
+            try
+            {
+                client.Dispose();
+            }
+            catch
+            {
+            }
+        }
+
+        public void Dispose()
+        {
+            ILlmClient? current;
+            lock (_swapLock)
+            {
+                current = _current;
+                _current = null;
+                _activeProviderName = string.Empty;
+            }
+
+            if (current != null)
+            {
+                SafeDispose(current);
+            }
+        }
+    }
+}

--- a/Providers/Core/LlmClientManager.cs
+++ b/Providers/Core/LlmClientManager.cs
@@ -29,7 +29,9 @@ namespace Saturn.Providers
     /// </summary>
     public sealed class LlmClientManager : ILlmClientSource, IDisposable
     {
-        private static readonly TimeSpan RetiredClientGracePeriod = TimeSpan.FromMinutes(10);
+        // Long enough to outlive any realistic in-flight turn on the old client,
+        // including local-server requests that use LM Studio's 10-minute timeout.
+        private static readonly TimeSpan RetiredClientGracePeriod = TimeSpan.FromMinutes(30);
 
         private readonly object _swapLock = new();
         private ILlmClient? _current;
@@ -51,7 +53,15 @@ namespace Saturn.Providers
 
         public event EventHandler<ProviderChangedEventArgs>? ProviderChanged;
 
-        public async Task<SwapResult> SwapAsync(string providerName, ProviderSettings settings, CancellationToken cancellationToken = default)
+        public Task<SwapResult> SwapAsync(string providerName, ProviderSettings settings, CancellationToken cancellationToken = default)
+            => SwapAsync(providerName, settings, requireValidation: true, cancellationToken);
+
+        /// <summary>
+        /// Connects a provider. With <paramref name="requireValidation"/> false the client
+        /// is installed without a liveness probe — used at startup so a transient network
+        /// blip degrades to per-request errors instead of refusing to launch.
+        /// </summary>
+        public async Task<SwapResult> SwapAsync(string providerName, ProviderSettings settings, bool requireValidation, CancellationToken cancellationToken = default)
         {
             ILlmProvider provider;
             try
@@ -75,21 +85,24 @@ namespace Saturn.Providers
                 return SwapResult.Failed(ex.Message);
             }
 
-            bool reachable;
-            try
+            if (requireValidation)
             {
-                reachable = await candidate.ValidateConnectionAsync(cancellationToken);
-            }
-            catch (Exception ex)
-            {
-                SafeDispose(candidate);
-                return SwapResult.Failed($"Could not connect to {provider.DisplayName}: {ex.Message}");
-            }
+                bool reachable;
+                try
+                {
+                    reachable = await candidate.ValidateConnectionAsync(cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    SafeDispose(candidate);
+                    return SwapResult.Failed($"Could not connect to {provider.DisplayName}: {ex.Message}");
+                }
 
-            if (!reachable)
-            {
-                SafeDispose(candidate);
-                return SwapResult.Failed($"Could not connect to {provider.DisplayName}. Check the provider settings and that the service is reachable.");
+                if (!reachable)
+                {
+                    SafeDispose(candidate);
+                    return SwapResult.Failed($"Could not connect to {provider.DisplayName}. Check the provider settings and that the service is reachable.");
+                }
             }
 
             ILlmClient? retired;

--- a/Providers/Core/ModelCatalog.cs
+++ b/Providers/Core/ModelCatalog.cs
@@ -65,6 +65,10 @@ namespace Saturn.Providers
                     return models;
                 }
             }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
             catch
             {
             }
@@ -120,6 +124,10 @@ namespace Saturn.Providers
                 }
 
                 return models.FirstOrDefault(m => m.IsLoaded == true)?.Id ?? models[0].Id;
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
             }
             catch
             {

--- a/Providers/Core/ModelCatalog.cs
+++ b/Providers/Core/ModelCatalog.cs
@@ -29,8 +29,20 @@ namespace Saturn.Providers
                 return new List<ModelInfo>();
             }
 
-            var client = clientSource.Current;
-            var providerKey = clientSource.ActiveProviderName;
+            // The two reads on the source are not atomic across a concurrent swap; re-read
+            // the name until it brackets the client read consistently, so a list can never
+            // be cached under the wrong provider's key.
+            string providerKey;
+            ILlmClient client;
+            while (true)
+            {
+                providerKey = clientSource.ActiveProviderName;
+                client = clientSource.Current;
+                if (clientSource.ActiveProviderName == providerKey)
+                {
+                    break;
+                }
+            }
 
             lock (_lock)
             {
@@ -79,6 +91,19 @@ namespace Saturn.Providers
                 if (models.Any(m => string.Equals(m.Id, requestedModel, StringComparison.OrdinalIgnoreCase)))
                 {
                     return requestedModel;
+                }
+
+                // OpenRouter routing variants ("vendor/model:nitro", ":online", ":free")
+                // are valid request ids that never appear verbatim in the models listing;
+                // when the base model exists, trust the requested variant.
+                var variantSeparator = requestedModel.LastIndexOf(':');
+                if (variantSeparator > 0)
+                {
+                    var baseModel = requestedModel.Substring(0, variantSeparator);
+                    if (models.Any(m => string.Equals(m.Id, baseModel, StringComparison.OrdinalIgnoreCase)))
+                    {
+                        return requestedModel;
+                    }
                 }
 
                 if (!string.IsNullOrWhiteSpace(preferredFallback) &&

--- a/Providers/Core/ModelCatalog.cs
+++ b/Providers/Core/ModelCatalog.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Saturn.Providers
+{
+    /// <summary>
+    /// Shared, provider-keyed cache of model listings. Keyed per provider so swapping
+    /// never surfaces a previous provider's models, with each provider declaring its own
+    /// freshness window (local servers change their list whenever the user loads or
+    /// unloads a model).
+    /// </summary>
+    public static class ModelCatalog
+    {
+        private static readonly object _lock = new();
+        private static readonly Dictionary<string, (List<ModelInfo> Models, DateTime FetchedAt)> _cache =
+            new(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Lists models for the active provider, from cache when fresh. Falls back to the
+        /// provider's static fallback list when the live listing fails or is empty.
+        /// </summary>
+        public static async Task<List<ModelInfo>> GetAsync(ILlmClientSource clientSource, CancellationToken cancellationToken = default)
+        {
+            if (clientSource == null || !clientSource.IsConnected)
+            {
+                return new List<ModelInfo>();
+            }
+
+            var client = clientSource.Current;
+            var providerKey = clientSource.ActiveProviderName;
+
+            lock (_lock)
+            {
+                if (_cache.TryGetValue(providerKey, out var cached) &&
+                    DateTime.UtcNow - cached.FetchedAt < client.Capabilities.ModelListCacheDuration)
+                {
+                    return cached.Models;
+                }
+            }
+
+            try
+            {
+                var models = await client.ListModelsAsync(cancellationToken);
+                if (models.Count > 0)
+                {
+                    lock (_lock)
+                    {
+                        _cache[providerKey] = (models, DateTime.UtcNow);
+                    }
+                    return models;
+                }
+            }
+            catch
+            {
+            }
+
+            return client.Capabilities.FallbackModels.ToList();
+        }
+
+        /// <summary>
+        /// Returns <paramref name="requestedModel"/> when the active provider offers it;
+        /// otherwise the best available substitute (a loaded model first, then the
+        /// provider default, then the first listed). Lets sub-agent requests written for
+        /// one provider degrade gracefully after a swap instead of erroring per request.
+        /// </summary>
+        public static async Task<string> ResolveModelAsync(ILlmClientSource clientSource, string requestedModel, string? preferredFallback = null)
+        {
+            try
+            {
+                var models = await GetAsync(clientSource);
+                if (models.Count == 0)
+                {
+                    return requestedModel;
+                }
+
+                if (models.Any(m => string.Equals(m.Id, requestedModel, StringComparison.OrdinalIgnoreCase)))
+                {
+                    return requestedModel;
+                }
+
+                if (!string.IsNullOrWhiteSpace(preferredFallback) &&
+                    models.Any(m => string.Equals(m.Id, preferredFallback, StringComparison.OrdinalIgnoreCase)))
+                {
+                    return preferredFallback!;
+                }
+
+                var defaultModel = clientSource.Current.Capabilities.DefaultModel;
+                if (!string.IsNullOrWhiteSpace(defaultModel) &&
+                    models.Any(m => string.Equals(m.Id, defaultModel, StringComparison.OrdinalIgnoreCase)))
+                {
+                    return defaultModel;
+                }
+
+                return models.FirstOrDefault(m => m.IsLoaded == true)?.Id ?? models[0].Id;
+            }
+            catch
+            {
+                return requestedModel;
+            }
+        }
+
+        public static void Invalidate()
+        {
+            lock (_lock)
+            {
+                _cache.Clear();
+            }
+        }
+    }
+}

--- a/Providers/Core/ModelInfo.cs
+++ b/Providers/Core/ModelInfo.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace Saturn.Providers
+{
+    /// <summary>
+    /// Provider-neutral model metadata surfaced to the UI. Fields that a provider
+    /// cannot supply (pricing on local servers, context length on bare OpenAI-compatible
+    /// endpoints) are simply left null and the UI degrades accordingly.
+    /// </summary>
+    public sealed class ModelInfo
+    {
+        public string Id { get; set; } = string.Empty;
+
+        /// <summary>Human-friendly name; falls back to Id when the provider has none.</summary>
+        public string? DisplayName { get; set; }
+
+        public string? Description { get; set; }
+
+        public int? ContextLength { get; set; }
+
+        /// <summary>Per-token prompt price as provided by the API (string form, provider units).</summary>
+        public string? PromptPrice { get; set; }
+
+        /// <summary>Per-token completion price as provided by the API (string form, provider units).</summary>
+        public string? CompletionPrice { get; set; }
+
+        /// <summary>Whether the model is currently loaded in memory. Only meaningful for local providers.</summary>
+        public bool? IsLoaded { get; set; }
+
+        public string Display => string.IsNullOrWhiteSpace(DisplayName) ? Id : DisplayName!;
+    }
+}

--- a/Providers/Core/ProviderRegistry.cs
+++ b/Providers/Core/ProviderRegistry.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Saturn.Providers
+{
+    /// <summary>
+    /// Name-to-provider lookup. Adding a provider to Saturn means implementing
+    /// <see cref="ILlmProvider"/> and registering it here during startup.
+    /// </summary>
+    public static class ProviderRegistry
+    {
+        private static readonly object _lock = new();
+        private static readonly Dictionary<string, ILlmProvider> _providers = new(StringComparer.OrdinalIgnoreCase);
+
+        public static void Register(ILlmProvider provider)
+        {
+            if (provider == null) throw new ArgumentNullException(nameof(provider));
+            lock (_lock)
+            {
+                _providers[provider.Name] = provider;
+            }
+        }
+
+        public static bool TryGet(string name, out ILlmProvider provider)
+        {
+            lock (_lock)
+            {
+                return _providers.TryGetValue(name ?? string.Empty, out provider!);
+            }
+        }
+
+        public static ILlmProvider Get(string name)
+        {
+            if (TryGet(name, out var provider))
+            {
+                return provider;
+            }
+
+            lock (_lock)
+            {
+                var known = _providers.Count == 0 ? "(none registered)" : string.Join(", ", _providers.Keys);
+                throw new InvalidOperationException($"Unknown provider '{name}'. Available providers: {known}.");
+            }
+        }
+
+        public static IReadOnlyList<ILlmProvider> All
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return _providers.Values.OrderBy(p => p.DisplayName, StringComparer.OrdinalIgnoreCase).ToList();
+                }
+            }
+        }
+
+        /// <summary>Removes all registrations. Intended for test isolation only.</summary>
+        public static void Clear()
+        {
+            lock (_lock)
+            {
+                _providers.Clear();
+            }
+        }
+    }
+}

--- a/Providers/Core/ProviderSettingDescriptor.cs
+++ b/Providers/Core/ProviderSettingDescriptor.cs
@@ -1,0 +1,52 @@
+using System;
+
+namespace Saturn.Providers
+{
+    public enum ProviderSettingKind
+    {
+        Text,
+        Secret,
+        Url,
+        Number
+    }
+
+    /// <summary>
+    /// Describes one configurable setting of a provider so generic UI can render an
+    /// input field for it and resolution can fall back to environment variables.
+    /// </summary>
+    public sealed class ProviderSettingDescriptor
+    {
+        public required string Key { get; init; }
+        public required string Label { get; init; }
+        public ProviderSettingKind Kind { get; init; } = ProviderSettingKind.Text;
+        public bool Required { get; init; }
+        public string? DefaultValue { get; init; }
+
+        /// <summary>Environment variable consulted when the setting is absent from saved config.</summary>
+        public string? EnvironmentVariable { get; init; }
+
+        /// <summary>
+        /// Resolves the effective value: explicit setting first, then environment
+        /// variable, then the descriptor default.
+        /// </summary>
+        public string? Resolve(ProviderSettings? settings)
+        {
+            var configured = settings?.Get(Key);
+            if (!string.IsNullOrWhiteSpace(configured))
+            {
+                return configured;
+            }
+
+            if (!string.IsNullOrWhiteSpace(EnvironmentVariable))
+            {
+                var fromEnv = Environment.GetEnvironmentVariable(EnvironmentVariable);
+                if (!string.IsNullOrWhiteSpace(fromEnv))
+                {
+                    return fromEnv;
+                }
+            }
+
+            return DefaultValue;
+        }
+    }
+}

--- a/Providers/Core/ProviderSettings.cs
+++ b/Providers/Core/ProviderSettings.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+
+namespace Saturn.Providers
+{
+    /// <summary>
+    /// String-keyed settings bag for one provider, persisted in agent-config.json.
+    /// Keys are defined by each provider's <see cref="ProviderSettingDescriptor"/> list.
+    /// </summary>
+    public sealed class ProviderSettings
+    {
+        public Dictionary<string, string?> Values { get; init; } = new(StringComparer.OrdinalIgnoreCase);
+
+        public string? Get(string key) => Values.TryGetValue(key, out var value) ? value : null;
+
+        public void Set(string key, string? value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                Values.Remove(key);
+            }
+            else
+            {
+                Values[key] = value;
+            }
+        }
+
+        public ProviderSettings Clone()
+        {
+            var clone = new ProviderSettings();
+            foreach (var kvp in Values)
+            {
+                clone.Values[kvp.Key] = kvp.Value;
+            }
+            return clone;
+        }
+    }
+}

--- a/Providers/LMStudio/LMStudioClient.cs
+++ b/Providers/LMStudio/LMStudioClient.cs
@@ -43,15 +43,23 @@ namespace Saturn.Providers
                 HttpMessageHandler = handlerFactory?.Invoke()
             };
             _v1Http = new HttpClientAdapter(v1Options);
-            _chat = new ChatCompletionsService(_v1Http);
-            _chatStreaming = new ChatCompletionsStreamingService(_v1Http, v1Options);
-
-            _nativeHttp = new HttpClientAdapter(new OpenRouterOptions
+            try
             {
-                BaseUrl = root + "/api/v0",
-                Timeout = TimeSpan.FromSeconds(10),
-                HttpMessageHandler = handlerFactory?.Invoke()
-            });
+                _chat = new ChatCompletionsService(_v1Http);
+                _chatStreaming = new ChatCompletionsStreamingService(_v1Http, v1Options);
+
+                _nativeHttp = new HttpClientAdapter(new OpenRouterOptions
+                {
+                    BaseUrl = root + "/api/v0",
+                    Timeout = TimeSpan.FromSeconds(10),
+                    HttpMessageHandler = handlerFactory?.Invoke()
+                });
+            }
+            catch
+            {
+                _v1Http.Dispose();
+                throw;
+            }
         }
 
         public string BaseUrl => _baseUrl;
@@ -83,9 +91,13 @@ namespace Saturn.Providers
                 root = root.Substring(0, root.Length - "/v1".Length).TrimEnd('/');
             }
 
-            if (!Uri.TryCreate(root, UriKind.Absolute, out _))
+            // Require an explicit http(s) scheme: "localhost:1234" parses as a URI with
+            // scheme "localhost" and would only fail later with a generic connect error.
+            if (!Uri.TryCreate(root, UriKind.Absolute, out var uri) ||
+                (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
             {
-                throw new InvalidOperationException($"LM Studio base URL '{baseUrl}' is not a valid absolute URL.");
+                throw new InvalidOperationException(
+                    $"LM Studio base URL '{baseUrl}' is not a valid http(s) URL. Example: http://localhost:1234/v1");
             }
 
             return root;

--- a/Providers/LMStudio/LMStudioClient.cs
+++ b/Providers/LMStudio/LMStudioClient.cs
@@ -1,0 +1,251 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Saturn.OpenRouter;
+using Saturn.OpenRouter.Http;
+using Saturn.OpenRouter.Models.Api.Chat;
+using Saturn.OpenRouter.Models.Api.Models;
+using Saturn.OpenRouter.Services;
+
+namespace Saturn.Providers
+{
+    /// <summary>
+    /// Client for LM Studio's local server. Chat goes through the OpenAI-compatible
+    /// /v1 endpoints, reusing the SDK's HTTP/SSE plumbing with a different base URL and
+    /// no auth. Model listings are enriched best-effort from LM Studio's native REST API
+    /// (/api/v0/models), which knows context lengths and which models are loaded.
+    /// </summary>
+    public sealed class LMStudioClient : ILlmClient
+    {
+        private readonly HttpClientAdapter _v1Http;
+        private readonly HttpClientAdapter _nativeHttp;
+        private readonly ChatCompletionsService _chat;
+        private readonly ChatCompletionsStreamingService _chatStreaming;
+        private readonly string _baseUrl;
+
+        public LMStudioClient(string baseUrl, TimeSpan timeout)
+        {
+            var root = NormalizeRootUrl(baseUrl);
+            _baseUrl = root + "/v1";
+
+            // ApiKey is deliberately left null: LM Studio ignores auth, and constructing
+            // the adapter directly (instead of OpenRouterClient) avoids picking up
+            // OPENROUTER_API_KEY from the environment and sending it to a local server.
+            var v1Options = new OpenRouterOptions
+            {
+                BaseUrl = _baseUrl,
+                Timeout = timeout
+            };
+            _v1Http = new HttpClientAdapter(v1Options);
+            _chat = new ChatCompletionsService(_v1Http);
+            _chatStreaming = new ChatCompletionsStreamingService(_v1Http, v1Options);
+
+            _nativeHttp = new HttpClientAdapter(new OpenRouterOptions
+            {
+                BaseUrl = root + "/api/v0",
+                Timeout = TimeSpan.FromSeconds(10)
+            });
+        }
+
+        public string BaseUrl => _baseUrl;
+
+        public LlmClientCapabilities Capabilities { get; } = new()
+        {
+            ProviderName = "LM Studio",
+            RequiresApiKey = false,
+            SupportsTransforms = false,
+            SupportsUsageInclude = false,
+            SupportsToolChoice = true,
+            SupportsPricing = false,
+            SupportsCaching = false,
+            DefaultModel = string.Empty,
+            ModelListCacheDuration = TimeSpan.FromSeconds(30),
+            FallbackModels = Array.Empty<ModelInfo>()
+        };
+
+        internal static string NormalizeRootUrl(string baseUrl)
+        {
+            if (string.IsNullOrWhiteSpace(baseUrl))
+            {
+                throw new InvalidOperationException("LM Studio base URL is empty.");
+            }
+
+            var root = baseUrl.Trim().TrimEnd('/');
+            if (root.EndsWith("/v1", StringComparison.OrdinalIgnoreCase))
+            {
+                root = root.Substring(0, root.Length - "/v1".Length).TrimEnd('/');
+            }
+
+            if (!Uri.TryCreate(root, UriKind.Absolute, out _))
+            {
+                throw new InvalidOperationException($"LM Studio base URL '{baseUrl}' is not a valid absolute URL.");
+            }
+
+            return root;
+        }
+
+        public async Task<ChatCompletionResponse?> ChatAsync(ChatCompletionRequest request, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                return await _chat.CreateAsync(request, cancellationToken);
+            }
+            catch (HttpRequestException ex)
+            {
+                throw Unreachable(ex);
+            }
+        }
+
+        public async IAsyncEnumerable<ChatCompletionChunk> StreamChatAsync(
+            ChatCompletionRequest request,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            var enumerator = _chatStreaming.StreamAsync(request, cancellationToken).GetAsyncEnumerator(cancellationToken);
+            await using (enumerator.ConfigureAwait(false))
+            {
+                while (true)
+                {
+                    bool moved;
+                    try
+                    {
+                        moved = await enumerator.MoveNextAsync();
+                    }
+                    catch (HttpRequestException ex)
+                    {
+                        throw Unreachable(ex);
+                    }
+
+                    if (!moved)
+                    {
+                        yield break;
+                    }
+
+                    yield return enumerator.Current;
+                }
+            }
+        }
+
+        public async Task<List<ModelInfo>> ListModelsAsync(CancellationToken cancellationToken = default)
+        {
+            ModelListResponse? response;
+            try
+            {
+                response = await _v1Http.SendJsonAsync<ModelListResponse>(HttpMethod.Get, "models", null, null, cancellationToken);
+            }
+            catch (HttpRequestException ex)
+            {
+                throw Unreachable(ex);
+            }
+
+            var models = (response?.Data ?? Array.Empty<Model>())
+                .Where(m => !string.IsNullOrEmpty(m.Id))
+                .Select(m => new ModelInfo { Id = m.Id! })
+                .ToList();
+
+            await EnrichFromNativeApiAsync(models, cancellationToken);
+
+            return models
+                .OrderByDescending(m => m.IsLoaded == true)
+                .ThenBy(m => m.Id, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+
+        /// <summary>
+        /// Fills in context length and loaded state from /api/v0/models. That API is
+        /// beta and may be disabled or change shape, so any failure leaves the baseline
+        /// /v1 listing untouched.
+        /// </summary>
+        private async Task EnrichFromNativeApiAsync(List<ModelInfo> models, CancellationToken cancellationToken)
+        {
+            if (models.Count == 0)
+            {
+                return;
+            }
+
+            JsonElement root;
+            try
+            {
+                root = await _nativeHttp.SendJsonAsync<JsonElement>(HttpMethod.Get, "models", null, null, cancellationToken);
+            }
+            catch
+            {
+                return;
+            }
+
+            try
+            {
+                if (root.ValueKind != JsonValueKind.Object ||
+                    !root.TryGetProperty("data", out var data) ||
+                    data.ValueKind != JsonValueKind.Array)
+                {
+                    return;
+                }
+
+                var byId = models.ToDictionary(m => m.Id, StringComparer.OrdinalIgnoreCase);
+                foreach (var entry in data.EnumerateArray())
+                {
+                    if (entry.ValueKind != JsonValueKind.Object ||
+                        !entry.TryGetProperty("id", out var idProp) ||
+                        idProp.ValueKind != JsonValueKind.String)
+                    {
+                        continue;
+                    }
+
+                    if (!byId.TryGetValue(idProp.GetString()!, out var model))
+                    {
+                        continue;
+                    }
+
+                    if (entry.TryGetProperty("max_context_length", out var ctxProp) &&
+                        ctxProp.ValueKind == JsonValueKind.Number &&
+                        ctxProp.TryGetInt32(out var contextLength) &&
+                        contextLength > 0)
+                    {
+                        model.ContextLength = contextLength;
+                    }
+
+                    if (entry.TryGetProperty("state", out var stateProp) &&
+                        stateProp.ValueKind == JsonValueKind.String)
+                    {
+                        model.IsLoaded = string.Equals(stateProp.GetString(), "loaded", StringComparison.OrdinalIgnoreCase);
+                    }
+                }
+            }
+            catch
+            {
+            }
+        }
+
+        public async Task<bool> ValidateConnectionAsync(CancellationToken cancellationToken = default)
+        {
+            using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeout.CancelAfter(TimeSpan.FromSeconds(5));
+            try
+            {
+                await _v1Http.SendJsonAsync<ModelListResponse>(HttpMethod.Get, "models", null, null, timeout.Token);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private InvalidOperationException Unreachable(Exception inner) =>
+            new(
+                $"Cannot reach LM Studio at {_baseUrl}. Is LM Studio running with its local server started? " +
+                "(In LM Studio: Developer tab -> Start Server.)",
+                inner);
+
+        public void Dispose()
+        {
+            _v1Http.Dispose();
+            _nativeHttp.Dispose();
+        }
+    }
+}

--- a/Providers/LMStudio/LMStudioClient.cs
+++ b/Providers/LMStudio/LMStudioClient.cs
@@ -258,8 +258,14 @@ namespace Saturn.Providers
 
         public void Dispose()
         {
-            _v1Http.Dispose();
-            _nativeHttp.Dispose();
+            try
+            {
+                _v1Http.Dispose();
+            }
+            finally
+            {
+                _nativeHttp.Dispose();
+            }
         }
     }
 }

--- a/Providers/LMStudio/LMStudioClient.cs
+++ b/Providers/LMStudio/LMStudioClient.cs
@@ -28,7 +28,7 @@ namespace Saturn.Providers
         private readonly ChatCompletionsStreamingService _chatStreaming;
         private readonly string _baseUrl;
 
-        public LMStudioClient(string baseUrl, TimeSpan timeout)
+        public LMStudioClient(string baseUrl, TimeSpan timeout, Func<HttpMessageHandler>? handlerFactory = null)
         {
             var root = NormalizeRootUrl(baseUrl);
             _baseUrl = root + "/v1";
@@ -39,7 +39,8 @@ namespace Saturn.Providers
             var v1Options = new OpenRouterOptions
             {
                 BaseUrl = _baseUrl,
-                Timeout = timeout
+                Timeout = timeout,
+                HttpMessageHandler = handlerFactory?.Invoke()
             };
             _v1Http = new HttpClientAdapter(v1Options);
             _chat = new ChatCompletionsService(_v1Http);
@@ -48,7 +49,8 @@ namespace Saturn.Providers
             _nativeHttp = new HttpClientAdapter(new OpenRouterOptions
             {
                 BaseUrl = root + "/api/v0",
-                Timeout = TimeSpan.FromSeconds(10)
+                Timeout = TimeSpan.FromSeconds(10),
+                HttpMessageHandler = handlerFactory?.Invoke()
             });
         }
 

--- a/Providers/LMStudio/LMStudioProvider.cs
+++ b/Providers/LMStudio/LMStudioProvider.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Saturn.Providers
+{
+    public sealed class LMStudioProvider : ILlmProvider
+    {
+        public const string ProviderName = "lmstudio";
+        public const string BaseUrlSetting = "baseUrl";
+        public const string TimeoutSetting = "timeoutSeconds";
+
+        // Local generation can take minutes on modest hardware, so the default request
+        // timeout is far above the cloud default.
+        private const int DefaultTimeoutSeconds = 600;
+
+        public string Name => ProviderName;
+        public string DisplayName => "LM Studio";
+
+        public IReadOnlyList<ProviderSettingDescriptor> SettingDescriptors { get; } = new[]
+        {
+            new ProviderSettingDescriptor
+            {
+                Key = BaseUrlSetting,
+                Label = "Base URL",
+                Kind = ProviderSettingKind.Url,
+                Required = true,
+                DefaultValue = "http://localhost:1234/v1",
+                EnvironmentVariable = "LMSTUDIO_BASE_URL"
+            },
+            new ProviderSettingDescriptor
+            {
+                Key = TimeoutSetting,
+                Label = "Request timeout (seconds)",
+                Kind = ProviderSettingKind.Number,
+                DefaultValue = DefaultTimeoutSeconds.ToString()
+            }
+        };
+
+        public Task<ILlmClient> CreateClientAsync(ProviderSettings settings, CancellationToken cancellationToken = default)
+        {
+            var baseUrl = SettingDescriptors.First(d => d.Key == BaseUrlSetting).Resolve(settings);
+            if (string.IsNullOrWhiteSpace(baseUrl))
+            {
+                throw new InvalidOperationException("LM Studio requires a base URL (default: http://localhost:1234/v1).");
+            }
+
+            var timeoutText = SettingDescriptors.First(d => d.Key == TimeoutSetting).Resolve(settings);
+            if (!int.TryParse(timeoutText, out var timeoutSeconds) || timeoutSeconds <= 0)
+            {
+                timeoutSeconds = DefaultTimeoutSeconds;
+            }
+
+            return Task.FromResult<ILlmClient>(new LMStudioClient(baseUrl, TimeSpan.FromSeconds(timeoutSeconds)));
+        }
+    }
+}

--- a/Providers/OpenRouter/OpenRouterLlmClient.cs
+++ b/Providers/OpenRouter/OpenRouterLlmClient.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Saturn.OpenRouter;
+using Saturn.OpenRouter.Models.Api.Chat;
+
+namespace Saturn.Providers
+{
+    /// <summary>
+    /// ILlmClient adapter over the vendored OpenRouter SDK client.
+    /// </summary>
+    public sealed class OpenRouterLlmClient : ILlmClient
+    {
+        private readonly OpenRouterClient _inner;
+
+        public OpenRouterLlmClient(OpenRouterClient inner)
+        {
+            _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+        }
+
+        /// <summary>The underlying SDK client, for OpenRouter-specific services (credits, generation stats).</summary>
+        public OpenRouterClient Inner => _inner;
+
+        public LlmClientCapabilities Capabilities { get; } = new()
+        {
+            ProviderName = "OpenRouter",
+            RequiresApiKey = true,
+            SupportsTransforms = true,
+            SupportsUsageInclude = true,
+            SupportsToolChoice = true,
+            SupportsPricing = true,
+            SupportsCaching = true,
+            DefaultModel = "anthropic/claude-sonnet-4",
+            ModelListCacheDuration = TimeSpan.FromMinutes(30),
+            FallbackModels = new[]
+            {
+                new ModelInfo { Id = "openai/gpt-5", DisplayName = "OpenAI: GPT-5" },
+                new ModelInfo { Id = "openai/gpt-5-mini", DisplayName = "OpenAI: GPT-5-Mini" },
+                new ModelInfo { Id = "openai/gpt-5-nano", DisplayName = "OpenAI: GPT-5-Nano" },
+                new ModelInfo { Id = "openai/gpt-oss-120b", DisplayName = "OpenAI: GPT-OSS-120B" },
+                new ModelInfo { Id = "openai/gpt-oss-20b", DisplayName = "OpenAI: GPT-OSS-20B" },
+                new ModelInfo { Id = "anthropic/claude-opus-4.1", DisplayName = "Anthropic: Opus-4.1" },
+                new ModelInfo { Id = "anthropic/claude-opus-4", DisplayName = "Anthropic: Opus-4" },
+                new ModelInfo { Id = "anthropic/claude-sonnet-4", DisplayName = "Anthropic: Sonnet-4" },
+                new ModelInfo { Id = "anthropic/claude-3.7-sonnet", DisplayName = "Anthropic: Sonnet-3.7" },
+                new ModelInfo { Id = "anthropic/claude-3.5-haiku", DisplayName = "Anthropic: Haiku-3.5" },
+                new ModelInfo { Id = "moonshotai/kimi-k2:free", DisplayName = "Kimi-K2" }
+            }
+        };
+
+        public Task<ChatCompletionResponse?> ChatAsync(ChatCompletionRequest request, CancellationToken cancellationToken = default)
+            => _inner.Chat.CreateAsync(request, cancellationToken);
+
+        public IAsyncEnumerable<ChatCompletionChunk> StreamChatAsync(ChatCompletionRequest request, CancellationToken cancellationToken = default)
+            => _inner.ChatStreaming.StreamAsync(request, cancellationToken);
+
+        public async Task<List<ModelInfo>> ListModelsAsync(CancellationToken cancellationToken = default)
+        {
+            var response = await _inner.Models.ListAllAsync(cancellationToken);
+            if (response?.Data == null)
+            {
+                return new List<ModelInfo>();
+            }
+
+            return response.Data
+                .Where(m => !string.IsNullOrEmpty(m.Id))
+                .Select(m => new ModelInfo
+                {
+                    Id = m.Id!,
+                    DisplayName = m.Name,
+                    Description = m.Description,
+                    ContextLength = m.ContextLength,
+                    PromptPrice = m.Pricing?.Prompt,
+                    CompletionPrice = m.Pricing?.Completion
+                })
+                .OrderBy(m => m.Display, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+
+        public async Task<bool> ValidateConnectionAsync(CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                await _inner.Credits.GetAsync(cancellationToken);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        public void Dispose() => _inner.Dispose();
+    }
+}

--- a/Providers/OpenRouter/OpenRouterProvider.cs
+++ b/Providers/OpenRouter/OpenRouterProvider.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Saturn.OpenRouter;
+
+namespace Saturn.Providers
+{
+    public sealed class OpenRouterProvider : ILlmProvider
+    {
+        public const string ProviderName = "openrouter";
+        public const string ApiKeySetting = "apiKey";
+
+        public string Name => ProviderName;
+        public string DisplayName => "OpenRouter";
+
+        public IReadOnlyList<ProviderSettingDescriptor> SettingDescriptors { get; } = new[]
+        {
+            new ProviderSettingDescriptor
+            {
+                Key = ApiKeySetting,
+                Label = "API Key",
+                Kind = ProviderSettingKind.Secret,
+                Required = true,
+                EnvironmentVariable = "OPENROUTER_API_KEY"
+            }
+        };
+
+        public Task<ILlmClient> CreateClientAsync(ProviderSettings settings, CancellationToken cancellationToken = default)
+        {
+            var apiKey = SettingDescriptors[0].Resolve(settings);
+            if (string.IsNullOrWhiteSpace(apiKey))
+            {
+                throw new InvalidOperationException(
+                    "OpenRouter requires an API key. Set the OPENROUTER_API_KEY environment variable, " +
+                    "or switch to a local provider with SATURN_PROVIDER=lmstudio.");
+            }
+
+            var client = new OpenRouterClient(new OpenRouterOptions
+            {
+                ApiKey = apiKey,
+                Referer = "https://github.com/xyOz-dev/Saturn",
+                Title = "Saturn"
+            });
+
+            return Task.FromResult<ILlmClient>(new OpenRouterLlmClient(client));
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 ### *Your personal swarm of employees, without the salary.*
 
 [![.NET](https://img.shields.io/badge/.NET-8.0-512BD4?style=for-the-badge&logo=dotnet)](https://dotnet.microsoft.com/)
-[![OpenRouter](https://img.shields.io/badge/OpenRouter-Powered-00A8E1?style=for-the-badge)](https://openrouter.ai/)
+[![OpenRouter](https://img.shields.io/badge/OpenRouter-Supported-00A8E1?style=for-the-badge)](https://openrouter.ai/)
+[![LM Studio](https://img.shields.io/badge/LM_Studio-Supported-4E1F9D?style=for-the-badge)](https://lmstudio.ai/)
 [![GitHub Stars](https://img.shields.io/github/stars/xyOz-dev/Saturn?style=for-the-badge&color=yellow)](https://github.com/xyOz-dev/Saturn/stargazers)
 
 </div>
@@ -18,7 +19,7 @@
 
 Saturn is an AI coding agent that runs entirely in your terminal. You describe what you want done in plain English, and Saturn reads your code, makes edits, runs commands, and reports back, all inside the Git repository you point it at.
 
-Under the hood it connects to [OpenRouter](https://openrouter.ai/), so you can use models from Anthropic, OpenAI, Google and others with a single API key. It is built on .NET 8 and Terminal.Gui, and installs as a standard .NET global tool.
+Under the hood it connects to [OpenRouter](https://openrouter.ai/), so you can use models from Anthropic, OpenAI, Google and others with a single API key — or to a local [LM Studio](https://lmstudio.ai/) server, so you can run entirely offline on your own hardware. Providers can be switched at any time from the Agent menu without restarting. It is built on .NET 8 and Terminal.Gui, and installs as a standard .NET global tool.
 
 ## Features
 
@@ -26,6 +27,7 @@ Under the hood it connects to [OpenRouter](https://openrouter.ai/), so you can u
 - **A full tool suite** the agent uses on your behalf: read, write and diff files, grep and glob searches, shell command execution, and web fetch
 - **Command approval**, so the agent asks before running shell commands
 - **Multi-agent orchestration**: the main agent can spawn sub-agents, hand tasks off to them, check their status and collect results, letting it work on several parts of a task in parallel
+- **Multiple providers**: OpenRouter for cloud models, LM Studio for local ones, hot-swappable from within the UI
 - **Modes and user rules** to customize the agent's behavior per task or globally
 - **Persistent chat history** stored locally in SQLite, so you can reload previous sessions
 - **Git-aware**: Saturn requires a Git repository, so every change it makes can be reviewed and reverted with normal Git workflow
@@ -34,7 +36,9 @@ Under the hood it connects to [OpenRouter](https://openrouter.ai/), so you can u
 
 - **.NET 8.0 SDK** or later
 - **Git**. Saturn only operates inside a Git repository. If you start it elsewhere it will offer to initialize one.
-- **OpenRouter API key** ([get one here](https://openrouter.ai/))
+- **One LLM provider:**
+  - An **OpenRouter API key** ([get one here](https://openrouter.ai/)), or
+  - **LM Studio** ([download](https://lmstudio.ai/)) with its local server running and a model downloaded
 
 ## Installation
 
@@ -50,7 +54,9 @@ dotnet tool install --global --add-source ./nupkg SaturnAgent
 
 ## Quick Start
 
-### 1. Set up your API key
+### 1. Set up a provider
+
+**Option A — OpenRouter (cloud models):**
 
 ```bash
 # Windows (Command Prompt)
@@ -62,6 +68,28 @@ $env:OPENROUTER_API_KEY = "your-api-key-here"
 # macOS/Linux
 export OPENROUTER_API_KEY="your-api-key-here"
 ```
+
+**Option B — LM Studio (local models):**
+
+1. In LM Studio, download a model and start the local server (Developer tab → Start Server).
+2. Tell Saturn to use it:
+
+```bash
+# Windows (Command Prompt)
+setx SATURN_PROVIDER lmstudio
+
+# Windows (PowerShell)
+$env:SATURN_PROVIDER = "lmstudio"
+
+# macOS/Linux
+export SATURN_PROVIDER=lmstudio
+```
+
+Saturn connects to `http://localhost:1234/v1` by default; set `LMSTUDIO_BASE_URL` if your server runs elsewhere. If no model is configured, Saturn picks the first loaded model automatically.
+
+You can also switch providers later from inside Saturn via **Agent → Provider...** — the choice is remembered between runs, and each provider remembers its own model.
+
+> **Note on local models:** Saturn drives everything through tool calls, so use a model with solid tool-calling support (e.g. Qwen 2.5 Coder, Llama 3.1+, Mistral). Small models may produce malformed tool calls or loop. Sub-agent parallelism is also limited by the fact that a local server generates for one request at a time.
 
 ### 2. Launch Saturn
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ export SATURN_PROVIDER=lmstudio
 
 Saturn connects to `http://localhost:1234/v1` by default; set `LMSTUDIO_BASE_URL` if your server runs elsewhere. If no model is configured, Saturn picks the first loaded model automatically.
 
-You can also switch providers later from inside Saturn via **Agent → Provider...** — the choice is remembered between runs, and each provider remembers its own model.
+You can also switch providers later from inside Saturn via **Agent → Provider...** — the choice is remembered between runs, and each provider remembers its own model. Note that the `SATURN_PROVIDER` environment variable, when set, always wins at launch — so if you set it permanently (e.g. with `setx`) it will override the in-app choice on the next start. Clear it (`setx SATURN_PROVIDER ""` or unset it in your shell profile) if you prefer to control the provider from the UI.
 
 > **Note on local models:** Saturn drives everything through tool calls, so use a model with solid tool-calling support (e.g. Qwen 2.5 Coder, Llama 3.1+, Mistral). Small models may produce malformed tool calls or loop. Sub-agent parallelism is also limited by the fact that a local server generates for one request at a time.
 

--- a/Saturn.Tests/Providers/AgentRequestShapingTests.cs
+++ b/Saturn.Tests/Providers/AgentRequestShapingTests.cs
@@ -97,6 +97,37 @@ namespace Saturn.Tests.Providers
         }
 
         [Fact]
+        public async Task Execute_AfterProviderSwap_RoutesToTheNewClient()
+        {
+            var nameA = "shape-a-" + Guid.NewGuid().ToString("N");
+            var nameB = "shape-b-" + Guid.NewGuid().ToString("N");
+            var clientA = new FakeLlmClient();
+            var clientB = new FakeLlmClient();
+            ProviderRegistry.Register(new FakeProvider { Name = nameA, Factory = _ => clientA });
+            ProviderRegistry.Register(new FakeProvider { Name = nameB, Factory = _ => clientB });
+
+            var manager = new LlmClientManager();
+            (await manager.SwapAsync(nameA, new ProviderSettings())).Success.Should().BeTrue();
+
+            var agent = new TestAgent(new AgentConfiguration
+            {
+                Name = "Test",
+                SystemPrompt = "You are a test agent.",
+                ClientSource = manager,
+                Model = "test-model"
+            });
+
+            await agent.Execute<Message>("one");
+            clientA.LastRequest.Should().NotBeNull();
+            clientB.LastRequest.Should().BeNull();
+
+            (await manager.SwapAsync(nameB, new ProviderSettings())).Success.Should().BeTrue();
+
+            await agent.Execute<Message>("two");
+            clientB.LastRequest.Should().NotBeNull("the turn after a swap must resolve the new client");
+        }
+
+        [Fact]
         public async Task Execute_AfterSwapToNonCachingProvider_StripsCacheControlFromHistory()
         {
             // History accumulated under a caching provider (system message is a

--- a/Saturn.Tests/Providers/AgentRequestShapingTests.cs
+++ b/Saturn.Tests/Providers/AgentRequestShapingTests.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -76,6 +78,51 @@ namespace Saturn.Tests.Providers
 
             client.LastRequest!.Tools.Should().NotBeNullOrEmpty();
             client.LastRequest.ToolChoice.Should().NotBeNull();
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("{\"patchText\": \"truncated mid-str")]
+        public async Task Execute_ToolCallWithUnparseableArguments_IsSanitizedBeforeItPoisonsHistory(string brokenArguments)
+        {
+            // A generation cut off by the token limit can emit a tool call whose
+            // arguments are empty or truncated JSON. Echoed back verbatim, that crashes
+            // strict chat templates server-side on every subsequent request.
+            var client = new FakeLlmClient();
+            client.ResponseQueue.Enqueue(new ChatCompletionResponse
+            {
+                Choices = new[]
+                {
+                    new Choice
+                    {
+                        Message = new AssistantMessageResponse
+                        {
+                            Role = "assistant",
+                            ToolCalls = new[]
+                            {
+                                new ToolCall
+                                {
+                                    Id = "call_1",
+                                    Type = "function",
+                                    Function = new ToolCall.FunctionCall { Name = "read_file", Arguments = brokenArguments }
+                                }
+                            }
+                        },
+                        FinishReason = "length"
+                    }
+                }
+            });
+            // Second (default) response is a plain reply, ending the tool loop.
+
+            var agent = CreateAgent(new LlmClientCapabilities { SupportsToolChoice = true }, client,
+                enableTools: true, toolNames: new List<string> { "read_file" });
+
+            await agent.Execute<Message>("hello");
+
+            client.Requests.Should().HaveCountGreaterThan(1);
+            var followUp = client.Requests[^1];
+            var assistantToolMessage = followUp.Messages!.First(m => m.Role == "assistant" && m.ToolCalls != null);
+            assistantToolMessage.ToolCalls![0].Function!.Arguments.Should().Be("{}");
         }
 
         [Fact]

--- a/Saturn.Tests/Providers/AgentRequestShapingTests.cs
+++ b/Saturn.Tests/Providers/AgentRequestShapingTests.cs
@@ -95,5 +95,29 @@ namespace Saturn.Tests.Providers
             agent.ChatHistory[0].Role.Should().Be("system");
             agent.ChatHistory[0].Content.ValueKind.Should().Be(JsonValueKind.Array);
         }
+
+        [Fact]
+        public async Task Execute_AfterSwapToNonCachingProvider_StripsCacheControlFromHistory()
+        {
+            // History accumulated under a caching provider (system message is a
+            // cache_control content-part array)...
+            var cachingClient = new FakeLlmClient();
+            var agent = CreateAgent(new LlmClientCapabilities { SupportsCaching = true }, cachingClient);
+            agent.ChatHistory[0].Content.ValueKind.Should().Be(JsonValueKind.Array);
+
+            // ...must go over the wire as plain text once a non-caching provider is active.
+            var plainClient = new FakeLlmClient { Capabilities = new LlmClientCapabilities { SupportsCaching = false } };
+            agent.Configuration.ClientSource = new StaticClientSource(plainClient, "swapped");
+
+            await agent.Execute<Message>("hello");
+
+            plainClient.LastRequest.Should().NotBeNull();
+            var systemMessage = plainClient.LastRequest!.Messages![0];
+            systemMessage.Role.Should().Be("system");
+            systemMessage.Content.ValueKind.Should().Be(JsonValueKind.String);
+
+            // The stored history keeps its original shape for a potential swap back.
+            agent.ChatHistory[0].Content.ValueKind.Should().Be(JsonValueKind.Array);
+        }
     }
 }

--- a/Saturn.Tests/Providers/AgentRequestShapingTests.cs
+++ b/Saturn.Tests/Providers/AgentRequestShapingTests.cs
@@ -1,0 +1,99 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Saturn.Agents.Core;
+using Saturn.OpenRouter.Models.Api.Chat;
+using Saturn.Providers;
+using Xunit;
+
+namespace Saturn.Tests.Providers
+{
+    public class AgentRequestShapingTests
+    {
+        private static TestAgent CreateAgent(LlmClientCapabilities capabilities, FakeLlmClient client, bool enableTools = false, List<string>? toolNames = null)
+        {
+            client.Capabilities = capabilities;
+            var config = new AgentConfiguration
+            {
+                Name = "Test",
+                SystemPrompt = "You are a test agent.",
+                ClientSource = new StaticClientSource(client, "test-provider"),
+                Model = "test-model",
+                EnableTools = enableTools,
+                ToolNames = toolNames ?? new List<string>(),
+                MaintainHistory = true
+            };
+            return new TestAgent(config);
+        }
+
+        [Fact]
+        public async Task Execute_ProviderWithoutExtensions_OmitsTransformsUsageAndToolChoice()
+        {
+            var client = new FakeLlmClient();
+            var agent = CreateAgent(new LlmClientCapabilities
+            {
+                SupportsTransforms = false,
+                SupportsUsageInclude = false,
+                SupportsToolChoice = true
+            }, client);
+
+            await agent.Execute<Message>("hello");
+
+            client.LastRequest.Should().NotBeNull();
+            client.LastRequest!.Transforms.Should().BeNull();
+            client.LastRequest.Usage.Should().BeNull();
+            // No tools attached, so tool_choice must stay off the wire too.
+            client.LastRequest.ToolChoice.Should().BeNull();
+            client.LastRequest.Tools.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task Execute_ProviderWithExtensions_SendsTransformsAndUsage()
+        {
+            var client = new FakeLlmClient();
+            var agent = CreateAgent(new LlmClientCapabilities
+            {
+                SupportsTransforms = true,
+                SupportsUsageInclude = true,
+                SupportsToolChoice = true
+            }, client);
+
+            await agent.Execute<Message>("hello");
+
+            client.LastRequest!.Transforms.Should().BeEquivalentTo(new[] { "middle-out" });
+            client.LastRequest.Usage.Should().NotBeNull();
+        }
+
+        [Fact]
+        public async Task Execute_ToolsEnabled_SendsToolsAndToolChoice()
+        {
+            var client = new FakeLlmClient();
+            var agent = CreateAgent(new LlmClientCapabilities { SupportsToolChoice = true }, client,
+                enableTools: true, toolNames: new List<string> { "read_file" });
+
+            await agent.Execute<Message>("hello");
+
+            client.LastRequest!.Tools.Should().NotBeNullOrEmpty();
+            client.LastRequest.ToolChoice.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void SystemPrompt_CachingUnsupported_UsesPlainStringContent()
+        {
+            var agent = CreateAgent(new LlmClientCapabilities { SupportsCaching = false }, new FakeLlmClient());
+
+            agent.ChatHistory[0].Role.Should().Be("system");
+            agent.ChatHistory[0].Content.ValueKind.Should().Be(JsonValueKind.String);
+        }
+
+        [Fact]
+        public void SystemPrompt_CachingSupported_UsesCacheControlContentParts()
+        {
+            var agent = CreateAgent(new LlmClientCapabilities { SupportsCaching = true }, new FakeLlmClient());
+
+            agent.ChatHistory[0].Role.Should().Be("system");
+            agent.ChatHistory[0].Content.ValueKind.Should().Be(JsonValueKind.Array);
+        }
+    }
+}

--- a/Saturn.Tests/Providers/ConfigurationManagerFileTests.cs
+++ b/Saturn.Tests/Providers/ConfigurationManagerFileTests.cs
@@ -106,6 +106,22 @@ namespace Saturn.Tests.Providers
         }
 
         [Fact]
+        public async Task Load_CaseCollidingProviderKeys_CollapsesInsteadOfDroppingConfig()
+        {
+            // A hand-edited (or pre-fix) file can contain keys differing only by case;
+            // rebuilding with a case-insensitive comparer must not throw and take the
+            // whole config load down with it.
+            await File.WriteAllTextAsync(ConfigFile,
+                """{"activeProvider":"lmstudio","model":"first-model","providers":{"lmstudio":{"model":"first-model"},"LMStudio":{"model":"second-model"}}}""");
+
+            var config = await ConfigurationManager.LoadConfigurationAsync();
+
+            config.Should().NotBeNull();
+            config!.Providers.Should().HaveCount(1);
+            ConfigurationManager.GetProviderModel(config, "lmstudio").Should().Be("first-model");
+        }
+
+        [Fact]
         public async Task SaveProviderSelection_SecretMatchingEnvironment_IsNotPersisted()
         {
             var providerName = "secretprov-" + Guid.NewGuid().ToString("N");

--- a/Saturn.Tests/Providers/ConfigurationManagerFileTests.cs
+++ b/Saturn.Tests/Providers/ConfigurationManagerFileTests.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Saturn.Configuration;
+using Saturn.Configuration.Objects;
+using Saturn.Providers;
+using Xunit;
+
+namespace Saturn.Tests.Providers
+{
+    /// <summary>
+    /// File-backed config tests, isolated from the user's real config via the
+    /// SATURN_CONFIG_DIR override. Kept in one class so the process-wide env var
+    /// is only touched by sequentially-running tests.
+    /// </summary>
+    public class ConfigurationManagerFileTests : IDisposable
+    {
+        private readonly string _configDir;
+
+        public ConfigurationManagerFileTests()
+        {
+            _configDir = Path.Combine(Path.GetTempPath(), "SaturnTests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_configDir);
+            Environment.SetEnvironmentVariable("SATURN_CONFIG_DIR", _configDir);
+        }
+
+        public void Dispose()
+        {
+            Environment.SetEnvironmentVariable("SATURN_CONFIG_DIR", null);
+            try
+            {
+                Directory.Delete(_configDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+
+        private string ConfigFile => Path.Combine(_configDir, "agent-config.json");
+
+        [Fact]
+        public async Task Load_LegacyConfig_MigratesToProviderShape()
+        {
+            // A config written before provider support: flat model, no provider fields.
+            await File.WriteAllTextAsync(ConfigFile,
+                """{"name":"Assistant","model":"anthropic/claude-sonnet-4","temperature":0.15,"enableStreaming":true}""");
+
+            var config = await ConfigurationManager.LoadConfigurationAsync();
+
+            config.Should().NotBeNull();
+            config!.ActiveProvider.Should().Be("openrouter");
+            config.Providers.Should().ContainKey("openrouter");
+            config.Providers!["openrouter"].Model.Should().Be("anthropic/claude-sonnet-4");
+            config.Model.Should().Be("anthropic/claude-sonnet-4");
+        }
+
+        [Fact]
+        public async Task Save_WithoutProviderFields_PreservesProvidersBlockOnDisk()
+        {
+            // Seed a config that knows about both providers.
+            var seeded = new PersistedAgentConfiguration
+            {
+                Name = "Assistant",
+                Model = "qwen2.5-coder-32b",
+                ActiveProvider = "lmstudio",
+                Providers = new Dictionary<string, PersistedProviderConfiguration>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["lmstudio"] = new()
+                    {
+                        Model = "qwen2.5-coder-32b",
+                        Settings = new Dictionary<string, string?> { ["baseUrl"] = "http://box:5000/v1" }
+                    },
+                    ["openrouter"] = new() { Model = "anthropic/claude-sonnet-4" }
+                }
+            };
+            await ConfigurationManager.SaveConfigurationAsync(seeded);
+
+            // A UI-style save built from the live agent config: no provider fields at all.
+            await ConfigurationManager.SaveConfigurationAsync(new PersistedAgentConfiguration
+            {
+                Name = "Assistant",
+                Model = "new-local-model"
+            });
+
+            var reloaded = await ConfigurationManager.LoadConfigurationAsync();
+
+            reloaded!.ActiveProvider.Should().Be("lmstudio");
+            reloaded.Providers.Should().ContainKey("openrouter");
+            reloaded.Providers!["openrouter"].Model.Should().Be("anthropic/claude-sonnet-4");
+            reloaded.Providers["lmstudio"].Settings!["baseUrl"].Should().Be("http://box:5000/v1");
+            // The flat model save flows into the active provider's model memory.
+            reloaded.Providers["lmstudio"].Model.Should().Be("new-local-model");
+        }
+
+        [Fact]
+        public async Task Load_ProvidersKeys_AreCaseInsensitiveAfterRoundTrip()
+        {
+            await File.WriteAllTextAsync(ConfigFile,
+                """{"activeProvider":"lmstudio","providers":{"lmstudio":{"model":"qwen2.5-coder-32b"}}}""");
+
+            var config = await ConfigurationManager.LoadConfigurationAsync();
+
+            ConfigurationManager.GetProviderModel(config, "LMStudio").Should().Be("qwen2.5-coder-32b");
+        }
+
+        [Fact]
+        public async Task SaveProviderSelection_SecretMatchingEnvironment_IsNotPersisted()
+        {
+            var providerName = "secretprov-" + Guid.NewGuid().ToString("N");
+            var envVar = "SATURN_TEST_KEY_" + Guid.NewGuid().ToString("N");
+            Environment.SetEnvironmentVariable(envVar, "sk-from-env");
+            try
+            {
+                ProviderRegistry.Register(new FakeProvider
+                {
+                    Name = providerName,
+                    SettingDescriptors = new[]
+                    {
+                        new ProviderSettingDescriptor
+                        {
+                            Key = "apiKey",
+                            Label = "API Key",
+                            Kind = ProviderSettingKind.Secret,
+                            EnvironmentVariable = envVar
+                        }
+                    }
+                });
+
+                // Value identical to the env var: persisting it would store the key in
+                // plaintext and shadow the env var after rotation.
+                var mirrored = new ProviderSettings();
+                mirrored.Set("apiKey", "sk-from-env");
+                await ConfigurationManager.SaveProviderSelectionAsync(providerName, mirrored);
+
+                var config = await ConfigurationManager.LoadConfigurationAsync();
+                config!.Providers![providerName].Settings.Should().NotContainKey("apiKey");
+
+                // An explicitly different key is the user's deliberate choice and persists.
+                var custom = new ProviderSettings();
+                custom.Set("apiKey", "sk-custom");
+                await ConfigurationManager.SaveProviderSelectionAsync(providerName, custom);
+
+                config = await ConfigurationManager.LoadConfigurationAsync();
+                config!.Providers![providerName].Settings!["apiKey"].Should().Be("sk-custom");
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(envVar, null);
+            }
+        }
+
+        [Fact]
+        public async Task Save_LeavesNoTempFileBehind()
+        {
+            await ConfigurationManager.SaveConfigurationAsync(new PersistedAgentConfiguration { Name = "A", Model = "m" });
+
+            File.Exists(ConfigFile).Should().BeTrue();
+            File.Exists(ConfigFile + ".tmp").Should().BeFalse();
+        }
+    }
+}

--- a/Saturn.Tests/Providers/ConfigurationProviderHelpersTests.cs
+++ b/Saturn.Tests/Providers/ConfigurationProviderHelpersTests.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Saturn.Configuration;
+using Saturn.Configuration.Objects;
+using Xunit;
+
+namespace Saturn.Tests.Providers
+{
+    public class ConfigurationProviderHelpersTests
+    {
+        [Fact]
+        public void GetProviderSettings_ReturnsSavedValues()
+        {
+            var config = new PersistedAgentConfiguration
+            {
+                Providers = new Dictionary<string, PersistedProviderConfiguration>
+                {
+                    ["lmstudio"] = new()
+                    {
+                        Settings = new Dictionary<string, string?> { ["baseUrl"] = "http://box:5000/v1" }
+                    }
+                }
+            };
+
+            var settings = ConfigurationManager.GetProviderSettings(config, "lmstudio");
+
+            settings.Get("baseUrl").Should().Be("http://box:5000/v1");
+        }
+
+        [Fact]
+        public void GetProviderSettings_UnknownProvider_ReturnsEmptySettings()
+        {
+            ConfigurationManager.GetProviderSettings(null, "lmstudio").Values.Should().BeEmpty();
+            ConfigurationManager.GetProviderSettings(new PersistedAgentConfiguration(), "lmstudio").Values.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void GetProviderModel_PrefersPerProviderMemory()
+        {
+            var config = new PersistedAgentConfiguration
+            {
+                ActiveProvider = "openrouter",
+                Model = "anthropic/claude-sonnet-4",
+                Providers = new Dictionary<string, PersistedProviderConfiguration>
+                {
+                    ["lmstudio"] = new() { Model = "qwen2.5-coder-32b" }
+                }
+            };
+
+            ConfigurationManager.GetProviderModel(config, "lmstudio").Should().Be("qwen2.5-coder-32b");
+        }
+
+        [Fact]
+        public void GetProviderModel_FlatModelOnlyCountsForItsOwnProvider()
+        {
+            var config = new PersistedAgentConfiguration
+            {
+                ActiveProvider = "openrouter",
+                Model = "anthropic/claude-sonnet-4"
+            };
+
+            // The flat legacy field belonged to OpenRouter, so it must not leak into
+            // another provider's model resolution.
+            ConfigurationManager.GetProviderModel(config, "openrouter").Should().Be("anthropic/claude-sonnet-4");
+            ConfigurationManager.GetProviderModel(config, "lmstudio").Should().BeNull();
+        }
+    }
+}

--- a/Saturn.Tests/Providers/LMStudioClientTests.cs
+++ b/Saturn.Tests/Providers/LMStudioClientTests.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Saturn.OpenRouter.Models.Api.Chat;
+using Saturn.Providers;
+using Xunit;
+
+namespace Saturn.Tests.Providers
+{
+    public class LMStudioClientTests
+    {
+        private const string ChatResponseJson = """
+            {"id":"1","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}]}
+            """;
+
+        private static (LMStudioClient Client, List<(HttpRequestMessage Request, string Body)> Log) CreateClient(
+            Func<HttpRequestMessage, HttpResponseMessage> responder,
+            string baseUrl = "http://localhost:1234/v1")
+        {
+            var log = new List<(HttpRequestMessage, string)>();
+            var client = new LMStudioClient(baseUrl, TimeSpan.FromSeconds(30), () => new StubHttpHandler(responder, log));
+            return (client, log);
+        }
+
+        private static ChatCompletionRequest SimpleRequest() => new()
+        {
+            Model = "test-model",
+            Messages = new[]
+            {
+                new Message { Role = "user", Content = JsonDocument.Parse("\"hi\"").RootElement }
+            }
+        };
+
+        [Theory]
+        [InlineData("http://localhost:1234")]
+        [InlineData("http://localhost:1234/")]
+        [InlineData("http://localhost:1234/v1")]
+        [InlineData("http://localhost:1234/v1/")]
+        public void BaseUrl_IsNormalizedToV1(string input)
+        {
+            var (client, _) = CreateClient(_ => StubHttpHandler.Json("{}"), input);
+            client.BaseUrl.Should().Be("http://localhost:1234/v1");
+        }
+
+        [Fact]
+        public void Constructor_InvalidUrl_Throws()
+        {
+            var act = () => new LMStudioClient("not a url", TimeSpan.FromSeconds(1));
+            act.Should().Throw<InvalidOperationException>();
+        }
+
+        [Fact]
+        public async Task ChatAsync_SendsNoAuthHeaderAndOmitsNullExtensionFields()
+        {
+            var (client, log) = CreateClient(request =>
+                request.RequestUri!.AbsolutePath.EndsWith("/chat/completions")
+                    ? StubHttpHandler.Json(ChatResponseJson)
+                    : StubHttpHandler.Json("{}"));
+
+            var response = await client.ChatAsync(SimpleRequest());
+
+            response!.Choices![0].Message!.Content.Should().Be("hello");
+
+            var (request, body) = log.Single(e => e.Request.RequestUri!.AbsolutePath.EndsWith("/chat/completions"));
+            request.RequestUri!.AbsolutePath.Should().Be("/v1/chat/completions");
+            request.Headers.Authorization.Should().BeNull();
+
+            using var json = JsonDocument.Parse(body);
+            json.RootElement.TryGetProperty("transforms", out _).Should().BeFalse();
+            json.RootElement.TryGetProperty("usage", out _).Should().BeFalse();
+            json.RootElement.TryGetProperty("tool_choice", out _).Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task ChatAsync_ConnectionRefused_ThrowsActionableMessage()
+        {
+            var (client, _) = CreateClient(_ => throw new HttpRequestException("connection refused"));
+
+            var act = () => client.ChatAsync(SimpleRequest());
+
+            (await act.Should().ThrowAsync<InvalidOperationException>())
+                .WithMessage("*Cannot reach LM Studio at http://localhost:1234/v1*");
+        }
+
+        [Fact]
+        public async Task ListModelsAsync_MergesNativeApiEnrichment()
+        {
+            var (client, _) = CreateClient(request =>
+            {
+                var path = request.RequestUri!.AbsolutePath;
+                if (path == "/v1/models")
+                {
+                    return StubHttpHandler.Json("""{"data":[{"id":"model-a","object":"model"},{"id":"model-b","object":"model"}]}""");
+                }
+                if (path == "/api/v0/models")
+                {
+                    return StubHttpHandler.Json("""{"data":[{"id":"model-b","max_context_length":8192,"state":"loaded"},{"id":"model-a","state":"not-loaded"}]}""");
+                }
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            });
+
+            var models = await client.ListModelsAsync();
+
+            models.Should().HaveCount(2);
+            // Loaded models sort first.
+            models[0].Id.Should().Be("model-b");
+            models[0].IsLoaded.Should().BeTrue();
+            models[0].ContextLength.Should().Be(8192);
+            models[1].Id.Should().Be("model-a");
+            models[1].IsLoaded.Should().BeFalse();
+            models[1].ContextLength.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task ListModelsAsync_NativeApiFailure_KeepsBaselineListing()
+        {
+            var (client, _) = CreateClient(request =>
+                request.RequestUri!.AbsolutePath == "/v1/models"
+                    ? StubHttpHandler.Json("""{"data":[{"id":"model-a","object":"model"}]}""")
+                    : new HttpResponseMessage(HttpStatusCode.InternalServerError));
+
+            var models = await client.ListModelsAsync();
+
+            models.Should().ContainSingle(m => m.Id == "model-a");
+        }
+
+        [Fact]
+        public async Task ValidateConnectionAsync_ReturnsFalseWhenUnreachable()
+        {
+            var (client, _) = CreateClient(_ => throw new HttpRequestException("connection refused"));
+
+            (await client.ValidateConnectionAsync()).Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task ValidateConnectionAsync_ReturnsTrueWhenServerResponds()
+        {
+            var (client, _) = CreateClient(_ => StubHttpHandler.Json("""{"data":[]}"""));
+
+            (await client.ValidateConnectionAsync()).Should().BeTrue();
+        }
+
+        [Fact]
+        public void Capabilities_DisableOpenRouterExtensions()
+        {
+            var (client, _) = CreateClient(_ => StubHttpHandler.Json("{}"));
+
+            client.Capabilities.SupportsTransforms.Should().BeFalse();
+            client.Capabilities.SupportsUsageInclude.Should().BeFalse();
+            client.Capabilities.SupportsPricing.Should().BeFalse();
+            client.Capabilities.SupportsCaching.Should().BeFalse();
+            client.Capabilities.RequiresApiKey.Should().BeFalse();
+        }
+    }
+}

--- a/Saturn.Tests/Providers/LlmClientManagerTests.cs
+++ b/Saturn.Tests/Providers/LlmClientManagerTests.cs
@@ -81,6 +81,22 @@ namespace Saturn.Tests.Providers
         }
 
         [Fact]
+        public async Task SwapAsync_ValidationNotRequired_InstallsUnreachableClient()
+        {
+            // Startup path: a transient outage must degrade to per-request errors, not
+            // refuse to connect at all.
+            var providerName = "swap-novalidate-" + Guid.NewGuid().ToString("N");
+            var client = new FakeLlmClient { ValidateResult = false };
+            ProviderRegistry.Register(new FakeProvider { Name = providerName, Factory = _ => client });
+
+            var manager = new LlmClientManager();
+            var result = await manager.SwapAsync(providerName, new ProviderSettings(), requireValidation: false);
+
+            result.Success.Should().BeTrue();
+            manager.Current.Should().BeSameAs(client);
+        }
+
+        [Fact]
         public void Current_BeforeAnySwap_Throws()
         {
             var manager = new LlmClientManager();

--- a/Saturn.Tests/Providers/LlmClientManagerTests.cs
+++ b/Saturn.Tests/Providers/LlmClientManagerTests.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Saturn.Providers;
+using Xunit;
+
+namespace Saturn.Tests.Providers
+{
+    public class LlmClientManagerTests
+    {
+        [Fact]
+        public async Task SwapAsync_UnknownProvider_FailsWithoutTouchingCurrent()
+        {
+            var manager = new LlmClientManager();
+
+            var result = await manager.SwapAsync("does-not-exist-" + Guid.NewGuid().ToString("N"), new ProviderSettings());
+
+            result.Success.Should().BeFalse();
+            result.Error.Should().Contain("Unknown provider");
+            manager.IsConnected.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task SwapAsync_Success_SetsCurrentAndRaisesEvent()
+        {
+            var providerName = "swap-ok-" + Guid.NewGuid().ToString("N");
+            var client = new FakeLlmClient();
+            ProviderRegistry.Register(new FakeProvider { Name = providerName, Factory = _ => client });
+
+            var manager = new LlmClientManager();
+            ProviderChangedEventArgs? raised = null;
+            manager.ProviderChanged += (_, e) => raised = e;
+
+            var result = await manager.SwapAsync(providerName, new ProviderSettings());
+
+            result.Success.Should().BeTrue();
+            manager.IsConnected.Should().BeTrue();
+            manager.Current.Should().BeSameAs(client);
+            manager.ActiveProviderName.Should().Be(providerName);
+            raised.Should().NotBeNull();
+            raised!.NewProviderName.Should().Be(providerName);
+        }
+
+        [Fact]
+        public async Task SwapAsync_ValidateFails_KeepsPreviousClientActive()
+        {
+            var goodName = "swap-good-" + Guid.NewGuid().ToString("N");
+            var badName = "swap-bad-" + Guid.NewGuid().ToString("N");
+            var goodClient = new FakeLlmClient();
+            var badClient = new FakeLlmClient { ValidateResult = false };
+            ProviderRegistry.Register(new FakeProvider { Name = goodName, Factory = _ => goodClient });
+            ProviderRegistry.Register(new FakeProvider { Name = badName, Factory = _ => badClient });
+
+            var manager = new LlmClientManager();
+            (await manager.SwapAsync(goodName, new ProviderSettings())).Success.Should().BeTrue();
+
+            var result = await manager.SwapAsync(badName, new ProviderSettings());
+
+            result.Success.Should().BeFalse();
+            manager.Current.Should().BeSameAs(goodClient);
+            manager.ActiveProviderName.Should().Be(goodName);
+            badClient.Disposed.Should().BeTrue();
+            goodClient.Disposed.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task SwapAsync_ProviderThrowsOnCreate_ReturnsErrorMessage()
+        {
+            var providerName = "swap-throws-" + Guid.NewGuid().ToString("N");
+            ProviderRegistry.Register(new FakeProvider
+            {
+                Name = providerName,
+                Factory = _ => throw new InvalidOperationException("missing api key")
+            });
+
+            var manager = new LlmClientManager();
+            var result = await manager.SwapAsync(providerName, new ProviderSettings());
+
+            result.Success.Should().BeFalse();
+            result.Error.Should().Contain("missing api key");
+        }
+
+        [Fact]
+        public void Current_BeforeAnySwap_Throws()
+        {
+            var manager = new LlmClientManager();
+            var act = () => manager.Current;
+            act.Should().Throw<InvalidOperationException>();
+        }
+    }
+}

--- a/Saturn.Tests/Providers/ModelCatalogTests.cs
+++ b/Saturn.Tests/Providers/ModelCatalogTests.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Saturn.Providers;
+using Xunit;
+
+namespace Saturn.Tests.Providers
+{
+    public class ModelCatalogTests
+    {
+        private static StaticClientSource Source(FakeLlmClient client)
+            => new(client, "catalog-" + Guid.NewGuid().ToString("N"));
+
+        [Fact]
+        public async Task ResolveModelAsync_RequestedModelAvailable_ReturnsIt()
+        {
+            var client = new FakeLlmClient
+            {
+                Models = new List<ModelInfo> { new() { Id = "model-a" }, new() { Id = "model-b" } }
+            };
+
+            var resolved = await ModelCatalog.ResolveModelAsync(Source(client), "model-b");
+
+            resolved.Should().Be("model-b");
+        }
+
+        [Fact]
+        public async Task ResolveModelAsync_MissingModel_PrefersFallbackThenDefaultThenLoaded()
+        {
+            var client = new FakeLlmClient
+            {
+                Models = new List<ModelInfo>
+                {
+                    new() { Id = "model-a" },
+                    new() { Id = "parent-model" }
+                }
+            };
+
+            var withFallback = await ModelCatalog.ResolveModelAsync(Source(client), "unavailable", "parent-model");
+            withFallback.Should().Be("parent-model");
+
+            var loadedClient = new FakeLlmClient
+            {
+                Models = new List<ModelInfo>
+                {
+                    new() { Id = "model-a" },
+                    new() { Id = "model-loaded", IsLoaded = true }
+                }
+            };
+
+            var withLoaded = await ModelCatalog.ResolveModelAsync(Source(loadedClient), "unavailable");
+            withLoaded.Should().Be("model-loaded");
+        }
+
+        [Fact]
+        public async Task ResolveModelAsync_EmptyListing_ReturnsRequestedUnchanged()
+        {
+            var client = new FakeLlmClient { Models = new List<ModelInfo>() };
+
+            var resolved = await ModelCatalog.ResolveModelAsync(Source(client), "whatever");
+
+            resolved.Should().Be("whatever");
+        }
+
+        [Fact]
+        public async Task GetAsync_EmptyLiveListing_FallsBackToCapabilityModels()
+        {
+            var client = new FakeLlmClient
+            {
+                Models = new List<ModelInfo>(),
+                Capabilities = new LlmClientCapabilities
+                {
+                    FallbackModels = new[] { new ModelInfo { Id = "fallback-model" } }
+                }
+            };
+
+            var models = await ModelCatalog.GetAsync(Source(client));
+
+            models.Should().ContainSingle(m => m.Id == "fallback-model");
+        }
+
+        [Fact]
+        public async Task GetAsync_DisconnectedSource_ReturnsEmpty()
+        {
+            var models = await ModelCatalog.GetAsync(null!);
+            models.Should().BeEmpty();
+        }
+    }
+}

--- a/Saturn.Tests/Providers/ModelCatalogTests.cs
+++ b/Saturn.Tests/Providers/ModelCatalogTests.cs
@@ -54,6 +54,24 @@ namespace Saturn.Tests.Providers
         }
 
         [Fact]
+        public async Task ResolveModelAsync_VariantSlugWithKnownBaseModel_IsKept()
+        {
+            var client = new FakeLlmClient
+            {
+                Models = new List<ModelInfo>
+                {
+                    new() { Id = "anthropic/claude-sonnet-4" },
+                    new() { Id = "other/model" }
+                }
+            };
+
+            // Routing variants never appear in the listing but are valid request ids.
+            var resolved = await ModelCatalog.ResolveModelAsync(Source(client), "anthropic/claude-sonnet-4:nitro");
+
+            resolved.Should().Be("anthropic/claude-sonnet-4:nitro");
+        }
+
+        [Fact]
         public async Task ResolveModelAsync_EmptyListing_ReturnsRequestedUnchanged()
         {
             var client = new FakeLlmClient { Models = new List<ModelInfo>() };

--- a/Saturn.Tests/Providers/ProviderRegistryTests.cs
+++ b/Saturn.Tests/Providers/ProviderRegistryTests.cs
@@ -1,0 +1,40 @@
+using System;
+using FluentAssertions;
+using Saturn.Providers;
+using Xunit;
+
+namespace Saturn.Tests.Providers
+{
+    public class ProviderRegistryTests
+    {
+        [Fact]
+        public void Get_IsCaseInsensitive()
+        {
+            var name = "case-" + Guid.NewGuid().ToString("N");
+            ProviderRegistry.Register(new FakeProvider { Name = name });
+
+            ProviderRegistry.Get(name.ToUpperInvariant()).Name.Should().Be(name);
+        }
+
+        [Fact]
+        public void Get_UnknownName_ThrowsWithAvailableProviders()
+        {
+            var registered = "known-" + Guid.NewGuid().ToString("N");
+            ProviderRegistry.Register(new FakeProvider { Name = registered });
+
+            var act = () => ProviderRegistry.Get("nope-" + Guid.NewGuid().ToString("N"));
+
+            act.Should().Throw<InvalidOperationException>().WithMessage($"*{registered}*");
+        }
+
+        [Fact]
+        public void Register_SameNameTwice_LastOneWins()
+        {
+            var name = "dup-" + Guid.NewGuid().ToString("N");
+            ProviderRegistry.Register(new FakeProvider { Name = name, DisplayName = "First" });
+            ProviderRegistry.Register(new FakeProvider { Name = name, DisplayName = "Second" });
+
+            ProviderRegistry.Get(name).DisplayName.Should().Be("Second");
+        }
+    }
+}

--- a/Saturn.Tests/Providers/ProviderSettingDescriptorTests.cs
+++ b/Saturn.Tests/Providers/ProviderSettingDescriptorTests.cs
@@ -1,0 +1,85 @@
+using System;
+using FluentAssertions;
+using Saturn.Providers;
+using Xunit;
+
+namespace Saturn.Tests.Providers
+{
+    public class ProviderSettingDescriptorTests
+    {
+        [Fact]
+        public void Resolve_ExplicitSettingBeatsEnvironmentAndDefault()
+        {
+            var envVar = "SATURN_TEST_" + Guid.NewGuid().ToString("N");
+            Environment.SetEnvironmentVariable(envVar, "from-env");
+            try
+            {
+                var descriptor = new ProviderSettingDescriptor
+                {
+                    Key = "value",
+                    Label = "Value",
+                    DefaultValue = "from-default",
+                    EnvironmentVariable = envVar
+                };
+
+                var settings = new ProviderSettings();
+                settings.Set("value", "from-config");
+
+                descriptor.Resolve(settings).Should().Be("from-config");
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(envVar, null);
+            }
+        }
+
+        [Fact]
+        public void Resolve_EnvironmentBeatsDefault()
+        {
+            var envVar = "SATURN_TEST_" + Guid.NewGuid().ToString("N");
+            Environment.SetEnvironmentVariable(envVar, "from-env");
+            try
+            {
+                var descriptor = new ProviderSettingDescriptor
+                {
+                    Key = "value",
+                    Label = "Value",
+                    DefaultValue = "from-default",
+                    EnvironmentVariable = envVar
+                };
+
+                descriptor.Resolve(new ProviderSettings()).Should().Be("from-env");
+                descriptor.Resolve(null).Should().Be("from-env");
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(envVar, null);
+            }
+        }
+
+        [Fact]
+        public void Resolve_FallsBackToDefault()
+        {
+            var descriptor = new ProviderSettingDescriptor
+            {
+                Key = "value",
+                Label = "Value",
+                DefaultValue = "from-default",
+                EnvironmentVariable = "SATURN_TEST_UNSET_" + Guid.NewGuid().ToString("N")
+            };
+
+            descriptor.Resolve(new ProviderSettings()).Should().Be("from-default");
+        }
+
+        [Fact]
+        public void Set_EmptyValue_RemovesKey()
+        {
+            var settings = new ProviderSettings();
+            settings.Set("key", "value");
+            settings.Set("key", "  ");
+
+            settings.Get("key").Should().BeNull();
+            settings.Values.Should().BeEmpty();
+        }
+    }
+}

--- a/Saturn.Tests/Providers/TestDoubles.cs
+++ b/Saturn.Tests/Providers/TestDoubles.cs
@@ -19,11 +19,22 @@ namespace Saturn.Tests.Providers
         public bool ValidateResult { get; set; } = true;
         public bool Disposed { get; private set; }
         public ChatCompletionRequest? LastRequest { get; private set; }
+        public List<ChatCompletionRequest> Requests { get; } = new();
         public string ResponseContent { get; set; } = "ok";
+
+        /// <summary>Scripted responses returned in order; when empty, a plain text reply is returned.</summary>
+        public Queue<ChatCompletionResponse> ResponseQueue { get; } = new();
 
         public Task<ChatCompletionResponse?> ChatAsync(ChatCompletionRequest request, CancellationToken cancellationToken = default)
         {
             LastRequest = request;
+            Requests.Add(request);
+
+            if (ResponseQueue.Count > 0)
+            {
+                return Task.FromResult<ChatCompletionResponse?>(ResponseQueue.Dequeue());
+            }
+
             return Task.FromResult<ChatCompletionResponse?>(new ChatCompletionResponse
             {
                 Choices = new[]

--- a/Saturn.Tests/Providers/TestDoubles.cs
+++ b/Saturn.Tests/Providers/TestDoubles.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Saturn.Agents.Core;
+using Saturn.OpenRouter.Models.Api.Chat;
+using Saturn.Providers;
+
+namespace Saturn.Tests.Providers
+{
+    public class FakeLlmClient : ILlmClient
+    {
+        public LlmClientCapabilities Capabilities { get; set; } = new();
+        public List<ModelInfo> Models { get; set; } = new();
+        public bool ValidateResult { get; set; } = true;
+        public bool Disposed { get; private set; }
+        public ChatCompletionRequest? LastRequest { get; private set; }
+        public string ResponseContent { get; set; } = "ok";
+
+        public Task<ChatCompletionResponse?> ChatAsync(ChatCompletionRequest request, CancellationToken cancellationToken = default)
+        {
+            LastRequest = request;
+            return Task.FromResult<ChatCompletionResponse?>(new ChatCompletionResponse
+            {
+                Choices = new[]
+                {
+                    new Choice
+                    {
+                        Message = new AssistantMessageResponse { Role = "assistant", Content = ResponseContent },
+                        FinishReason = "stop"
+                    }
+                }
+            });
+        }
+
+        public async IAsyncEnumerable<ChatCompletionChunk> StreamChatAsync(
+            ChatCompletionRequest request,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            LastRequest = request;
+            await Task.CompletedTask;
+            yield break;
+        }
+
+        public Task<List<ModelInfo>> ListModelsAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(new List<ModelInfo>(Models));
+
+        public Task<bool> ValidateConnectionAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(ValidateResult);
+
+        public void Dispose() => Disposed = true;
+    }
+
+    public class FakeProvider : ILlmProvider
+    {
+        public string Name { get; init; } = "fake";
+        public string DisplayName { get; init; } = "Fake";
+        public IReadOnlyList<ProviderSettingDescriptor> SettingDescriptors { get; init; } =
+            Array.Empty<ProviderSettingDescriptor>();
+        public Func<ProviderSettings, ILlmClient> Factory { get; init; } = _ => new FakeLlmClient();
+
+        public Task<ILlmClient> CreateClientAsync(ProviderSettings settings, CancellationToken cancellationToken = default)
+            => Task.FromResult(Factory(settings));
+    }
+
+    /// <summary>Agent that skips SQLite persistence so tests stay on the fake client only.</summary>
+    public class TestAgent : AgentBase
+    {
+        public TestAgent(AgentConfiguration configuration) : base(configuration)
+        {
+        }
+
+        protected override void InitializeRepository()
+        {
+        }
+    }
+
+    public class StubHttpHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _responder;
+        private readonly List<(HttpRequestMessage Request, string Body)> _log;
+
+        public StubHttpHandler(Func<HttpRequestMessage, HttpResponseMessage> responder, List<(HttpRequestMessage, string)> log)
+        {
+            _responder = responder;
+            _log = log;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var body = request.Content == null ? string.Empty : await request.Content.ReadAsStringAsync(cancellationToken);
+            lock (_log)
+            {
+                _log.Add((request, body));
+            }
+            return _responder(request);
+        }
+
+        public static HttpResponseMessage Json(string body, HttpStatusCode status = HttpStatusCode.OK)
+        {
+            return new HttpResponseMessage(status)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json")
+            };
+        }
+    }
+}

--- a/UI/AgentConfiguration.cs
+++ b/UI/AgentConfiguration.cs
@@ -2,8 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Saturn.OpenRouter;
-using Saturn.OpenRouter.Models.Api.Models;
+using Saturn.Providers;
 
 namespace Saturn.UI
 {
@@ -22,9 +21,6 @@ namespace Saturn.UI
         public bool RequireCommandApproval { get; set; } = true;
         public bool EnableUserRules { get; set; } = true;
         
-        private static List<Model>? _cachedModels;
-        private static DateTime _cacheTime;
-        private static readonly TimeSpan CacheDuration = TimeSpan.FromMinutes(30);
 
         public AgentConfiguration()
         {
@@ -73,51 +69,9 @@ Operating Principles
    - Be mindful of dependency sizes and build times.";
         }
 
-        public static async Task<List<Model>> GetAvailableModels(OpenRouterClient client)
+        public static Task<List<ModelInfo>> GetAvailableModels(ILlmClientSource clientSource)
         {
-            if (_cachedModels != null && DateTime.UtcNow - _cacheTime < CacheDuration)
-            {
-                return _cachedModels;
-            }
-
-            try
-            {
-                var response = await client.Models.ListAllAsync();
-                if (response?.Data != null)
-                {
-                    _cachedModels = response.Data
-                        .Where(m => !string.IsNullOrEmpty(m.Id))
-                        .OrderBy(m => m.Name ?? m.Id)
-                        .ToList();
-                    _cacheTime = DateTime.UtcNow;
-                    return _cachedModels;
-                }
-            }
-            catch (Exception)
-            {
-            }
-
-            return GetDefaultModels();
-        }
-
-        private static List<Model> GetDefaultModels()
-        {
-            var defaults = new[]
-            {
-                ("openai/gpt-5", "OpenAI: GPT-5"),
-                ("openai/gpt-5-mini", "OpenAI: GPT-5-Mini"),
-                ("openai/gpt-5-nano", "OpenAI: GPT-5-Nano"),
-                ("openai/gpt-oss-120b", "OpenAI: GPT-OSS-120B"),
-                ("openai/gpt-oss-20b", "OpenAI: GPT-OSS-20B"),
-                ("anthropic/claude-opus-4.1", "Anthropic: Opus-4.1"),
-                ("anthropic/claude-opus-4", "Anthropic: Opus-4"),
-                ("anthropic/claude-sonnet-4", "Anthropic: Sonnet-4"),
-                ("anthropic/claude-3.7-sonnet", "Anthropic: Sonnet-3.7"),
-                ("anthropic/claude-3.5-haiku", "Anthropic: Haiku-3.5"),
-                ("moonshotai/kimi-k2:free", "Kimi-K2")
-            };
-
-            return defaults.Select(d => new Model { Id = d.Item1, Name = d.Item2 }).ToList();
+            return ModelCatalog.GetAsync(clientSource);
         }
 
         public AgentConfiguration Clone()

--- a/UI/ChatInterface.cs
+++ b/UI/ChatInterface.cs
@@ -905,12 +905,26 @@ namespace Saturn.UI
                 cancellationTokenSource?.Cancel();
                 AgentManager.Instance.TerminateAllAgents();
             }
+            else if (AgentManager.Instance.GetCurrentAgentCount() > 0)
+            {
+                // Sub-agents run detached from the main agent's processing flag and would
+                // otherwise keep executing against the retired client.
+                var choice = MessageBox.Query("Provider",
+                    $"{AgentManager.Instance.GetCurrentAgentCount()} sub-agent(s) are still running. Terminate them and switch providers?",
+                    "Yes", "No");
+                if (choice != 0) return;
+
+                AgentManager.Instance.TerminateAllAgents();
+            }
 
             var persisted = await ConfigurationManager.LoadConfigurationAsync();
             var dialog = new ProviderSettingsDialog(manager, persisted);
             Application.Run(dialog);
 
             if (!dialog.Applied) return;
+
+            // The new provider must never see the old provider's cached model list.
+            ModelCatalog.Invalidate();
 
             var providerName = manager.ActiveProviderName;
             var capabilities = manager.Current.Capabilities;
@@ -941,7 +955,16 @@ namespace Saturn.UI
             await ConfigurationManager.SaveProviderSelectionAsync(providerName, dialog.AppliedSettings ?? new ProviderSettings(), model);
             await UpdateConfiguration();
 
-            chatView.Text += $"\n[Provider switched to {capabilities.ProviderName} | Model: {model}]\n\n";
+            chatView.Text += $"\n[Provider switched to {capabilities.ProviderName} | Model: {model}]\n";
+
+            var envProvider = Environment.GetEnvironmentVariable("SATURN_PROVIDER");
+            if (!string.IsNullOrWhiteSpace(envProvider) &&
+                !string.Equals(envProvider.Trim(), providerName, StringComparison.OrdinalIgnoreCase))
+            {
+                chatView.Text += $"[Note: the SATURN_PROVIDER={envProvider} environment variable overrides this choice on the next launch]\n";
+            }
+            chatView.Text += "\n";
+
             ScrollChatToBottom();
             Application.Refresh();
         }
@@ -1301,6 +1324,7 @@ namespace Saturn.UI
                 try
                 {
                     ApplyModeToUIConfiguration(dialog.SelectedMode);
+                    await ResolveCurrentModelForProviderAsync();
                     await UpdateConfiguration();
                 }
                 catch (Exception ex)
@@ -1338,11 +1362,29 @@ namespace Saturn.UI
                 if (applyNow == 0)
                 {
                     ApplyModeToUIConfiguration(editorDialog.ResultMode);
+                    await ResolveCurrentModelForProviderAsync();
                     await UpdateConfiguration();
                 }
             }
         }
         
+        /// <summary>
+        /// Modes store model ids written for whichever provider was active when they were
+        /// created; substitute a model the current provider actually serves.
+        /// </summary>
+        private async Task ResolveCurrentModelForProviderAsync()
+        {
+            if (clientSource == null || !clientSource.IsConnected) return;
+
+            var resolved = await ModelCatalog.ResolveModelAsync(clientSource, currentConfig.Model, agent.Configuration.Model);
+            if (!string.Equals(resolved, currentConfig.Model, StringComparison.OrdinalIgnoreCase))
+            {
+                chatView.Text += $"\n[Model '{currentConfig.Model}' is not available on {GetProviderDisplayName()}; using '{resolved}']\n";
+                currentConfig.Model = resolved;
+                ScrollChatToBottom();
+            }
+        }
+
         private void ApplyModeToUIConfiguration(Mode mode)
         {
             currentConfig.Model = mode.Model;

--- a/UI/ChatInterface.cs
+++ b/UI/ChatInterface.cs
@@ -778,7 +778,11 @@ namespace Saturn.UI
 
         private async Task ShowModelSelectionDialog()
         {
-            if (clientSource == null || !clientSource.IsConnected) return;
+            if (clientSource == null || !clientSource.IsConnected)
+            {
+                MessageBox.ErrorQuery("Select Model", "No LLM provider connected.", "OK");
+                return;
+            }
             var models = await AgentConfiguration.GetAvailableModels(clientSource);
             if (models.Count == 0)
             {
@@ -787,7 +791,7 @@ namespace Saturn.UI
                 return;
             }
             var modelNames = models.Select(m => m.Display).ToArray();
-            var currentIndex = Array.FindIndex(modelNames, m => models[Array.IndexOf(modelNames, m)].Id == currentConfig.Model);
+            var currentIndex = models.FindIndex(m => string.Equals(m.Id, currentConfig.Model, StringComparison.OrdinalIgnoreCase));
             if (currentIndex < 0) currentIndex = 0;
 
             var dialog = new Dialog("Select Model", 60, 20);

--- a/UI/ChatInterface.cs
+++ b/UI/ChatInterface.cs
@@ -13,9 +13,8 @@ using Saturn.Agents.MultiAgent;
 using Saturn.Configuration;
 using Saturn.Data;
 using Saturn.Data.Models;
-using Saturn.OpenRouter;
 using Saturn.OpenRouter.Models.Api.Chat;
-using Saturn.OpenRouter.Models.Api.Models;
+using Saturn.Providers;
 using Saturn.UI.Dialogs;
 
 namespace Saturn.UI
@@ -34,7 +33,7 @@ namespace Saturn.UI
         private bool isProcessing;
         private CancellationTokenSource? cancellationTokenSource;
         private AgentConfiguration currentConfig;
-        private OpenRouterClient? openRouterClient;
+        private ILlmClientSource? clientSource;
         private MarkdownRenderer markdownRenderer;
         
         // Rules file monitoring
@@ -42,10 +41,10 @@ namespace Saturn.UI
         private DateTime? lastRulesModifiedTime;
         private string? cachedSystemPromptWithRules;
 
-        public ChatInterface(Agent aiAgent, OpenRouterClient? client = null)
+        public ChatInterface(Agent aiAgent, ILlmClientSource? client = null)
         {
             agent = aiAgent ?? throw new ArgumentNullException(nameof(aiAgent));
-            openRouterClient = client ?? agent.Configuration.Client as OpenRouterClient;
+            clientSource = client ?? agent.Configuration.ClientSource;
             isProcessing = false;
             
             agent.OnToolCall += (toolName, args) => UpdateToolCall(toolName, args);
@@ -69,7 +68,8 @@ namespace Saturn.UI
         
         private void InitializeAgentManager()
         {
-            AgentManager.Instance.Initialize(openRouterClient!);
+            AgentManager.Instance.Initialize(clientSource!);
+            AgentManager.Instance.SetParentModel(agent.Configuration.Model);
             
             AgentManager.Instance.OnAgentCreated += (agentId, name) =>
             {
@@ -199,6 +199,7 @@ namespace Saturn.UI
                 {
                     new MenuItem("_Modes...", "", async () => await ShowModeSelectionDialogAsync()),
                     null,
+                    new MenuItem("_Provider...", "", async () => await ShowProviderDialogAsync()),
                     new MenuItem("_Select Model...", "", async () => await ShowModelSelectionDialog()),
                     new MenuItem("_Temperature...", "", () => ShowTemperatureDialog()),
                     new MenuItem("_Max Tokens...", "", () => ShowMaxTokensDialog()),
@@ -570,6 +571,7 @@ namespace Saturn.UI
             var message = "Welcome to Saturn\nDont forget to join our discord to stay updated.\n\"https://discord.gg/VSjW36MfYZ\"";
             message += "\n================================\n";
             message += $"Agent: {agent.Name}\n";
+            message += $"Provider: {GetProviderDisplayName()}\n";
             message += $"Model: {agent.Configuration.Model}\n";
             message += $"Streaming: {(agent.Configuration.EnableStreaming ? "Enabled" : "Disabled")}\n";
             message += $"Tools: {(agent.Configuration.EnableTools ? "Enabled" : "Disabled")}\n";
@@ -603,13 +605,15 @@ namespace Saturn.UI
                 if (agent.CurrentSessionId == null)
                 {
                     await agent.InitializeSessionAsync("main");
-                    
+
                     if (agent.CurrentSessionId != null)
                     {
                         AgentManager.Instance.SetParentSessionId(agent.CurrentSessionId);
                         AgentManager.Instance.SetParentEnableUserRules(agent.Configuration.EnableUserRules);
                     }
                 }
+
+                AgentManager.Instance.SetParentModel(agent.Configuration.Model);
                 
                 chatView.Text += $"You: {message}\n";
                 inputField.Text = "";
@@ -774,9 +778,15 @@ namespace Saturn.UI
 
         private async Task ShowModelSelectionDialog()
         {
-            if (openRouterClient == null) return;
-            var models = await AgentConfiguration.GetAvailableModels(openRouterClient);
-            var modelNames = models.Select(m => m.Name ?? m.Id).ToArray();
+            if (clientSource == null || !clientSource.IsConnected) return;
+            var models = await AgentConfiguration.GetAvailableModels(clientSource);
+            if (models.Count == 0)
+            {
+                MessageBox.ErrorQuery("Select Model",
+                    $"No models available from {GetProviderDisplayName()}. If you are using a local provider, make sure a model is downloaded.", "OK");
+                return;
+            }
+            var modelNames = models.Select(m => m.Display).ToArray();
             var currentIndex = Array.FindIndex(modelNames, m => models[Array.IndexOf(modelNames, m)].Id == currentConfig.Model);
             if (currentIndex < 0) currentIndex = 0;
 
@@ -816,13 +826,9 @@ namespace Saturn.UI
 
             listView.SelectedItemChanged += (args) =>
             {
-                var selectedModel = models[args.Item];
-                var info = $"ID: {selectedModel.Id}";
-                if (selectedModel.ContextLength.HasValue)
-                    info += $" | Context: {selectedModel.ContextLength:N0} tokens";
-                infoLabel.Text = info;
+                infoLabel.Text = DescribeModel(models[args.Item]);
             };
-            
+
             listView.OpenSelectedItem += (args) =>
             {
                 selectModel();
@@ -848,15 +854,96 @@ namespace Saturn.UI
             
             if (models.Count > 0 && currentIndex >= 0)
             {
-                var initialModel = models[currentIndex];
-                var info = $"ID: {initialModel.Id}";
-                if (initialModel.ContextLength.HasValue)
-                    info += $" | Context: {initialModel.ContextLength:N0} tokens";
-                infoLabel.Text = info;
+                infoLabel.Text = DescribeModel(models[currentIndex]);
             }
-            
+
             listView.SetFocus();
             Application.Run(dialog);
+        }
+
+        private static string DescribeModel(ModelInfo model)
+        {
+            var info = $"ID: {model.Id}";
+            if (model.ContextLength.HasValue)
+                info += $" | Context: {model.ContextLength:N0} tokens";
+            if (model.IsLoaded == true)
+                info += " | loaded";
+            return info;
+        }
+
+        private string GetProviderDisplayName()
+        {
+            try
+            {
+                if (clientSource != null && clientSource.IsConnected)
+                {
+                    return clientSource.Current.Capabilities.ProviderName;
+                }
+            }
+            catch
+            {
+            }
+            return "Not connected";
+        }
+
+        private async Task ShowProviderDialogAsync()
+        {
+            if (clientSource is not LlmClientManager manager)
+            {
+                MessageBox.ErrorQuery("Provider", "Provider switching is not available in this session.", "OK");
+                return;
+            }
+
+            if (isProcessing)
+            {
+                // Mixing providers inside one running task is a debugging nightmare;
+                // require an explicit cancel first.
+                var choice = MessageBox.Query("Provider",
+                    "A task is currently running. Cancel it and switch providers?", "Yes", "No");
+                if (choice != 0) return;
+
+                cancellationTokenSource?.Cancel();
+                AgentManager.Instance.TerminateAllAgents();
+            }
+
+            var persisted = await ConfigurationManager.LoadConfigurationAsync();
+            var dialog = new ProviderSettingsDialog(manager, persisted);
+            Application.Run(dialog);
+
+            if (!dialog.Applied) return;
+
+            var providerName = manager.ActiveProviderName;
+            var capabilities = manager.Current.Capabilities;
+
+            // Restore the model remembered for this provider, or pick one it serves.
+            var model = ConfigurationManager.GetProviderModel(persisted, providerName);
+            if (string.IsNullOrWhiteSpace(model))
+            {
+                model = capabilities.DefaultModel;
+            }
+
+            if (string.IsNullOrWhiteSpace(model))
+            {
+                var models = await AgentConfiguration.GetAvailableModels(clientSource);
+                model = models.FirstOrDefault(m => m.IsLoaded == true)?.Id
+                    ?? models.FirstOrDefault()?.Id
+                    ?? currentConfig.Model;
+            }
+            else
+            {
+                model = await ModelCatalog.ResolveModelAsync(clientSource, model);
+            }
+
+            currentConfig.Model = model;
+            agent.Configuration.Model = model;
+            AgentManager.Instance.SetParentModel(model);
+
+            await ConfigurationManager.SaveProviderSelectionAsync(providerName, dialog.AppliedSettings ?? new ProviderSettings(), model);
+            await UpdateConfiguration();
+
+            chatView.Text += $"\n[Provider switched to {capabilities.ProviderName} | Model: {model}]\n\n";
+            ScrollChatToBottom();
+            Application.Refresh();
         }
 
         private void ShowTemperatureDialog()
@@ -920,7 +1007,7 @@ namespace Saturn.UI
 
         private void ShowSubAgentDefaultsDialog()
         {
-            var dialog = new SubAgentConfigDialog(openRouterClient);
+            var dialog = new SubAgentConfigDialog(clientSource);
             Application.Run(dialog);
             
             if (dialog.ConfigurationSaved)
@@ -1233,7 +1320,7 @@ namespace Saturn.UI
         
         private async Task ShowModeEditorDialogAsync(Mode modeToEdit)
         {
-            var editorDialog = new ModeEditorDialog(modeToEdit, openRouterClient);
+            var editorDialog = new ModeEditorDialog(modeToEdit, clientSource);
             Application.Run(editorDialog);
             
             if (editorDialog.ResultMode != null)
@@ -1486,6 +1573,7 @@ namespace Saturn.UI
                     {
                         updatedLines.Add(line);
                         updatedLines.Add($"Agent: {agent.Name}");
+                        updatedLines.Add($"Provider: {GetProviderDisplayName()}");
                         updatedLines.Add($"Model: {agent.Configuration.Model}");
                         updatedLines.Add($"Streaming: {(agent.Configuration.EnableStreaming ? "Enabled" : "Disabled")}");
                         updatedLines.Add($"Tools: {(agent.Configuration.EnableTools ? "Enabled" : "Disabled")}");
@@ -1502,9 +1590,9 @@ namespace Saturn.UI
                         skipConfigLines = false;
                     }
                 }
-                else if (skipConfigLines && 
-                    (line.StartsWith("Agent:") || line.StartsWith("Model:") || 
-                     line.StartsWith("Streaming:") || line.StartsWith("Tools:") || 
+                else if (skipConfigLines &&
+                    (line.StartsWith("Agent:") || line.StartsWith("Provider:") || line.StartsWith("Model:") ||
+                     line.StartsWith("Streaming:") || line.StartsWith("Tools:") ||
                      line.StartsWith("Available Tools:")))
                 {
                     continue;

--- a/UI/Dialogs/ModeEditorDialog.cs
+++ b/UI/Dialogs/ModeEditorDialog.cs
@@ -5,14 +5,13 @@ using System.Threading.Tasks;
 using Terminal.Gui;
 using Saturn.Agents.Core;
 using Saturn.Tools.Core;
-using Saturn.OpenRouter;
-using Saturn.OpenRouter.Models.Api.Models;
+using Saturn.Providers;
 
 namespace Saturn.UI.Dialogs
 {
     public class ModeEditorDialog : Dialog
     {
-        private OpenRouterClient? openRouterClient;
+        private ILlmClientSource? clientSource;
         private TextField nameField = null!;
         private TextField agentNameField = null!;
         private TextField descriptionField = null!;
@@ -36,11 +35,11 @@ namespace Saturn.UI.Dialogs
         
         public Mode? ResultMode { get; private set; }
         
-        public ModeEditorDialog(Mode? existingMode = null, OpenRouterClient? client = null)
+        public ModeEditorDialog(Mode? existingMode = null, ILlmClientSource? client = null)
             : base(existingMode != null ? $"Edit Mode: {existingMode.Name}" : "Create New Mode", 90, 26)
         {
             ColorScheme = Colors.Dialog;
-            openRouterClient = client;
+            clientSource = client;
             
             isEditMode = existingMode != null;
             mode = existingMode ?? new Mode();
@@ -252,14 +251,19 @@ namespace Saturn.UI.Dialogs
         
         private async void OnSelectModelClicked()
         {
-            if (openRouterClient == null)
+            if (clientSource == null || !clientSource.IsConnected)
             {
-                MessageBox.ErrorQuery("Error", "OpenRouter client not available", "OK");
+                MessageBox.ErrorQuery("Error", "No LLM provider connected", "OK");
                 return;
             }
-            
-            var models = await UI.AgentConfiguration.GetAvailableModels(openRouterClient);
-            var modelNames = models.Select(m => m.Name ?? m.Id).ToArray();
+
+            var models = await UI.AgentConfiguration.GetAvailableModels(clientSource);
+            if (models.Count == 0)
+            {
+                MessageBox.ErrorQuery("Error", "No models available from the current provider", "OK");
+                return;
+            }
+            var modelNames = models.Select(m => m.Display).ToArray();
             var currentIndex = Array.FindIndex(modelNames, m => models[Array.IndexOf(modelNames, m)].Id == mode.Model);
             if (currentIndex < 0) currentIndex = 0;
 

--- a/UI/Dialogs/ModeEditorDialog.cs
+++ b/UI/Dialogs/ModeEditorDialog.cs
@@ -264,7 +264,7 @@ namespace Saturn.UI.Dialogs
                 return;
             }
             var modelNames = models.Select(m => m.Display).ToArray();
-            var currentIndex = Array.FindIndex(modelNames, m => models[Array.IndexOf(modelNames, m)].Id == mode.Model);
+            var currentIndex = models.FindIndex(m => string.Equals(m.Id, mode.Model, StringComparison.OrdinalIgnoreCase));
             if (currentIndex < 0) currentIndex = 0;
 
             var dialog = new Dialog("Select Model", 60, 20);

--- a/UI/Dialogs/ProviderSettingsDialog.cs
+++ b/UI/Dialogs/ProviderSettingsDialog.cs
@@ -1,0 +1,280 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Terminal.Gui;
+using Saturn.Configuration;
+using Saturn.Configuration.Objects;
+using Saturn.Providers;
+
+namespace Saturn.UI.Dialogs
+{
+    /// <summary>
+    /// Generic provider picker. The provider list comes from the registry and the
+    /// settings fields are rendered from each provider's descriptors, so new providers
+    /// get their UI for free. Apply validates the connection before swapping; a failed
+    /// connect leaves the current provider untouched.
+    /// </summary>
+    public class ProviderSettingsDialog : Dialog
+    {
+        private readonly LlmClientManager manager;
+        private readonly PersistedAgentConfiguration? persistedConfig;
+        private readonly List<ILlmProvider> providers;
+
+        private RadioGroup providerRadio = null!;
+        private View settingsArea = null!;
+        private Label statusLabel = null!;
+        private Button testButton = null!;
+        private Button applyButton = null!;
+        private Button cancelButton = null!;
+        private readonly List<(ProviderSettingDescriptor Descriptor, TextField Field)> settingFields = new();
+
+        public bool Applied { get; private set; }
+        public ProviderSettings? AppliedSettings { get; private set; }
+
+        public ProviderSettingsDialog(LlmClientManager manager, PersistedAgentConfiguration? persistedConfig)
+            : base("Provider Settings", 78, 24)
+        {
+            ColorScheme = Colors.Dialog;
+            this.manager = manager;
+            this.persistedConfig = persistedConfig;
+            providers = ProviderRegistry.All.ToList();
+
+            InitializeComponents();
+        }
+
+        private void InitializeComponents()
+        {
+            var providerLabel = new Label("Provider:")
+            {
+                X = 1,
+                Y = 1
+            };
+
+            providerRadio = new RadioGroup(providers.Select(p => (NStack.ustring)p.DisplayName).ToArray())
+            {
+                X = 1,
+                Y = 2
+            };
+
+            var activeIndex = providers.FindIndex(p =>
+                string.Equals(p.Name, manager.ActiveProviderName, StringComparison.OrdinalIgnoreCase));
+            if (activeIndex >= 0)
+            {
+                providerRadio.SelectedItem = activeIndex;
+            }
+
+            providerRadio.SelectedItemChanged += (args) => RebuildSettingFields();
+
+            var separator = new Label(new string('─', 76))
+            {
+                X = 0,
+                Y = 2 + providers.Count + 1,
+                Width = Dim.Fill()
+            };
+
+            settingsArea = new View()
+            {
+                X = 1,
+                Y = Pos.Bottom(separator) + 1,
+                Width = Dim.Fill(1),
+                Height = 9
+            };
+
+            statusLabel = new Label("")
+            {
+                X = 1,
+                Y = Pos.Bottom(settingsArea) + 1,
+                Width = Dim.Fill(1),
+                Height = 2
+            };
+
+            testButton = new Button("_Test Connection")
+            {
+                X = Pos.Center() - 22,
+                Y = Pos.Bottom(statusLabel) + 1
+            };
+            testButton.Clicked += () => OnTestClicked();
+
+            applyButton = new Button("_Apply", true)
+            {
+                X = Pos.Right(testButton) + 2,
+                Y = Pos.Top(testButton)
+            };
+            applyButton.Clicked += () => OnApplyClicked();
+
+            cancelButton = new Button("_Cancel")
+            {
+                X = Pos.Right(applyButton) + 2,
+                Y = Pos.Top(testButton)
+            };
+            cancelButton.Clicked += () => Application.RequestStop();
+
+            Add(providerLabel, providerRadio, separator, settingsArea, statusLabel,
+                testButton, applyButton, cancelButton);
+
+            RebuildSettingFields();
+        }
+
+        private ILlmProvider SelectedProvider => providers[Math.Max(0, providerRadio.SelectedItem)];
+
+        private void RebuildSettingFields()
+        {
+            settingsArea.RemoveAll();
+            settingFields.Clear();
+
+            var provider = SelectedProvider;
+            var saved = ConfigurationManager.GetProviderSettings(persistedConfig, provider.Name);
+
+            // Prefer the values the live connection was actually built with.
+            if (string.Equals(provider.Name, manager.ActiveProviderName, StringComparison.OrdinalIgnoreCase))
+            {
+                foreach (var kvp in manager.ActiveSettings.Values)
+                {
+                    saved.Values[kvp.Key] = kvp.Value;
+                }
+            }
+
+            int y = 0;
+            foreach (var descriptor in provider.SettingDescriptors)
+            {
+                var label = new Label($"{descriptor.Label}:")
+                {
+                    X = 0,
+                    Y = y
+                };
+
+                var field = new TextField(saved.Get(descriptor.Key) ?? "")
+                {
+                    X = 28,
+                    Y = y,
+                    Width = Dim.Fill(1),
+                    Secret = descriptor.Kind == ProviderSettingKind.Secret
+                };
+
+                settingsArea.Add(label, field);
+                settingFields.Add((descriptor, field));
+                y++;
+
+                var hints = new List<string>();
+                if (!string.IsNullOrWhiteSpace(descriptor.EnvironmentVariable))
+                {
+                    var envSet = !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(descriptor.EnvironmentVariable));
+                    hints.Add(envSet
+                        ? $"env {descriptor.EnvironmentVariable} is set and used when blank"
+                        : $"falls back to env {descriptor.EnvironmentVariable}");
+                }
+                if (!string.IsNullOrWhiteSpace(descriptor.DefaultValue))
+                {
+                    hints.Add($"default: {descriptor.DefaultValue}");
+                }
+
+                if (hints.Count > 0)
+                {
+                    var hintLabel = new Label($"  ({string.Join(" | ", hints)})")
+                    {
+                        X = 0,
+                        Y = y,
+                        Width = Dim.Fill(1),
+                        ColorScheme = Colors.Menu
+                    };
+                    settingsArea.Add(hintLabel);
+                    y++;
+                }
+
+                y++;
+            }
+
+            statusLabel.Text = "";
+            settingsArea.SetNeedsDisplay();
+        }
+
+        private ProviderSettings CollectSettings()
+        {
+            var settings = new ProviderSettings();
+            foreach (var (descriptor, field) in settingFields)
+            {
+                settings.Set(descriptor.Key, field.Text?.ToString());
+            }
+            return settings;
+        }
+
+        private void SetBusy(bool busy)
+        {
+            testButton.Enabled = !busy;
+            applyButton.Enabled = !busy;
+            cancelButton.Enabled = !busy;
+        }
+
+        private void SetStatus(string message)
+        {
+            Application.MainLoop.Invoke(() =>
+            {
+                statusLabel.Text = message;
+                Application.Refresh();
+            });
+        }
+
+        private async void OnTestClicked()
+        {
+            var provider = SelectedProvider;
+            var settings = CollectSettings();
+
+            SetBusy(true);
+            SetStatus($"Testing connection to {provider.DisplayName}...");
+
+            try
+            {
+                var client = await provider.CreateClientAsync(settings);
+                try
+                {
+                    var reachable = await client.ValidateConnectionAsync();
+                    SetStatus(reachable
+                        ? $"Connection to {provider.DisplayName} OK."
+                        : $"Could not connect to {provider.DisplayName}. Check the settings and that the service is running.");
+                }
+                finally
+                {
+                    client.Dispose();
+                }
+            }
+            catch (Exception ex)
+            {
+                SetStatus(ex.Message);
+            }
+            finally
+            {
+                Application.MainLoop.Invoke(() => SetBusy(false));
+            }
+        }
+
+        private async void OnApplyClicked()
+        {
+            var provider = SelectedProvider;
+            var settings = CollectSettings();
+
+            SetBusy(true);
+            SetStatus($"Connecting to {provider.DisplayName}...");
+
+            try
+            {
+                var result = await manager.SwapAsync(provider.Name, settings);
+                if (result.Success)
+                {
+                    Applied = true;
+                    AppliedSettings = settings;
+                    Application.MainLoop.Invoke(() => Application.RequestStop());
+                }
+                else
+                {
+                    SetStatus(result.Error ?? "Failed to connect.");
+                    Application.MainLoop.Invoke(() => SetBusy(false));
+                }
+            }
+            catch (Exception ex)
+            {
+                SetStatus(ex.Message);
+                Application.MainLoop.Invoke(() => SetBusy(false));
+            }
+        }
+    }
+}

--- a/UI/Dialogs/ProviderSettingsDialog.cs
+++ b/UI/Dialogs/ProviderSettingsDialog.cs
@@ -27,9 +27,24 @@ namespace Saturn.UI.Dialogs
         private Button applyButton = null!;
         private Button cancelButton = null!;
         private readonly List<(ProviderSettingDescriptor Descriptor, TextField Field)> settingFields = new();
+        private bool isBusy;
 
         public bool Applied { get; private set; }
         public ProviderSettings? AppliedSettings { get; private set; }
+
+        /// <summary>
+        /// While a test/apply is in flight the dialog must not close: dismissing it
+        /// mid-swap would leave the manager half-applied and the later RequestStop
+        /// would land on the main window instead.
+        /// </summary>
+        public override bool ProcessKey(KeyEvent keyEvent)
+        {
+            if (isBusy && keyEvent.Key == Key.Esc)
+            {
+                return true;
+            }
+            return base.ProcessKey(keyEvent);
+        }
 
         public ProviderSettingsDialog(LlmClientManager manager, PersistedAgentConfiguration? persistedConfig)
             : base("Provider Settings", 78, 24)
@@ -119,7 +134,12 @@ namespace Saturn.UI.Dialogs
 
         private void RebuildSettingFields()
         {
+            var oldViews = settingsArea.Subviews.ToList();
             settingsArea.RemoveAll();
+            foreach (var view in oldViews)
+            {
+                view.Dispose();
+            }
             settingFields.Clear();
 
             var provider = SelectedProvider;
@@ -160,8 +180,8 @@ namespace Saturn.UI.Dialogs
                 {
                     var envSet = !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(descriptor.EnvironmentVariable));
                     hints.Add(envSet
-                        ? $"env {descriptor.EnvironmentVariable} is set and used when blank"
-                        : $"falls back to env {descriptor.EnvironmentVariable}");
+                        ? $"blank = env {descriptor.EnvironmentVariable}"
+                        : $"env: {descriptor.EnvironmentVariable}");
                 }
                 if (!string.IsNullOrWhiteSpace(descriptor.DefaultValue))
                 {
@@ -200,6 +220,7 @@ namespace Saturn.UI.Dialogs
 
         private void SetBusy(bool busy)
         {
+            isBusy = busy;
             testButton.Enabled = !busy;
             applyButton.Enabled = !busy;
             cancelButton.Enabled = !busy;
@@ -262,7 +283,16 @@ namespace Saturn.UI.Dialogs
                 {
                     Applied = true;
                     AppliedSettings = settings;
-                    Application.MainLoop.Invoke(() => Application.RequestStop());
+                    Application.MainLoop.Invoke(() =>
+                    {
+                        SetBusy(false);
+                        // Only stop this dialog; if it somehow already closed, stopping
+                        // the current toplevel would take down the main window.
+                        if (Application.Current == this)
+                        {
+                            Application.RequestStop();
+                        }
+                    });
                 }
                 else
                 {

--- a/UI/Dialogs/SubAgentConfigDialog.cs
+++ b/UI/Dialogs/SubAgentConfigDialog.cs
@@ -4,8 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Terminal.Gui;
 using Saturn.Config;
-using Saturn.OpenRouter;
-using Saturn.OpenRouter.Models.Api.Models;
+using Saturn.Providers;
 
 namespace Saturn.UI.Dialogs
 {
@@ -24,16 +23,16 @@ namespace Saturn.UI.Dialogs
         private Button saveButton;
         private Button cancelButton;
         
-        private List<Model> availableModels = new();
-        private OpenRouterClient? client;
+        private List<ModelInfo> availableModels = new();
+        private ILlmClientSource? clientSource;
         private SubAgentPreferences preferences;
-        
+
         public bool ConfigurationSaved { get; private set; }
-        
-        public SubAgentConfigDialog(OpenRouterClient? openRouterClient = null)
+
+        public SubAgentConfigDialog(ILlmClientSource? clientSource = null)
             : base("Default Sub-Agent Configuration", 80, 22)
         {
-            client = openRouterClient;
+            this.clientSource = clientSource;
             preferences = SubAgentPreferences.Instance;
             
             InitializeComponents();
@@ -223,17 +222,17 @@ namespace Saturn.UI.Dialogs
         
         private async Task LoadModelsAsync()
         {
-            if (client == null) return;
-            
+            if (clientSource == null || !clientSource.IsConnected) return;
+
             try
             {
-                var response = await client.Models.ListAllAsync();
-                if (response?.Data != null)
+                var models = await AgentConfiguration.GetAvailableModels(clientSource);
+                if (models.Count > 0)
                 {
-                    availableModels = response.Data
+                    availableModels = models
                         .OrderBy(m => m.Id)
                         .ToList();
-                    
+
                     var modelNames = availableModels.Select(m => m.Id).ToArray();
                     
                     Application.MainLoop.Invoke(() =>
@@ -273,14 +272,10 @@ namespace Saturn.UI.Dialogs
             
             if (model != null)
             {
-                var contextLengthText = model.ContextLength.HasValue && model.ContextLength.Value > 0 
-                    ? $"{model.ContextLength.Value:N0} tokens" 
-                    : "Unknown";
-                var pricing = model.Pricing != null ? $" | ${model.Pricing.Prompt:F5}/{model.Pricing.Completion:F5}" : "";
-                modelInfoLabel.Text = $"Context: {contextLengthText}{pricing}";
+                modelInfoLabel.Text = DescribeModel(model);
             }
         }
-        
+
         private void OnReviewerModelChanged(ListViewItemEventArgs args)
         {
             if (args.Value == null) return;
@@ -290,12 +285,20 @@ namespace Saturn.UI.Dialogs
             
             if (model != null)
             {
-                var contextLengthText = model.ContextLength.HasValue && model.ContextLength.Value > 0 
-                    ? $"{model.ContextLength.Value:N0} tokens" 
-                    : "Unknown";
-                var pricing = model.Pricing != null ? $" | ${model.Pricing.Prompt:F5}/{model.Pricing.Completion:F5}" : "";
-                reviewerModelInfoLabel.Text = $"Context: {contextLengthText}{pricing}";
+                reviewerModelInfoLabel.Text = DescribeModel(model);
             }
+        }
+
+        private static string DescribeModel(ModelInfo model)
+        {
+            var contextLengthText = model.ContextLength.HasValue && model.ContextLength.Value > 0
+                ? $"{model.ContextLength.Value:N0} tokens"
+                : "Unknown";
+            var pricing = !string.IsNullOrEmpty(model.PromptPrice)
+                ? $" | ${model.PromptPrice}/{model.CompletionPrice}"
+                : "";
+            var loaded = model.IsLoaded == true ? " | loaded" : "";
+            return $"Context: {contextLengthText}{pricing}{loaded}";
         }
         
         private void OnSaveClicked()


### PR DESCRIPTION
## Summary

Saturn is no longer hard-wired to OpenRouter. This PR introduces a provider abstraction layer with two backends — OpenRouter (unchanged default) and LM Studio (local, offline, no API key) — switchable at runtime from **Agent → Provider...** without a restart. Adding future providers (Ollama, OpenAI direct, etc.) is one new folder under `Providers/` plus a single registration line.

## Motivation

Running Saturn against local models has been a recurring ask. Rather than bolting LM Studio onto the existing client, this restructures the LLM access path so *any* OpenAI-compatible backend can slot in: agents resolve their client through a swappable source instead of holding one, and provider-specific request extensions are driven by declared capabilities instead of `if` checks on provider names.

## How it works

**Provider core (`Providers/Core/`)**
- `ILlmClient` — chat, streaming chat, model listing, connection probe. The OpenRouter SDK DTOs serve as the shared wire format since both backends speak the OpenAI dialect.
- `ILlmProvider` — the plugin contract: a stable name, display name, self-describing setting descriptors (key/label/kind/env-var/default), and a client factory. The provider settings dialog renders its fields from these descriptors, so new providers get UI for free.
- `LlmClientManager` — the swap engine. Builds and validates the candidate client *before* atomically replacing the active one; a failed connect leaves the session untouched. The replaced client is disposed after a 30-minute grace period because in-flight turns may still be streaming on it. Raises `ProviderChanged`.
- `ProviderRegistry` — name → provider lookup, registered at startup.
- `ModelCatalog` — provider-keyed model list cache (each provider declares its own freshness window; 30 s for LM Studio since its list changes when models load/unload) plus model resolution: requested model → exact match → OpenRouter `:variant` slugs kept when the base model exists → preferred fallback → provider default → first loaded model.

**Capability-gated requests.** `AgentBase` builds requests from `LlmClientCapabilities`: OpenRouter keeps `transforms`, `usage.include`, `tool_choice`, and Anthropic `cache_control` content parts exactly as before (wire-identical to master); LM Studio never sees any of them. Three related fixes ride along: `tool_choice` is no longer sent without a `tools` array; history accumulated under a caching provider is sanitized per-request (not mutated) when the active provider doesn't support `cache_control`, so a mid-session swap can't ship Anthropic-specific fields to a local server; and tool-call arguments are validated as JSON before entering history — a generation cut off by the token limit can emit a tool call with empty or truncated arguments, which, echoed back verbatim, crashes strict chat templates server-side (HTTP 500 on every subsequent request; found while testing against a real LM Studio instance). Truncated responses now also surface a "max token limit reached" notice in the UI.

**LM Studio client (`Providers/LMStudio/`).** OpenAI-compatible `/v1` endpoints through the existing HTTP/SSE plumbing with a normalized base URL (accepts with/without `/v1`), no auth header, and a 10-minute default timeout for slow local generation. Model listings are enriched best-effort from LM Studio's native REST API (`/api/v0/models`) with context length and loaded state; any failure there falls back silently to the plain `/v1` listing. Connection-refused errors are rewritten to an actionable "is the LM Studio server running?" message.

**Configuration.** `agent-config.json` gains `activeProvider` and per-provider blocks (`settings` + per-provider model memory, so switching back and forth restores the model used on each side). Legacy configs migrate silently on load. Saves are serialized and atomic (temp file + rename), and existing save paths merge the provider fields rather than wiping them. Secrets that merely mirror an environment variable are never persisted. Provider resolution order at launch: `SATURN_PROVIDER` env var → saved config → OpenRouter. The config directory can be overridden with `SATURN_CONFIG_DIR`.

**Startup behavior change.** A transient network failure no longer prevents launch: the client is installed unvalidated (missing API key still fails fast with a clear message), a liveness probe prints a warning instead of exiting, and the user can switch providers from the UI. On LM Studio with no configured model, Saturn picks the first loaded model.

**Multi-agent.** Sub-agent and reviewer model requests are resolved against the active provider (with the parent model as fallback), so tool-driven agent creation written for OpenRouter slugs degrades gracefully on LM Studio. Switching providers while sub-agents are running prompts to terminate them first.

## Backward compatibility

- Existing OpenRouter setups need no changes: same env var, same defaults, and the request payload is unchanged on the wire (verified by request-shaping tests).
- Old config files are migrated in place; all previous fields are preserved.
- `AgentConfiguration.Client` (typed `OpenRouterClient`) became `ClientSource` (`ILlmClientSource`) — internal API only.

## Testing

- 49 new unit tests (85 total, all passing): swap semantics (validate-fail keeps the old client, unvalidated startup install, post-swap turns route to the new client), LM Studio wire behavior through a stubbed HTTP handler (endpoint paths, no auth header, extension fields absent from serialized JSON, native-API enrichment and its failure tolerance), request shaping per capability profile, cache_control stripping after a swap, model resolution incl. `:variant` slugs, settings resolution precedence (explicit → env → default), and file-backed config migration/merge/atomicity via `SATURN_CONFIG_DIR` isolation.
- Manually needs a pass against a real LM Studio instance (streamed tool calls and cancellation are the interesting cases); test checklist below.

### Manual test checklist
- [x] `SATURN_PROVIDER=lmstudio` launch with server running / not running (warning + UI still opens)
- [x] Streamed multi-step tool-calling task on a tool-capable local model (e.g. Qwen 2.5 Coder)
- [x] Esc-cancel mid-generation frees the server
- [x] Agent → Provider... swap in both directions mid-session; per-provider model restored
- [x] Sub-agent spawn/handoff on LM Studio
- [x] Existing OpenRouter workflow unchanged

## Known limitations

- Retired-client disposal is time-based (30 min), not usage-refcounted; a single turn would have to span a swap *and* run longer than that to be affected.
- Config writes are serialized in-process but not locked across two concurrent Saturn instances.
- Local tool-calling quality depends on the model; the README recommends tool-capable models and notes that a local server serializes generation, which limits sub-agent parallelism.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple LLM providers, including OpenRouter and local LM Studio servers.
  * Added in-app provider selection, connection testing, provider-specific settings, and model discovery.
  * Added provider-aware model selection with cached listings and fallback handling.
  * Chat requests now adapt automatically to provider capabilities, including streaming, tools, and caching.

* **Bug Fixes**
  * Improved handling of truncated or invalid tool-call arguments.
  * Prevented configuration loss during saves and migrated legacy configuration files automatically.

* **Documentation**
  * Updated setup instructions for OpenRouter and LM Studio.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
