### PR TITLE
Address CodeRabbit review on background command lifecycle

### DIFF
--- a/Saturn.Tests/Tools/ExecuteCommandToolTests.cs
+++ b/Saturn.Tests/Tools/ExecuteCommandToolTests.cs
@@ -76,6 +76,7 @@ namespace Saturn.Tests.Tools
         {
             var tool = NewTool();
             var kill = new KillCommandTool();
+            var getOutput = new GetCommandOutputTool();
 
             var start = await tool.ExecuteAsync(new Dictionary<string, object>
             {
@@ -83,6 +84,7 @@ namespace Saturn.Tests.Tools
                 ["run_in_background"] = true
             });
 
+            start.Success.Should().BeTrue();
             var commandId = (string)((Dictionary<string, object>)start.RawData!)["command_id"];
 
             var killResult = await kill.ExecuteAsync(new Dictionary<string, object> { ["command_id"] = commandId });
@@ -90,6 +92,11 @@ namespace Saturn.Tests.Tools
             killResult.Success.Should().BeTrue();
             var killData = (Dictionary<string, object>)killResult.RawData!;
             ((string)killData["status"]).Should().Be("killed");
+
+            // The killed state must survive the race with the process exit handler.
+            var poll = await getOutput.ExecuteAsync(new Dictionary<string, object> { ["command_id"] = commandId });
+            var pollData = (Dictionary<string, object>)poll.RawData!;
+            ((string)pollData["status"]).Should().Be("killed");
         }
 
         [Fact]

--- a/Tools/Core/BackgroundCommandManager.cs
+++ b/Tools/Core/BackgroundCommandManager.cs
@@ -71,6 +71,32 @@ namespace Saturn.Tools.Core
             }
         }
 
+        /// <summary>
+        /// Undoes a <see cref="MarkKilled"/> claim when termination could not be carried out,
+        /// reconciling with the process's actual state so the command is not stuck as 'killed'.
+        /// </summary>
+        public void RevertKill()
+        {
+            lock (_lock)
+            {
+                if (_status != BackgroundCommandStatus.Killed)
+                    return;
+
+                bool exited;
+                try { exited = Process != null && Process.HasExited; } catch { exited = false; }
+
+                if (exited)
+                {
+                    _status = BackgroundCommandStatus.Exited;
+                    try { ExitCode = Process!.ExitCode; } catch { }
+                }
+                else
+                {
+                    _status = BackgroundCommandStatus.Running;
+                }
+            }
+        }
+
         public void AppendStdout(string line)
         {
             lock (_lock) Append(_stdout, ref _stdoutCursor, line);
@@ -130,7 +156,30 @@ namespace Saturn.Tools.Core
         private readonly ConcurrentDictionary<string, BackgroundCommand> _commands = new();
         private int _counter;
 
-        private BackgroundCommandManager() { }
+        private BackgroundCommandManager()
+        {
+            // Ensure background children don't outlive the host process.
+            AppDomain.CurrentDomain.ProcessExit += (_, _) => Shutdown();
+        }
+
+        /// <summary>Terminates and disposes every tracked command, including running ones.</summary>
+        public void Shutdown()
+        {
+            foreach (var cmd in _commands.Values)
+            {
+                try
+                {
+                    if (cmd.MarkKilled())
+                        cmd.Process.Kill(entireProcessTree: true);
+                }
+                catch { }
+            }
+
+            foreach (var id in _commands.Keys.ToList())
+            {
+                Remove(id);
+            }
+        }
 
         public BackgroundCommand Register(string command, string workingDirectory, Process process)
         {

--- a/Tools/ExecuteCommandTool.cs
+++ b/Tools/ExecuteCommandTool.cs
@@ -311,8 +311,9 @@ Prefer the dedicated file tools (read_file, write_file, grep, glob, list_files) 
             }
             catch
             {
-                // The process never started, so drop the registration instead of leaving a
-                // phantom entry stuck in the 'running' state forever.
+                // Start() may have succeeded before BeginOutputReadLine threw; disposing the wrapper
+                // would not stop the OS process, so terminate it first, then drop the registration.
+                try { process.Kill(entireProcessTree: true); } catch { }
                 BackgroundCommandManager.Instance.Remove(bg.Id);
                 throw;
             }

--- a/Tools/GetCommandOutputTool.cs
+++ b/Tools/GetCommandOutputTool.cs
@@ -60,21 +60,28 @@ Returns only the output generated since the last call for that command_id, along
                 return Task.FromResult(CreateErrorResult($"No background command with id '{commandId}'"));
             }
 
-            var (stdout, stderr) = bg.ReadNew();
-
+            // Compile the filter before draining output: ReadNew advances the cursor, so a bad
+            // regex must fail before we consume (and lose) this poll's output.
+            Regex? filterRegex = null;
             var filter = GetParameter<string>(parameters, "filter", "");
             if (!string.IsNullOrEmpty(filter))
             {
                 try
                 {
-                    var regex = new Regex(filter, RegexOptions.None, TimeSpan.FromSeconds(2));
-                    stdout = FilterLines(stdout, regex);
-                    stderr = FilterLines(stderr, regex);
+                    filterRegex = new Regex(filter, RegexOptions.None, TimeSpan.FromSeconds(2));
                 }
                 catch (ArgumentException ex)
                 {
                     return Task.FromResult(CreateErrorResult($"Invalid filter regular expression: {ex.Message}"));
                 }
+            }
+
+            var (stdout, stderr) = bg.ReadNew();
+
+            if (filterRegex != null)
+            {
+                stdout = FilterLines(stdout, filterRegex);
+                stderr = FilterLines(stderr, filterRegex);
             }
 
             var status = bg.Status.ToString().ToLowerInvariant();

--- a/Tools/KillCommandTool.cs
+++ b/Tools/KillCommandTool.cs
@@ -67,6 +67,9 @@ Terminates the process and its child process tree. Use this to shut down dev ser
             }
             catch (Exception ex)
             {
+                // Termination failed, so don't leave the command falsely marked as killed:
+                // reconcile with the process's real state (exited or still running).
+                bg.RevertKill();
                 return Task.FromResult(CreateErrorResult($"Failed to kill command '{commandId}': {ex.Message}"));
             }
 


### PR DESCRIPTION
Follow-up to #23, which merged before these review fixes landed.

Validate the output filter regex before draining a poll so a bad pattern no longer discards that read. Kill the OS process, not just the wrapper, when background setup throws after start. Roll back the killed state if Kill fails so a command is never falsely reported killed. Add a manager shutdown that stops tracked commands on process exit, and assert the killed state persists.