### PR TITLE
Add session-scoped todo tracking with update_todos

### DIFF
--- a/Agents/Core/AgentBase.cs
+++ b/Agents/Core/AgentBase.cs
@@ -489,6 +489,7 @@ namespace Saturn.Agents.Core
                             {
                                 Configuration = Configuration,
                                 AgentInstanceId = Id,
+                                SessionId = CurrentSessionId,
                                 ManagerAgentId = ManagerAgentId,
                                 AgentName = Name,
                                 IsOrchestrator = IsOrchestrator

--- a/Agents/Core/Mode.cs
+++ b/Agents/Core/Mode.cs
@@ -59,7 +59,8 @@ namespace Saturn.Agents.Core
                     "write_file", "search_and_replace", "delete_file",
                     "create_agent", "hand_off_to_agent", "get_agent_status", 
                     "wait_for_agent", "get_task_result", "terminate_agent", "execute_command",
-                    "get_command_output", "kill_command", "web_fetch"
+                    "get_command_output", "kill_command", "web_fetch",
+                    "update_todos"
                 },
                 SystemPromptOverride = null,
                 Model = "anthropic/claude-sonnet-4",

--- a/Data/ChatHistoryRepository.cs
+++ b/Data/ChatHistoryRepository.cs
@@ -95,6 +95,13 @@ public class ChatHistoryRepository : IDisposable
                 FOREIGN KEY (SessionId) REFERENCES ChatSessions(Id)
             )";
 
+        var createSessionTodosTable = @"
+            CREATE TABLE IF NOT EXISTS SessionTodos (
+                SessionId TEXT PRIMARY KEY,
+                TodosJson TEXT NOT NULL,
+                UpdatedAt TEXT NOT NULL
+            )";
+
         var createIndices = @"
             CREATE INDEX IF NOT EXISTS idx_messages_session ON ChatMessages(SessionId);
             CREATE INDEX IF NOT EXISTS idx_messages_timestamp ON ChatMessages(Timestamp);
@@ -108,6 +115,8 @@ public class ChatHistoryRepository : IDisposable
         using (var cmd = new SqliteCommand(createMessagesTable, connection))
             cmd.ExecuteNonQuery();
         using (var cmd = new SqliteCommand(createToolCallsTable, connection))
+            cmd.ExecuteNonQuery();
+        using (var cmd = new SqliteCommand(createSessionTodosTable, connection))
             cmd.ExecuteNonQuery();
         using (var cmd = new SqliteCommand(createIndices, connection))
             cmd.ExecuteNonQuery();
@@ -611,6 +620,52 @@ public class ChatHistoryRepository : IDisposable
             cmd.Parameters.AddWithValue("@Id", sessionId);
 
             await cmd.ExecuteNonQueryAsync();
+        });
+    }
+
+    public async Task SaveSessionTodosAsync(string sessionId, string? todosJson)
+    {
+        await WithDbLockAsync(async () =>
+        {
+            using var connection = CreateConnection();
+
+            if (string.IsNullOrEmpty(todosJson))
+            {
+                var deleteSql = "DELETE FROM SessionTodos WHERE SessionId = @SessionId";
+                using var deleteCmd = new SqliteCommand(deleteSql, connection);
+                deleteCmd.Parameters.AddWithValue("@SessionId", sessionId);
+                await deleteCmd.ExecuteNonQueryAsync();
+                return;
+            }
+
+            var sql = @"
+                INSERT INTO SessionTodos (SessionId, TodosJson, UpdatedAt)
+                VALUES (@SessionId, @TodosJson, @UpdatedAt)
+                ON CONFLICT(SessionId) DO UPDATE SET
+                    TodosJson = @TodosJson,
+                    UpdatedAt = @UpdatedAt";
+
+            using var cmd = new SqliteCommand(sql, connection);
+            cmd.Parameters.AddWithValue("@SessionId", sessionId);
+            cmd.Parameters.AddWithValue("@TodosJson", todosJson);
+            cmd.Parameters.AddWithValue("@UpdatedAt", DateTime.UtcNow.ToString("O"));
+
+            await cmd.ExecuteNonQueryAsync();
+        });
+    }
+
+    public async Task<string?> GetSessionTodosAsync(string sessionId)
+    {
+        return await WithReadLockAsync(async () =>
+        {
+            using var connection = CreateConnection();
+
+            var sql = "SELECT TodosJson FROM SessionTodos WHERE SessionId = @SessionId";
+            using var cmd = new SqliteCommand(sql, connection);
+            cmd.Parameters.AddWithValue("@SessionId", sessionId);
+
+            var result = await cmd.ExecuteScalarAsync();
+            return result as string;
         });
     }
 

