### PR TITLE
Add background command lifecycle to execute_command

### DIFF
--- a/Agents/Core/Mode.cs
+++ b/Agents/Core/Mode.cs
@@ -57,7 +57,7 @@ namespace Saturn.Agents.Core
                     "write_file", "search_and_replace", "delete_file",
                     "create_agent", "hand_off_to_agent", "get_agent_status", 
                     "wait_for_agent", "get_task_result", "terminate_agent", "execute_command",
-                    "web_fetch"
+                    "get_command_output", "kill_command", "web_fetch"
                 },
                 SystemPromptOverride = null,
                 Model = "anthropic/claude-sonnet-4",

--- a/Program.cs
+++ b/Program.cs
@@ -230,7 +230,7 @@ Operating Principles
                     "write_file", "search_and_replace", "delete_file",
                     "create_agent", "hand_off_to_agent", "get_agent_status", 
                     "wait_for_agent", "get_task_result", "terminate_agent", "execute_command",
-                    "web_fetch"
+                    "get_command_output", "kill_command", "web_fetch"
                 },
             };
 

--- a/Saturn.Tests/Tools/ExecuteCommandToolTests.cs
+++ b/Saturn.Tests/Tools/ExecuteCommandToolTests.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Xunit;
+using FluentAssertions;
+using Saturn.Tools;
+using Saturn.Tools.Core;
+using Saturn.Tools.Objects;
+
+namespace Saturn.Tests.Tools
+{
+    public class ExecuteCommandToolTests
+    {
+        // Approval is bypassed so the tool can run headlessly in CI.
+        private static ExecuteCommandTool NewTool() =>
+            new ExecuteCommandTool(new CommandExecutorConfig(), new CommandApprovalService(false));
+
+        private static bool IsWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+        // Emits a line immediately, then blocks for ~20s so timeout/kill paths can be exercised.
+        private static string EarlyOutputThenHang =>
+            IsWindows ? "echo start && ping -n 20 127.0.0.1" : "echo start && sleep 20";
+
+        [Fact]
+        public async Task Timeout_ReturnsPartialOutput_WithoutThrowing()
+        {
+            var tool = NewTool();
+
+            var result = await tool.ExecuteAsync(new Dictionary<string, object>
+            {
+                ["command"] = EarlyOutputThenHang,
+                ["timeout"] = 2
+            });
+
+            result.Success.Should().BeFalse();
+            result.FormattedOutput.Should().Contain("TIMED OUT");
+            result.FormattedOutput.Should().Contain("start");
+        }
+
+        [Fact]
+        public async Task Background_StartsPollsAndCompletes()
+        {
+            var tool = NewTool();
+            var getOutput = new GetCommandOutputTool();
+
+            var start = await tool.ExecuteAsync(new Dictionary<string, object>
+            {
+                ["command"] = "echo bg_marker",
+                ["run_in_background"] = true
+            });
+
+            start.Success.Should().BeTrue();
+            var data = (Dictionary<string, object>)start.RawData!;
+            var commandId = (string)data["command_id"];
+            commandId.Should().NotBeNullOrEmpty();
+
+            // Poll until the process exits, accumulating output.
+            var collected = "";
+            var status = "running";
+            for (var i = 0; i < 50 && status == "running"; i++)
+            {
+                await Task.Delay(100);
+                var poll = await getOutput.ExecuteAsync(new Dictionary<string, object> { ["command_id"] = commandId });
+                var pollData = (Dictionary<string, object>)poll.RawData!;
+                collected += (string)pollData["stdout"];
+                status = (string)pollData["status"];
+            }
+
+            status.Should().Be("exited");
+            collected.Should().Contain("bg_marker");
+        }
+
+        [Fact]
+        public async Task Kill_StopsRunningBackgroundCommand()
+        {
+            var tool = NewTool();
+            var kill = new KillCommandTool();
+
+            var start = await tool.ExecuteAsync(new Dictionary<string, object>
+            {
+                ["command"] = EarlyOutputThenHang,
+                ["run_in_background"] = true
+            });
+
+            var commandId = (string)((Dictionary<string, object>)start.RawData!)["command_id"];
+
+            var killResult = await kill.ExecuteAsync(new Dictionary<string, object> { ["command_id"] = commandId });
+
+            killResult.Success.Should().BeTrue();
+            var killData = (Dictionary<string, object>)killResult.RawData!;
+            ((string)killData["status"]).Should().Be("killed");
+        }
+
+        [Fact]
+        public async Task GetCommandOutput_UnknownId_ReturnsError()
+        {
+            var getOutput = new GetCommandOutputTool();
+
+            var result = await getOutput.ExecuteAsync(new Dictionary<string, object> { ["command_id"] = "cmd_does_not_exist" });
+
+            result.Success.Should().BeFalse();
+            result.Error.Should().Contain("No background command");
+        }
+    }
+}

--- a/Tools/Core/BackgroundCommandManager.cs
+++ b/Tools/Core/BackgroundCommandManager.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Text;
+using System.Threading;
+
+namespace Saturn.Tools.Core
+{
+    public enum BackgroundCommandStatus
+    {
+        Running,
+        Exited,
+        Killed
+    }
+
+    /// <summary>
+    /// A command launched in the background. Output is buffered as it arrives and can be
+    /// drained incrementally via <see cref="ReadNew"/>, mirroring how a terminal is polled.
+    /// </summary>
+    public class BackgroundCommand
+    {
+        private const int MaxBufferLength = 1048576; // 1MB retained per stream
+
+        private readonly StringBuilder _stdout = new();
+        private readonly StringBuilder _stderr = new();
+        private int _stdoutCursor;
+        private int _stderrCursor;
+        private readonly object _lock = new();
+
+        public string Id { get; init; } = "";
+        public string Command { get; init; } = "";
+        public string WorkingDirectory { get; init; } = "";
+        public Process Process { get; init; } = null!;
+        public DateTime StartedAt { get; init; }
+        public BackgroundCommandStatus Status { get; set; } = BackgroundCommandStatus.Running;
+        public int? ExitCode { get; set; }
+
+        public void AppendStdout(string line)
+        {
+            lock (_lock) Append(_stdout, ref _stdoutCursor, line);
+        }
+
+        public void AppendStderr(string line)
+        {
+            lock (_lock) Append(_stderr, ref _stderrCursor, line);
+        }
+
+        /// <summary>
+        /// Returns output produced since the previous call and advances the read cursors.
+        /// </summary>
+        public (string StdOut, string StdErr) ReadNew()
+        {
+            lock (_lock)
+            {
+                var outNew = _stdout.ToString(_stdoutCursor, _stdout.Length - _stdoutCursor);
+                var errNew = _stderr.ToString(_stderrCursor, _stderr.Length - _stderrCursor);
+                _stdoutCursor = _stdout.Length;
+                _stderrCursor = _stderr.Length;
+                return (outNew, errNew);
+            }
+        }
+
+        private static void Append(StringBuilder buffer, ref int cursor, string line)
+        {
+            buffer.AppendLine(line);
+            if (buffer.Length > MaxBufferLength)
+            {
+                // Drop from the front so the most recent output (and unread tail) is retained.
+                var overflow = buffer.Length - MaxBufferLength;
+                buffer.Remove(0, overflow);
+                cursor = Math.Max(0, cursor - overflow);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Tracks commands started in the background so their output can be polled and they can be
+    /// killed on demand. Mirrors the lifecycle role AgentManager plays for sub-agents.
+    /// </summary>
+    public class BackgroundCommandManager
+    {
+        private static readonly Lazy<BackgroundCommandManager> _instance = new(() => new BackgroundCommandManager());
+        public static BackgroundCommandManager Instance => _instance.Value;
+
+        private readonly ConcurrentDictionary<string, BackgroundCommand> _commands = new();
+        private int _counter;
+
+        private BackgroundCommandManager() { }
+
+        public BackgroundCommand Register(string command, string workingDirectory, Process process)
+        {
+            var id = $"cmd_{Interlocked.Increment(ref _counter)}";
+            var bg = new BackgroundCommand
+            {
+                Id = id,
+                Command = command,
+                WorkingDirectory = workingDirectory,
+                Process = process,
+                StartedAt = DateTime.UtcNow
+            };
+            _commands[id] = bg;
+            return bg;
+        }
+
+        public BackgroundCommand? Get(string id)
+        {
+            return id != null && _commands.TryGetValue(id, out var cmd) ? cmd : null;
+        }
+
+        public IEnumerable<BackgroundCommand> GetAll() => _commands.Values;
+
+        public void Remove(string id) => _commands.TryRemove(id, out _);
+    }
+}

--- a/Tools/Core/BackgroundCommandManager.cs
+++ b/Tools/Core/BackgroundCommandManager.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Linq;
 using System.Text;
 using System.Threading;
 
@@ -18,7 +19,7 @@ namespace Saturn.Tools.Core
     /// A command launched in the background. Output is buffered as it arrives and can be
     /// drained incrementally via <see cref="ReadNew"/>, mirroring how a terminal is polled.
     /// </summary>
-    public class BackgroundCommand
+    public class BackgroundCommand : IDisposable
     {
         private const int MaxBufferLength = 1048576; // 1MB retained per stream
 
@@ -27,14 +28,48 @@ namespace Saturn.Tools.Core
         private int _stdoutCursor;
         private int _stderrCursor;
         private readonly object _lock = new();
+        private BackgroundCommandStatus _status = BackgroundCommandStatus.Running;
 
         public string Id { get; init; } = "";
         public string Command { get; init; } = "";
         public string WorkingDirectory { get; init; } = "";
         public Process Process { get; init; } = null!;
         public DateTime StartedAt { get; init; }
-        public BackgroundCommandStatus Status { get; set; } = BackgroundCommandStatus.Running;
-        public int? ExitCode { get; set; }
+        public int? ExitCode { get; private set; }
+
+        public BackgroundCommandStatus Status
+        {
+            get { lock (_lock) { return _status; } }
+        }
+
+        public bool IsTerminal
+        {
+            get { lock (_lock) { return _status != BackgroundCommandStatus.Running; } }
+        }
+
+        /// <summary>Records a natural exit. No-op if the command was already killed or exited.</summary>
+        public void MarkExited(int? exitCode)
+        {
+            lock (_lock)
+            {
+                if (_status != BackgroundCommandStatus.Running)
+                    return;
+                _status = BackgroundCommandStatus.Exited;
+                ExitCode = exitCode;
+            }
+        }
+
+        /// <summary>Records that the command was killed. Returns false if it had already finished.</summary>
+        public bool MarkKilled()
+        {
+            lock (_lock)
+            {
+                if (_status != BackgroundCommandStatus.Running)
+                    return false;
+                _status = BackgroundCommandStatus.Killed;
+                return true;
+            }
+        }
 
         public void AppendStdout(string line)
         {
@@ -72,6 +107,11 @@ namespace Saturn.Tools.Core
                 cursor = Math.Max(0, cursor - overflow);
             }
         }
+
+        public void Dispose()
+        {
+            try { Process?.Dispose(); } catch { }
+        }
     }
 
     /// <summary>
@@ -80,6 +120,10 @@ namespace Saturn.Tools.Core
     /// </summary>
     public class BackgroundCommandManager
     {
+        // Retain a bounded number of commands so finished processes don't leak handles or memory
+        // over a long session. Only terminal (exited/killed) commands are ever evicted.
+        private const int MaxRetainedCommands = 50;
+
         private static readonly Lazy<BackgroundCommandManager> _instance = new(() => new BackgroundCommandManager());
         public static BackgroundCommandManager Instance => _instance.Value;
 
@@ -100,6 +144,7 @@ namespace Saturn.Tools.Core
                 StartedAt = DateTime.UtcNow
             };
             _commands[id] = bg;
+            EvictTerminalOverflow();
             return bg;
         }
 
@@ -110,6 +155,32 @@ namespace Saturn.Tools.Core
 
         public IEnumerable<BackgroundCommand> GetAll() => _commands.Values;
 
-        public void Remove(string id) => _commands.TryRemove(id, out _);
+        public void Remove(string id)
+        {
+            if (id != null && _commands.TryRemove(id, out var cmd))
+            {
+                cmd.Dispose();
+            }
+        }
+
+        // Drop the oldest finished commands once we exceed the retention cap. Running commands are
+        // never evicted so their output stays pollable until they finish.
+        private void EvictTerminalOverflow()
+        {
+            var overflow = _commands.Count - MaxRetainedCommands;
+            if (overflow <= 0)
+                return;
+
+            var stale = _commands.Values
+                .Where(c => c.IsTerminal)
+                .OrderBy(c => c.StartedAt)
+                .Take(overflow)
+                .ToList();
+
+            foreach (var cmd in stale)
+            {
+                Remove(cmd.Id);
+            }
+        }
     }
 }