--- a/Program.cs
+++ b/Program.cs
@@ -230,6 +230,8 @@ Operating Principles
 
 2) Planning
    - Make a brief plan before edits or commands. Keep the plan to 3–7 bullets.
+   - Track multi-step work with update_todos: write the step list up front, keep exactly one item in_progress, and mark steps completed immediately.
+   - The update_todos list is your private, session-scoped scratchpad; use the task tools for the user's durable todo lists.
    - Identify opportunities for parallel execution with sub-agents.
    - Track delegated work to avoid duplication - mark tasks as delegated.
    - If requirements are ambiguous, ask targeted clarifying questions.
@@ -284,17 +286,19 @@ Operating Principles
                     "wait_for_agent", "get_task_result", "terminate_agent", "execute_command",
                     "get_command_output", "kill_command", "web_fetch",
                     "list_tasks", "create_task", "update_task", "complete_task",
-                    "wait_for_task", "claim_task", "dispatch_task", "list_due_tasks"
+                    "wait_for_task", "claim_task", "dispatch_task", "list_due_tasks",
+                    "update_todos"
                 },
             };
 
-            // Persisted configs predate the task system; backfill only those
-            // tools. Re-adding the full default set would silently restore
-            // tools the user deliberately removed (e.g. execute_command).
-            var taskSystemTools = new[]
+            // Persisted configs predate newer tools; backfill only those.
+            // Re-adding the full default set would silently restore tools
+            // the user deliberately removed (e.g. execute_command).
+            var backfillTools = new[]
             {
                 "list_tasks", "create_task", "update_task", "complete_task",
-                "wait_for_task", "claim_task", "dispatch_task", "list_due_tasks"
+                "wait_for_task", "claim_task", "dispatch_task", "list_due_tasks",
+                "update_todos"
             };
 
             if (persistedConfig != null)
@@ -304,7 +308,7 @@ Operating Principles
                 agentConfig.Model = model;
 
                 agentConfig.ToolNames = agentConfig.ToolNames
-                    .Union(taskSystemTools, StringComparer.OrdinalIgnoreCase)
+                    .Union(backfillTools, StringComparer.OrdinalIgnoreCase)
                     .ToList();
             }
             else

--- a/Saturn.Tests/Data/SessionTodosRepositoryTests.cs
+++ b/Saturn.Tests/Data/SessionTodosRepositoryTests.cs
@@ -1,0 +1,80 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Saturn.Data;
+using Xunit;
+
+namespace Saturn.Tests.Data
+{
+    public class SessionTodosRepositoryTests : IDisposable
+    {
+        private readonly string _workspace;
+
+        public SessionTodosRepositoryTests()
+        {
+            _workspace = Path.Combine(Path.GetTempPath(), $"SaturnTodosTest_{Guid.NewGuid():N}");
+            Directory.CreateDirectory(_workspace);
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(_workspace, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+
+        [Fact]
+        public async Task SaveAndGet_RoundTripsAcrossRepositoryInstances()
+        {
+            var sessionId = Guid.NewGuid().ToString();
+            var json = "[{\"content\":\"Step one\",\"status\":\"in_progress\"}]";
+
+            using (var repository = new ChatHistoryRepository(_workspace))
+            {
+                await repository.SaveSessionTodosAsync(sessionId, json);
+            }
+
+            using var fresh = new ChatHistoryRepository(_workspace);
+            var loaded = await fresh.GetSessionTodosAsync(sessionId);
+
+            loaded.Should().Be(json);
+        }
+
+        [Fact]
+        public async Task Save_Twice_OverwritesExistingRow()
+        {
+            var sessionId = Guid.NewGuid().ToString();
+            using var repository = new ChatHistoryRepository(_workspace);
+
+            await repository.SaveSessionTodosAsync(sessionId, "[\"old\"]");
+            await repository.SaveSessionTodosAsync(sessionId, "[\"new\"]");
+
+            (await repository.GetSessionTodosAsync(sessionId)).Should().Be("[\"new\"]");
+        }
+
+        [Fact]
+        public async Task Save_WithNullJson_DeletesRow()
+        {
+            var sessionId = Guid.NewGuid().ToString();
+            using var repository = new ChatHistoryRepository(_workspace);
+
+            await repository.SaveSessionTodosAsync(sessionId, "[\"data\"]");
+            await repository.SaveSessionTodosAsync(sessionId, null);
+
+            (await repository.GetSessionTodosAsync(sessionId)).Should().BeNull();
+        }
+
+        [Fact]
+        public async Task Get_ForUnknownSession_ReturnsNull()
+        {
+            using var repository = new ChatHistoryRepository(_workspace);
+
+            (await repository.GetSessionTodosAsync(Guid.NewGuid().ToString())).Should().BeNull();
+        }
+    }
+}

--- a/Saturn.Tests/Tools/UpdateTodosToolTests.cs
+++ b/Saturn.Tests/Tools/UpdateTodosToolTests.cs
@@ -18,7 +18,7 @@ namespace Saturn.Tests.Tools
             AgentContext.Current = null;
         }
 
-        private static void SetSession(string? sessionId)
+        private static void SetSession(string? sessionId, string agentInstanceId = "")
         {
             AgentContext.Current = new AgentExecutionContext
             {
@@ -29,6 +29,7 @@ namespace Saturn.Tests.Tools
                     ClientSource = new FakeClientSource()
                 },
                 AgentName = "TestAgent",
+                AgentInstanceId = agentInstanceId,
                 SessionId = sessionId
             };
         }