--- a/Tools/ExecuteCommandTool.cs
+++ b/Tools/ExecuteCommandTool.cs
@@ -267,6 +267,10 @@ Prefer the dedicated file tools (read_file, write_file, grep, glob, list_files) 
                 try { await process.WaitForExitAsync(); } catch { }
             }
 
+            // A blocking WaitForExit with no timeout ensures the async output handlers have
+            // drained before we read the buffers, so the tail of the output isn't lost.
+            try { process.WaitForExit(); } catch { }
+
             stopwatch.Stop();
 
             int exitCode;
@@ -294,16 +298,24 @@ Prefer the dedicated file tools (read_file, write_file, grep, glob, list_files) 
             process.ErrorDataReceived += (sender, e) => { if (e.Data != null) bg.AppendStderr(e.Data); };
             process.Exited += (sender, e) =>
             {
-                try { bg.ExitCode = process.ExitCode; } catch { }
-                if (bg.Status == BackgroundCommandStatus.Running)
-                {
-                    bg.Status = BackgroundCommandStatus.Exited;
-                }
+                int? exitCode = null;
+                try { exitCode = process.ExitCode; } catch { }
+                bg.MarkExited(exitCode);
             };
 
-            process.Start();
-            process.BeginOutputReadLine();
-            process.BeginErrorReadLine();
+            try
+            {
+                process.Start();
+                process.BeginOutputReadLine();
+                process.BeginErrorReadLine();
+            }
+            catch
+            {
+                // The process never started, so drop the registration instead of leaving a
+                // phantom entry stuck in the 'running' state forever.
+                BackgroundCommandManager.Instance.Remove(bg.Id);
+                throw;
+            }
 
             var message =
                 $"Command started in background with id '{bg.Id}'.\n" +