@@ -190,10 +191,49 @@ namespace Saturn.Tests.Tools
             var result = await tool.ExecuteAsync(Params(Item("Contextless step", "pending")));
 
             result.Success.Should().BeTrue();
+            result.FormattedOutput.Should().NotContain("Warning");
             TodoStore.CurrentKey().Should().Be(TodoStore.NoSessionKey);
             (await TodoStore.GetAsync(TodoStore.NoSessionKey)).Should().Contain(t => t.Content == "Contextless step");
 
             await TodoStore.SetAsync(TodoStore.NoSessionKey, Array.Empty<TodoItem>());
+        }
+
+        [Fact]
+        public async Task Execute_SessionlessAgents_DoNotShareLists()
+        {
+            var agentA = $"agent-a-{Guid.NewGuid():N}";
+            var agentB = $"agent-b-{Guid.NewGuid():N}";
+            var tool = new UpdateTodosTool();
+
+            SetSession(null, agentA);
+            var keyA = TodoStore.CurrentKey();
+            await tool.ExecuteAsync(Params(Item("Agent A step", "pending")));
+
+            SetSession(null, agentB);
+            var keyB = TodoStore.CurrentKey();
+            await tool.ExecuteAsync(Params(Item("Agent B step", "pending")));
+
+            keyA.Should().NotBe(keyB);
+            keyA.Should().NotBe(TodoStore.NoSessionKey);
+            (await TodoStore.GetAsync(keyA)).Single().Content.Should().Be("Agent A step");
+            (await TodoStore.GetAsync(keyB)).Single().Content.Should().Be("Agent B step");
+        }
+
+        [Fact]
+        public async Task Cache_EvictsLeastRecentlyUsedEntriesOverCap()
+        {
+            var prefix = $"evict-{Guid.NewGuid():N}";
+            var oldestKey = $"(agent:{prefix}-0)";
+            var items = new[] { new TodoItem("Step", TodoStatus.Pending) };
+
+            await TodoStore.SetAsync(oldestKey, items);
+            for (var i = 1; i <= 300; i++)
+            {
+                await TodoStore.SetAsync($"(agent:{prefix}-{i})", items);
+            }
+
+            (await TodoStore.GetAsync(oldestKey)).Should().BeEmpty();
+            (await TodoStore.GetAsync($"(agent:{prefix}-300)")).Should().HaveCount(1);
         }
 
         [Fact]