--- a/Tools/ExecuteCommandTool.cs
+++ b/Tools/ExecuteCommandTool.cs
@@ -14,8 +14,9 @@ namespace Saturn.Tools
 {
     public class ExecuteCommandTool : ToolBase
     {
-        private const int DefaultTimeoutSeconds = 30;
-        private const int MaxOutputLength = 1048576; // 1MB
+        private const int DefaultTimeoutSeconds = 120;
+        private const int MaxOutputLength = 1048576; // 1MB shown to the model
+        private const int MaxCaptureLength = 8388608; // 8MB safety ceiling retained during capture
         private readonly List<CommandHistory> _commandHistory = new();
         private readonly CommandExecutorConfig _config;
         private readonly ICommandApprovalService _approvalService;
@@ -37,9 +38,10 @@ namespace Saturn.Tools
 How commands run:
 - On Windows the command is run with 'cmd.exe /c'; on Linux/macOS with '/bin/sh -c'. Use the syntax of the current platform.
 - Commands run non-interactively with no stdin. Do not run commands that wait for user input (e.g. editors, REPLs, prompts) - they will hang until the timeout.
-- Default timeout is 30 seconds; pass 'timeout' (in seconds) for longer-running commands like builds or test suites.
-- Output is captured up to 1 MB; anything beyond that is truncated.
+- Default timeout is 120 seconds; pass 'timeout' (in seconds) for longer-running commands like builds or test suites. On timeout the process is killed and any output captured so far is still returned.
+- Output is captured up to 1 MB; the middle is elided if it is longer, keeping the start and end.
 - The user may be asked to approve each command before it runs; a denied command returns an error.
+- For long-running processes (dev servers, watchers), set 'run_in_background' to true. The tool returns a command_id immediately; poll its output with get_command_output and stop it with kill_command.
 
 When to use:
 - Running builds, tests, linters, or type checkers
@@ -68,8 +70,15 @@ Prefer the dedicated file tools (read_file, write_file, grep, glob, list_files) 
                 { "timeout", new Dictionary<string, object>
                     {
                         { "type", "integer" },
-                        { "default", 30 },
-                        { "description", "Command timeout in seconds. Default is 30 seconds; increase for builds and test runs" }
+                        { "default", 120 },
+                        { "description", "Command timeout in seconds. Default is 120 seconds; increase for builds and test runs. Ignored when run_in_background is true" }
+                    }
+                },
+                { "run_in_background", new Dictionary<string, object>
+                    {
+                        { "type", "boolean" },
+                        { "default", false },
+                        { "description", "Run the command in the background and return a command_id immediately instead of waiting. Use for dev servers, watchers, and other long-lived processes; read output with get_command_output and stop it with kill_command" }
                     }
                 },
                 { "captureOutput", new Dictionary<string, object>
@@ -114,6 +123,7 @@ Prefer the dedicated file tools (read_file, write_file, grep, glob, list_files) 
                 var timeoutSeconds = GetParameter<int>(arguments, "timeout", _config.DefaultTimeout);
                 var captureOutput = GetParameter<bool>(arguments, "captureOutput", true);
                 var runAsShell = GetParameter<bool>(arguments, "runAsShell", true);
+                var runInBackground = GetParameter<bool>(arguments, "run_in_background", false);
 
                 if (AgentContext.RequireCommandApproval)
                 {
@@ -136,6 +146,11 @@ Prefer the dedicated file tools (read_file, write_file, grep, glob, list_files) 
                 if (!Directory.Exists(workingDirectory))
                 {
                     return CreateErrorResult($"Working directory does not exist: {workingDirectory}");
+                }
+
+                if (runInBackground)
+                {
+                    return StartBackgroundCommand(command, workingDirectory, runAsShell);
                 }
 
                 var historyEntry = new CommandHistory
@@ -208,7 +223,7 @@ Prefer the dedicated file tools (read_file, write_file, grep, glob, list_files) 
             {
                 process.OutputDataReceived += (sender, e) =>
                 {
-                    if (e.Data != null && outputBuilder.Length < MaxOutputLength)
+                    if (e.Data != null && outputBuilder.Length < MaxCaptureLength)
                     {
                         outputBuilder.AppendLine(e.Data);
                     }
@@ -216,7 +231,7 @@ Prefer the dedicated file tools (read_file, write_file, grep, glob, list_files) 
 
                 process.ErrorDataReceived += (sender, e) =>
                 {
-                    if (e.Data != null && errorBuilder.Length < MaxOutputLength)
+                    if (e.Data != null && errorBuilder.Length < MaxCaptureLength)
                     {
                         errorBuilder.AppendLine(e.Data);
                     }
@@ -234,32 +249,74 @@ Prefer the dedicated file tools (read_file, write_file, grep, glob, list_files) 
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             cts.CancelAfter(timeout);
 
+            var timedOut = false;
             try
             {
                 await process.WaitForExitAsync(cts.Token);
             }
             catch (OperationCanceledException)
             {
+                timedOut = true;
                 try
                 {
                     process.Kill(entireProcessTree: true);
                 }
                 catch { }
 
-                throw new TimeoutException($"Command execution timed out after {timeout.TotalSeconds} seconds");
+                // Let the process finish exiting so any buffered output is flushed to us.
+                try { await process.WaitForExitAsync(); } catch { }
             }
 
             stopwatch.Stop();
 
+            int exitCode;
+            try { exitCode = process.ExitCode; } catch { exitCode = -1; }
+
             return new CommandResult
             {
-                ExitCode = process.ExitCode,
+                ExitCode = exitCode,
                 StandardOutput = outputBuilder.ToString(),
                 StandardError = errorBuilder.ToString(),
                 Duration = stopwatch.Elapsed,
                 Command = command,
-                WorkingDirectory = workingDirectory
+                WorkingDirectory = workingDirectory,
+                TimedOut = timedOut
             };
+        }
+
+        private ToolResult StartBackgroundCommand(string command, string workingDirectory, bool runAsShell)
+        {
+            var processInfo = CreateProcessStartInfo(command, workingDirectory, captureOutput: true, runAsShell);
+            var process = new Process { StartInfo = processInfo, EnableRaisingEvents = true };
+            var bg = BackgroundCommandManager.Instance.Register(command, workingDirectory, process);
+
+            process.OutputDataReceived += (sender, e) => { if (e.Data != null) bg.AppendStdout(e.Data); };
+            process.ErrorDataReceived += (sender, e) => { if (e.Data != null) bg.AppendStderr(e.Data); };
+            process.Exited += (sender, e) =>
+            {
+                try { bg.ExitCode = process.ExitCode; } catch { }
+                if (bg.Status == BackgroundCommandStatus.Running)
+                {
+                    bg.Status = BackgroundCommandStatus.Exited;
+                }
+            };
+
+            process.Start();
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+
+            var message =
+                $"Command started in background with id '{bg.Id}'.\n" +
+                $"Read its output with get_command_output (command_id: '{bg.Id}') and stop it with kill_command.";
+
+            return CreateSuccessResult(
+                new Dictionary<string, object>
+                {
+                    ["command_id"] = bg.Id,
+                    ["status"] = "running",
+                    ["command"] = command
+                },
+                message);
         }
 
         private ProcessStartInfo CreateProcessStartInfo(string command, string workingDirectory, bool captureOutput, bool runAsShell)
@@ -338,9 +395,13 @@ Prefer the dedicated file tools (read_file, write_file, grep, glob, list_files) 
         private ToolResult FormatResult(CommandResult result)
         {
             var output = new StringBuilder();
-            
+
             output.AppendLine($"Command: {result.Command}");
             output.AppendLine($"Working Directory: {result.WorkingDirectory}");
+            if (result.TimedOut)
+            {
+                output.AppendLine($"Status: TIMED OUT after {result.Duration.TotalSeconds:F1}s and was terminated (partial output below)");
+            }
             output.AppendLine($"Exit Code: {result.ExitCode}");
             output.AppendLine($"Duration: {result.Duration.TotalMilliseconds:F2}ms");
             output.AppendLine();
@@ -367,7 +428,14 @@ Prefer the dedicated file tools (read_file, write_file, grep, glob, list_files) 
             if (output.Length <= MaxOutputLength)
                 return output;
 
-            return output.Substring(0, MaxOutputLength) + "\n\n... (output truncated)";
+            // Keep the start and end; the middle is usually the least useful part of a long log.
+            var headLength = MaxOutputLength * 2 / 3;
+            var tailLength = MaxOutputLength - headLength;
+            var elided = output.Length - headLength - tailLength;
+
+            return output.Substring(0, headLength)
+                + $"\n\n... ({elided} characters elided) ...\n\n"
+                + output.Substring(output.Length - tailLength);
         }
 
         public IReadOnlyList<CommandHistory> GetCommandHistory() => _commandHistory.AsReadOnly();

--- a/Tools/GetCommandOutputTool.cs
+++ b/Tools/GetCommandOutputTool.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Saturn.Tools.Core;
+
+namespace Saturn.Tools
+{
+    public class GetCommandOutputTool : ToolBase
+    {
+        public override string Name => "get_command_output";
+
+        public override string Description => @"Read output produced by a command started with execute_command (run_in_background: true).
+
+Returns only the output generated since the last call for that command_id, along with the command's current status (running, exited, or killed) and its exit code once finished. Call it repeatedly to follow a long-running process.";
+
+        protected override Dictionary<string, object> GetParameterProperties()
+        {
+            return new Dictionary<string, object>
+            {
+                { "command_id", new Dictionary<string, object>
+                    {
+                        { "type", "string" },
+                        { "description", "The command_id returned by execute_command when it was started in the background" }
+                    }
+                },
+                { "filter", new Dictionary<string, object>
+                    {
+                        { "type", "string" },
+                        { "description", "Optional regular expression; only output lines matching it are returned" }
+                    }
+                }
+            };
+        }
+
+        protected override string[] GetRequiredParameters()
+        {
+            return new[] { "command_id" };
+        }
+
+        public override string GetDisplaySummary(Dictionary<string, object> parameters)
+        {
+            var id = GetParameter<string>(parameters, "command_id", "");
+            return $"Reading output of {id}";
+        }
+
+        public override Task<ToolResult> ExecuteAsync(Dictionary<string, object> parameters)
+        {
+            var commandId = GetParameter<string>(parameters, "command_id");
+            if (string.IsNullOrWhiteSpace(commandId))
+            {
+                return Task.FromResult(CreateErrorResult("command_id parameter is required"));
+            }
+
+            var bg = BackgroundCommandManager.Instance.Get(commandId);
+            if (bg == null)
+            {
+                return Task.FromResult(CreateErrorResult($"No background command with id '{commandId}'"));
+            }
+
+            var (stdout, stderr) = bg.ReadNew();
+
+            var filter = GetParameter<string>(parameters, "filter", "");
+            if (!string.IsNullOrEmpty(filter))
+            {
+                try
+                {
+                    var regex = new Regex(filter, RegexOptions.None, TimeSpan.FromSeconds(2));
+                    stdout = FilterLines(stdout, regex);
+                    stderr = FilterLines(stderr, regex);
+                }
+                catch (ArgumentException ex)
+                {
+                    return Task.FromResult(CreateErrorResult($"Invalid filter regular expression: {ex.Message}"));
+                }
+            }
+
+            var status = bg.Status.ToString().ToLowerInvariant();
+
+            var output = new StringBuilder();
+            output.AppendLine($"Command: {bg.Command}");
+            output.AppendLine($"Status: {status}");
+            if (bg.Status != BackgroundCommandStatus.Running && bg.ExitCode.HasValue)
+            {
+                output.AppendLine($"Exit Code: {bg.ExitCode.Value}");
+            }
+            output.AppendLine();
+
+            if (!string.IsNullOrWhiteSpace(stdout))
+            {
+                output.AppendLine("=== New Standard Output ===");
+                output.AppendLine(stdout.TrimEnd());
+            }
+
+            if (!string.IsNullOrWhiteSpace(stderr))
+            {
+                output.AppendLine("=== New Standard Error ===");
+                output.AppendLine(stderr.TrimEnd());
+            }
+
+            if (string.IsNullOrWhiteSpace(stdout) && string.IsNullOrWhiteSpace(stderr))
+            {
+                output.AppendLine("(no new output)");
+            }
+
+            return Task.FromResult(CreateSuccessResult(
+                new Dictionary<string, object>
+                {
+                    ["command_id"] = commandId,
+                    ["status"] = status,
+                    ["exit_code"] = bg.ExitCode as object ?? "",
+                    ["stdout"] = stdout,
+                    ["stderr"] = stderr
+                },
+                output.ToString()));
+        }
+
+        private static string FilterLines(string text, Regex regex)
+        {
+            if (string.IsNullOrEmpty(text))
+                return text;
+
+            var matched = text
+                .Split('\n')
+                .Where(line => regex.IsMatch(line));
+
+            return string.Join("\n", matched);
+        }
+    }
+}

--- a/Tools/KillCommandTool.cs
+++ b/Tools/KillCommandTool.cs
@@ -51,17 +51,19 @@ Terminates the process and its child process tree. Use this to shut down dev ser
                 return Task.FromResult(CreateErrorResult($"No background command with id '{commandId}'"));
             }
 
-            if (bg.Status != BackgroundCommandStatus.Running)
+            // Claim the killed state before terminating: killing the process fires its own
+            // Exited event, which would otherwise race us and report 'exited' instead of 'killed'.
+            if (!bg.MarkKilled())
             {
+                var current = bg.Status.ToString().ToLowerInvariant();
                 return Task.FromResult(CreateSuccessResult(
-                    new Dictionary<string, object> { ["command_id"] = commandId, ["status"] = bg.Status.ToString().ToLowerInvariant() },
-                    $"Command '{commandId}' is already {bg.Status.ToString().ToLowerInvariant()}."));
+                    new Dictionary<string, object> { ["command_id"] = commandId, ["status"] = current },
+                    $"Command '{commandId}' is already {current}."));
             }
 
             try
             {
                 bg.Process.Kill(entireProcessTree: true);
-                bg.Status = BackgroundCommandStatus.Killed;
             }
             catch (Exception ex)
             {

--- a/Tools/KillCommandTool.cs
+++ b/Tools/KillCommandTool.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Saturn.Tools.Core;
+
+namespace Saturn.Tools
+{
+    public class KillCommandTool : ToolBase
+    {
+        public override string Name => "kill_command";
+
+        public override string Description => @"Stop a command started with execute_command (run_in_background: true).
+
+Terminates the process and its child process tree. Use this to shut down dev servers, watchers, or any background command you no longer need.";
+
+        protected override Dictionary<string, object> GetParameterProperties()
+        {
+            return new Dictionary<string, object>
+            {
+                { "command_id", new Dictionary<string, object>
+                    {
+                        { "type", "string" },
+                        { "description", "The command_id returned by execute_command when it was started in the background" }
+                    }
+                }
+            };
+        }
+
+        protected override string[] GetRequiredParameters()
+        {
+            return new[] { "command_id" };
+        }
+
+        public override string GetDisplaySummary(Dictionary<string, object> parameters)
+        {
+            var id = GetParameter<string>(parameters, "command_id", "");
+            return $"Killing {id}";
+        }
+
+        public override Task<ToolResult> ExecuteAsync(Dictionary<string, object> parameters)
+        {
+            var commandId = GetParameter<string>(parameters, "command_id");
+            if (string.IsNullOrWhiteSpace(commandId))
+            {
+                return Task.FromResult(CreateErrorResult("command_id parameter is required"));
+            }
+
+            var bg = BackgroundCommandManager.Instance.Get(commandId);
+            if (bg == null)
+            {
+                return Task.FromResult(CreateErrorResult($"No background command with id '{commandId}'"));
+            }
+
+            if (bg.Status != BackgroundCommandStatus.Running)
+            {
+                return Task.FromResult(CreateSuccessResult(
+                    new Dictionary<string, object> { ["command_id"] = commandId, ["status"] = bg.Status.ToString().ToLowerInvariant() },
+                    $"Command '{commandId}' is already {bg.Status.ToString().ToLowerInvariant()}."));
+            }
+
+            try
+            {
+                bg.Process.Kill(entireProcessTree: true);
+                bg.Status = BackgroundCommandStatus.Killed;
+            }
+            catch (Exception ex)
+            {
+                return Task.FromResult(CreateErrorResult($"Failed to kill command '{commandId}': {ex.Message}"));
+            }
+
+            return Task.FromResult(CreateSuccessResult(
+                new Dictionary<string, object> { ["command_id"] = commandId, ["status"] = "killed" },
+                $"Command '{commandId}' was killed."));
+        }
+    }
+}

--- a/Tools/Objects/CommandExecutorConfig.cs
+++ b/Tools/Objects/CommandExecutorConfig.cs
@@ -5,7 +5,7 @@ namespace Saturn.Tools.Objects
     public class CommandExecutorConfig
     {
         public SecurityMode SecurityMode { get; set; } = SecurityMode.Unrestricted;
-        public int DefaultTimeout { get; set; } = 30;
+        public int DefaultTimeout { get; set; } = 120;
         public bool EnableHistory { get; set; } = true;
         public int MaxHistorySize { get; set; } = 100;
         public Func<string, CommandValidationResult>? CustomValidator { get; set; }

--- a/Tools/Objects/CommandResult.cs
+++ b/Tools/Objects/CommandResult.cs
@@ -10,5 +10,6 @@ namespace Saturn.Tools.Objects
         public TimeSpan Duration { get; set; }
         public string Command { get; set; } = string.Empty;
         public string WorkingDirectory { get; set; } = string.Empty;
+        public bool TimedOut { get; set; }
     }
 }


### PR DESCRIPTION
Adds run_in_background to execute_command so long-lived processes return a command_id right away. New get_command_output polls incremental output with status and exit code, and kill_command stops the process tree.

Also fixes execute_command to return partial output on timeout instead of throwing it away, keep the start and end of oversized output, and default to a 120s timeout.

Covered by cross-platform tests for the timeout, background, and kill paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Run commands in the background and receive a command ID for tracking.
  * View incremental command output, optionally filtered by a regular expression.
  * Stop running background commands, including their child processes.
* **Improvements**
  * Command timeouts now return partial output instead of throwing an error.
  * Default command timeout increased to two minutes.
  * Large outputs are captured more effectively and displayed with concise truncation.
* **Tests**
  * Added coverage for background execution, polling, termination, timeouts, and invalid command IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->