--- a/Saturn.Tests/Tools/UpdateTodosToolTests.cs
+++ b/Saturn.Tests/Tools/UpdateTodosToolTests.cs
@@ -1,0 +1,221 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Saturn.Agents.Core;
+using Saturn.Tests.Approvals;
+using Saturn.Tools.Core;
+using Saturn.Tools.Todo;
+using Xunit;
+
+namespace Saturn.Tests.Tools
+{
+    public class UpdateTodosToolTests : IDisposable
+    {
+        public void Dispose()
+        {
+            AgentContext.Current = null;
+        }
+
+        private static void SetSession(string? sessionId)
+        {
+            AgentContext.Current = new AgentExecutionContext
+            {
+                Configuration = new AgentConfiguration
+                {
+                    Name = "TestAgent",
+                    SystemPrompt = "test",
+                    ClientSource = new FakeClientSource()
+                },
+                AgentName = "TestAgent",
+                SessionId = sessionId
+            };
+        }
+
+        private static Dictionary<string, object> Item(string content, string status)
+        {
+            return new Dictionary<string, object>
+            {
+                { "content", content },
+                { "status", status }
+            };
+        }
+
+        private static Dictionary<string, object> Params(params object[] items)
+        {
+            return new Dictionary<string, object>
+            {
+                { "todos", new List<object>(items) }
+            };
+        }
+
+        [Fact]
+        public async Task Execute_WithValidList_ReturnsChecklist()
+        {
+            SetSession($"session-{Guid.NewGuid():N}");
+            var tool = new UpdateTodosTool();
+
+            var result = await tool.ExecuteAsync(Params(
+                Item("Explore the codebase", "completed"),
+                Item("Implement the tool", "in_progress"),
+                Item("Add tests", "pending")));
+
+            result.Success.Should().BeTrue();
+            result.FormattedOutput.Should().Contain("3 items: 1 completed, 1 in progress, 1 pending");
+            result.FormattedOutput.Should().Contain("[x] Explore the codebase");
+            result.FormattedOutput.Should().Contain("[~] Implement the tool");
+            result.FormattedOutput.Should().Contain("[ ] Add tests");
+        }
+
+        [Fact]
+        public async Task Execute_WithEmptyArray_ClearsList()
+        {
+            var key = $"session-{Guid.NewGuid():N}";
+            SetSession(key);
+            var tool = new UpdateTodosTool();
+
+            await tool.ExecuteAsync(Params(Item("Step one", "pending")));
+            var result = await tool.ExecuteAsync(Params());
+
+            result.Success.Should().BeTrue();
+            result.FormattedOutput.Should().Be("Todo list cleared.");
+            (await TodoStore.GetAsync(key)).Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task Execute_WithEmptyContent_ReturnsErrorNamingIndex()
+        {
+            SetSession($"session-{Guid.NewGuid():N}");
+            var tool = new UpdateTodosTool();
+
+            var result = await tool.ExecuteAsync(Params(
+                Item("Valid step", "pending"),
+                Item("", "pending")));
+
+            result.Success.Should().BeFalse();
+            result.Error.Should().Contain("todos[1].content");
+        }
+
+        [Fact]
+        public async Task Execute_WithInvalidStatus_ReturnsErrorListingValidValues()
+        {
+            SetSession($"session-{Guid.NewGuid():N}");
+            var tool = new UpdateTodosTool();
+
+            var result = await tool.ExecuteAsync(Params(Item("Step", "done")));
+
+            result.Success.Should().BeFalse();
+            result.Error.Should().Contain("pending, in_progress, completed");
+        }
+
+        [Fact]
+        public async Task Execute_WithTwoInProgressItems_ReturnsError()
+        {
+            SetSession($"session-{Guid.NewGuid():N}");
+            var tool = new UpdateTodosTool();
+
+            var result = await tool.ExecuteAsync(Params(
+                Item("First", "in_progress"),
+                Item("Second", "in_progress")));
+
+            result.Success.Should().BeFalse();
+            result.Error.Should().Contain("Only one item may be in_progress");
+        }
+
+        [Fact]
+        public async Task Execute_WithNonObjectItem_ReturnsError()
+        {
+            SetSession($"session-{Guid.NewGuid():N}");
+            var tool = new UpdateTodosTool();
+
+            var result = await tool.ExecuteAsync(Params("just a string"));
+
+            result.Success.Should().BeFalse();
+            result.Error.Should().Contain("todos[0]");
+        }
+
+        [Fact]
+        public async Task Execute_WithTooManyItems_ReturnsError()
+        {
+            SetSession($"session-{Guid.NewGuid():N}");
+            var tool = new UpdateTodosTool();
+            var items = Enumerable.Range(0, 51).Select(i => (object)Item($"Step {i}", "pending")).ToArray();
+
+            var result = await tool.ExecuteAsync(Params(items));
+
+            result.Success.Should().BeFalse();
+            result.Error.Should().Contain("at most 50");
+        }
+
+        [Fact]
+        public async Task Execute_SecondCall_ReplacesEntireList()
+        {
+            var key = $"session-{Guid.NewGuid():N}";
+            SetSession(key);
+            var tool = new UpdateTodosTool();
+
+            await tool.ExecuteAsync(Params(Item("Old step", "pending")));
+            await tool.ExecuteAsync(Params(Item("New step", "in_progress")));
+
+            var todos = await TodoStore.GetAsync(key);
+            todos.Should().HaveCount(1);
+            todos[0].Content.Should().Be("New step");
+            todos[0].Status.Should().Be(TodoStatus.InProgress);
+        }
+
+        [Fact]
+        public async Task Execute_DifferentSessions_KeepIndependentLists()
+        {
+            var keyA = $"session-{Guid.NewGuid():N}";
+            var keyB = $"session-{Guid.NewGuid():N}";
+            var tool = new UpdateTodosTool();
+
+            SetSession(keyA);
+            await tool.ExecuteAsync(Params(Item("Session A step", "pending")));
+
+            SetSession(keyB);
+            await tool.ExecuteAsync(Params(Item("Session B step", "pending")));
+
+            (await TodoStore.GetAsync(keyA)).Single().Content.Should().Be("Session A step");
+            (await TodoStore.GetAsync(keyB)).Single().Content.Should().Be("Session B step");
+        }
+
+        [Fact]
+        public async Task Execute_WithoutSession_UsesFallbackKey()
+        {
+            AgentContext.Current = null;
+            var tool = new UpdateTodosTool();
+
+            var result = await tool.ExecuteAsync(Params(Item("Contextless step", "pending")));
+
+            result.Success.Should().BeTrue();
+            TodoStore.CurrentKey().Should().Be(TodoStore.NoSessionKey);
+            (await TodoStore.GetAsync(TodoStore.NoSessionKey)).Should().Contain(t => t.Content == "Contextless step");
+
+            await TodoStore.SetAsync(TodoStore.NoSessionKey, Array.Empty<TodoItem>());
+        }
+
+        [Fact]
+        public async Task Execute_WithMissingTodosType_ReturnsError()
+        {
+            SetSession($"session-{Guid.NewGuid():N}");
+            var tool = new UpdateTodosTool();
+
+            var result = await tool.ExecuteAsync(new Dictionary<string, object> { { "todos", "not a list" } });
+
+            result.Success.Should().BeFalse();
+            result.Error.Should().Contain("array");
+        }
+
+        [Fact]
+        public void GetDisplaySummary_ReportsItemCount()
+        {
+            var tool = new UpdateTodosTool();
+
+            tool.GetDisplaySummary(Params(Item("A", "pending"), Item("B", "pending")))
+                .Should().Be("Updating todo list (2 items)");
+            tool.GetDisplaySummary(Params()).Should().Be("Clearing todo list");
+        }
+    }
+}

--- a/Tools/Core/AgentContext.cs
+++ b/Tools/Core/AgentContext.cs
@@ -7,6 +7,7 @@ namespace Saturn.Tools.Core
     {
         public required AgentConfiguration Configuration { get; init; }
         public string AgentInstanceId { get; init; } = "";
+        public string? SessionId { get; init; }
         public string? ManagerAgentId { get; init; }
         public string AgentName { get; init; } = "";
         public bool IsOrchestrator { get; init; }

--- a/Tools/Todo/TodoStore.cs
+++ b/Tools/Todo/TodoStore.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Saturn.Data;
+using Saturn.Tools.Core;
+
+namespace Saturn.Tools.Todo
+{
+    public enum TodoStatus
+    {
+        Pending,
+        InProgress,
+        Completed
+    }
+
+    public sealed record TodoItem(string Content, TodoStatus Status);
+
+    public static class TodoStore
+    {
+        public const string NoSessionKey = "(no-session)";
+
+        private static readonly ConcurrentDictionary<string, IReadOnlyList<TodoItem>> _lists = new();
+
+        // Own repository instance on the shared chats.db; per-agent repositories
+        // already coexist on the same file (WAL + busy_timeout).
+        private static readonly Lazy<ChatHistoryRepository?> _repository = new(() =>
+        {
+            try
+            {
+                return new ChatHistoryRepository();
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"Failed to open todo persistence store: {ex.Message}");
+                return null;
+            }
+        });
+
+        public static string CurrentKey()
+        {
+            var sessionId = AgentContext.Current?.SessionId;
+            return string.IsNullOrEmpty(sessionId) ? NoSessionKey : sessionId;
+        }
+
+        public static async Task<IReadOnlyList<TodoItem>> GetAsync(string key)
+        {
+            if (_lists.TryGetValue(key, out var cached))
+            {
+                return cached;
+            }
+
+            if (key != NoSessionKey && _repository.Value != null)
+            {
+                try
+                {
+                    var json = await _repository.Value.GetSessionTodosAsync(key);
+                    if (!string.IsNullOrEmpty(json))
+                    {
+                        var items = Deserialize(json);
+                        _lists[key] = items;
+                        return items;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine($"Failed to load todos for session {key}: {ex.Message}");
+                }
+            }
+
+            return Array.Empty<TodoItem>();
+        }
+
+        public static async Task SetAsync(string key, IReadOnlyList<TodoItem> items)
+        {
+            if (items.Count == 0)
+            {
+                _lists.TryRemove(key, out _);
+            }
+            else
+            {
+                _lists[key] = items;
+            }
+
+            if (key == NoSessionKey || _repository.Value == null)
+            {
+                return;
+            }
+
+            try
+            {
+                await _repository.Value.SaveSessionTodosAsync(key, items.Count == 0 ? null : Serialize(items));
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"Failed to persist todos for session {key}: {ex.Message}");
+            }
+        }
+
+        public static string StatusToString(TodoStatus status) => status switch
+        {
+            TodoStatus.InProgress => "in_progress",
+            TodoStatus.Completed => "completed",
+            _ => "pending"
+        };
+
+        public static bool TryParseStatus(string? value, out TodoStatus status)
+        {
+            switch (value)
+            {
+                case "pending":
+                    status = TodoStatus.Pending;
+                    return true;
+                case "in_progress":
+                    status = TodoStatus.InProgress;
+                    return true;
+                case "completed":
+                    status = TodoStatus.Completed;
+                    return true;
+                default:
+                    status = TodoStatus.Pending;
+                    return false;
+            }
+        }
+
+        private sealed record TodoItemDto(string content, string status);
+
+        private static string Serialize(IReadOnlyList<TodoItem> items)
+        {
+            var dtos = items.Select(i => new TodoItemDto(i.Content, StatusToString(i.Status))).ToList();
+            return JsonSerializer.Serialize(dtos);
+        }
+
+        private static IReadOnlyList<TodoItem> Deserialize(string json)
+        {
+            var dtos = JsonSerializer.Deserialize<List<TodoItemDto>>(json) ?? new List<TodoItemDto>();
+            return dtos
+                .Where(d => !string.IsNullOrEmpty(d.content))
+                .Select(d => new TodoItem(d.content, TryParseStatus(d.status, out var s) ? s : TodoStatus.Pending))
+                .ToList();
+        }
+    }
+}

--- a/Tools/Todo/TodoStore.cs
+++ b/Tools/Todo/TodoStore.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Saturn.Data;
 using Saturn.Tools.Core;
@@ -22,7 +23,11 @@ namespace Saturn.Tools.Todo
     {
         public const string NoSessionKey = "(no-session)";
 
+        private const int MaxCacheEntries = 256;
+
         private static readonly ConcurrentDictionary<string, IReadOnlyList<TodoItem>> _lists = new();
+        private static readonly ConcurrentDictionary<string, long> _lastAccess = new();
+        private static long _accessCounter;
 
         // Own repository instance on the shared chats.db; per-agent repositories
         // already coexist on the same file (WAL + busy_timeout).
@@ -41,18 +46,33 @@ namespace Saturn.Tools.Todo
 
         public static string CurrentKey()
         {
-            var sessionId = AgentContext.Current?.SessionId;
-            return string.IsNullOrEmpty(sessionId) ? NoSessionKey : sessionId;
+            var context = AgentContext.Current;
+            if (!string.IsNullOrEmpty(context?.SessionId))
+            {
+                return context!.SessionId!;
+            }
+
+            if (!string.IsNullOrEmpty(context?.AgentInstanceId))
+            {
+                return $"(agent:{context!.AgentInstanceId})";
+            }
+
+            return NoSessionKey;
         }
+
+        // Parenthesized keys are agent-instance fallbacks with no session to
+        // persist under; they live in memory only.
+        private static bool IsPersistable(string key) => !key.StartsWith("(");
 
         public static async Task<IReadOnlyList<TodoItem>> GetAsync(string key)
         {
             if (_lists.TryGetValue(key, out var cached))
             {
+                Touch(key);
                 return cached;
             }
 
-            if (key != NoSessionKey && _repository.Value != null)
+            if (IsPersistable(key) && _repository.Value != null)
             {
                 try
                 {
@@ -61,6 +81,8 @@ namespace Saturn.Tools.Todo
                     {
                         var items = Deserialize(json);
                         _lists[key] = items;
+                        Touch(key);
+                        EvictIfOverCap(key);
                         return items;
                     }
                 }
@@ -73,29 +95,74 @@ namespace Saturn.Tools.Todo
             return Array.Empty<TodoItem>();
         }
 
-        public static async Task SetAsync(string key, IReadOnlyList<TodoItem> items)
+        /// <summary>
+        /// Updates the list for the given key. Returns false when the list should
+        /// have been persisted but the write failed, so callers can warn that it
+        /// may not survive a restart.
+        /// </summary>
+        public static async Task<bool> SetAsync(string key, IReadOnlyList<TodoItem> items)
         {
             if (items.Count == 0)
             {
                 _lists.TryRemove(key, out _);
+                _lastAccess.TryRemove(key, out _);
             }
             else
             {
                 _lists[key] = items;
+                Touch(key);
+                EvictIfOverCap(key);
             }
 
-            if (key == NoSessionKey || _repository.Value == null)
+            if (!IsPersistable(key))
             {
-                return;
+                return true;
+            }
+
+            if (_repository.Value == null)
+            {
+                return false;
             }
 
             try
             {
                 await _repository.Value.SaveSessionTodosAsync(key, items.Count == 0 ? null : Serialize(items));
+                return true;
             }
             catch (Exception ex)
             {
                 Console.Error.WriteLine($"Failed to persist todos for session {key}: {ex.Message}");
+                return false;
+            }
+        }
+
+        private static void Touch(string key)
+        {
+            _lastAccess[key] = Interlocked.Increment(ref _accessCounter);
+        }
+
+        // Sessions are unbounded over a long-lived web process; persisted entries
+        // reload from the DB on the next access, so evicting them only costs a read.
+        // Non-persistable entries can be lost, which is acceptable for the rare
+        // sessionless caller once the cache holds hundreds of lists.
+        private static void EvictIfOverCap(string currentKey)
+        {
+            if (_lists.Count <= MaxCacheEntries)
+            {
+                return;
+            }
+
+            var evictable = _lastAccess
+                .Where(kv => kv.Key != currentKey)
+                .OrderBy(kv => kv.Value)
+                .Select(kv => kv.Key)
+                .Take(_lists.Count - MaxCacheEntries)
+                .ToList();
+
+            foreach (var key in evictable)
+            {
+                _lists.TryRemove(key, out _);
+                _lastAccess.TryRemove(key, out _);
             }
         }
 

--- a/Tools/Todo/UpdateTodosTool.cs
+++ b/Tools/Todo/UpdateTodosTool.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Saturn.Tools.Core;
+
+namespace Saturn.Tools.Todo
+{
+    public class UpdateTodosTool : ToolBase
+    {
+        private const int MaxItems = 50;
+
+        public override string Name => "update_todos";
+
+        public override string Description => @"Use this tool to track your plan for the current task as a todo checklist. It is scoped to this chat session, persists across restarts with it, and is not shown to other agents.
+
+When to use:
+- At the start of any multi-step task: write out the full step list
+- After finishing a step: mark it completed and move to the next
+- When the plan changes: rewrite the list to match reality
+
+How to use:
+- Send the COMPLETE list every call; it replaces the previous list entirely
+- Each item has 'content' (imperative description) and 'status' (pending, in_progress, or completed)
+- Keep at most one item in_progress at a time
+- Mark items completed as soon as they are done, not in batches
+- An empty array clears the list
+
+Important rules:
+- This list is your private scratchpad for plan tracking. For durable, user-visible task boards use the task tools (create_task, list_tasks, ...) instead.";
+
+        protected override Dictionary<string, object> GetParameterProperties()
+        {
+            return new Dictionary<string, object>
+            {
+                { "todos", new Dictionary<string, object>
+                    {
+                        { "type", "array" },
+                        { "description", "The complete todo list. Replaces the previous list. An empty array clears the list" },
+                        { "items", new Dictionary<string, object>
+                            {
+                                { "type", "object" },
+                                { "properties", new Dictionary<string, object>
+                                    {
+                                        { "content", new Dictionary<string, object>
+                                            {
+                                                { "type", "string" },
+                                                { "description", "Imperative description of the step, e.g. 'Add tests for the parser'" }
+                                            }
+                                        },
+                                        { "status", new Dictionary<string, object>
+                                            {
+                                                { "type", "string" },
+                                                { "enum", new[] { "pending", "in_progress", "completed" } },
+                                                { "description", "Current state of this step" }
+                                            }
+                                        }
+                                    }
+                                },
+                                { "required", new[] { "content", "status" } }
+                            }
+                        }
+                    }
+                }
+            };
+        }
+
+        protected override string[] GetRequiredParameters()
+        {
+            return new[] { "todos" };
+        }
+
+        public override string GetDisplaySummary(Dictionary<string, object> parameters)
+        {
+            if (parameters.TryGetValue("todos", out var value) && value is List<object> list)
+            {
+                return list.Count == 0
+                    ? "Clearing todo list"
+                    : $"Updating todo list ({list.Count} item{(list.Count == 1 ? "" : "s")})";
+            }
+
+            return "Updating todo list";
+        }
+
+        public override async Task<ToolResult> ExecuteAsync(Dictionary<string, object> parameters)
+        {
+            if (!parameters.TryGetValue("todos", out var rawTodos) || rawTodos is not List<object> rawList)
+            {
+                return CreateErrorResult("todos must be an array of {content, status} objects");
+            }
+
+            if (rawList.Count > MaxItems)
+            {
+                return CreateErrorResult($"Too many todos ({rawList.Count}); keep the list to at most {MaxItems} items");
+            }
+
+            var items = new List<TodoItem>(rawList.Count);
+            var inProgressCount = 0;
+
+            for (var i = 0; i < rawList.Count; i++)
+            {
+                if (rawList[i] is not Dictionary<string, object> item)
+                {
+                    return CreateErrorResult($"todos[{i}] must be an object with 'content' and 'status'");
+                }
+
+                item.TryGetValue("content", out var contentValue);
+                var content = contentValue as string;
+                if (string.IsNullOrWhiteSpace(content))
+                {
+                    return CreateErrorResult($"todos[{i}].content must be a non-empty string");
+                }
+
+                item.TryGetValue("status", out var statusValue);
+                if (!TodoStore.TryParseStatus(statusValue as string, out var status))
+                {
+                    return CreateErrorResult($"todos[{i}].status must be one of: pending, in_progress, completed");
+                }
+
+                if (status == TodoStatus.InProgress && ++inProgressCount > 1)
+                {
+                    return CreateErrorResult("Only one item may be in_progress at a time");
+                }
+
+                items.Add(new TodoItem(content.Trim(), status));
+            }
+
+            await TodoStore.SetAsync(TodoStore.CurrentKey(), items);
+
+            if (items.Count == 0)
+            {
+                return CreateSuccessResult(new { count = 0, todos = Array.Empty<object>() }, "Todo list cleared.");
+            }
+
+            var completed = items.Count(t => t.Status == TodoStatus.Completed);
+            var pending = items.Count(t => t.Status == TodoStatus.Pending);
+
+            var output = new StringBuilder();
+            output.AppendLine($"Todo list updated ({items.Count} item{(items.Count == 1 ? "" : "s")}: {completed} completed, {inProgressCount} in progress, {pending} pending):");
+            foreach (var item in items)
+            {
+                var marker = item.Status switch
+                {
+                    TodoStatus.Completed => "[x]",
+                    TodoStatus.InProgress => "[~]",
+                    _ => "[ ]"
+                };
+                output.AppendLine($"{marker} {item.Content}");
+            }
+
+            var rawData = new
+            {
+                count = items.Count,
+                completed,
+                inProgress = inProgressCount,
+                pending,
+                todos = items.Select(t => new { content = t.Content, status = TodoStore.StatusToString(t.Status) }).ToList()
+            };
+
+            return CreateSuccessResult(rawData, output.ToString().TrimEnd());
+        }
+    }
+}

--- a/Tools/Todo/UpdateTodosTool.cs
+++ b/Tools/Todo/UpdateTodosTool.cs
@@ -126,11 +126,17 @@ Important rules:
                 items.Add(new TodoItem(content.Trim(), status));
             }
 
-            await TodoStore.SetAsync(TodoStore.CurrentKey(), items);
+            var persisted = await TodoStore.SetAsync(TodoStore.CurrentKey(), items);
+            var persistenceWarning = persisted
+                ? null
+                : "Warning: the todo list could not be persisted and may not survive a restart.";
 
             if (items.Count == 0)
             {
-                return CreateSuccessResult(new { count = 0, todos = Array.Empty<object>() }, "Todo list cleared.");
+                var clearedOutput = persistenceWarning == null
+                    ? "Todo list cleared."
+                    : $"Todo list cleared.\n{persistenceWarning}";
+                return CreateSuccessResult(new { count = 0, persisted, todos = Array.Empty<object>() }, clearedOutput);
             }
 
             var completed = items.Count(t => t.Status == TodoStatus.Completed);
@@ -149,12 +155,18 @@ Important rules:
                 output.AppendLine($"{marker} {item.Content}");
             }
 
+            if (persistenceWarning != null)
+            {
+                output.AppendLine(persistenceWarning);
+            }
+
             var rawData = new
             {
                 count = items.Count,
                 completed,
                 inProgress = inProgressCount,
                 pending,
+                persisted,
                 todos = items.Select(t => new { content = t.Content, status = TodoStore.StatusToString(t.Status) }).ToList()
             };
 


### PR DESCRIPTION
Adds an update_todos tool so agents can track a plan checklist for the current chat session.
The list is stored per session in chats.db, survives restarts, and reattaches on session resume.
Works in both terminal and web mode, with validation, mode/config registration, and unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a session-scoped todo checklist for tracking multi-step work.
  - Todo lists persist across sessions and remain separate between sessions.
  - Checklists support pending, in-progress, and completed statuses, with progress summaries.
  - The todo tool is enabled by default, including for existing configurations.

- **Bug Fixes**
  - Improved session handling so todo updates are associated with the correct session.
  - Added validation and clear error messages for invalid or oversized checklists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->