### PR TITLE
Add web_search tool with configurable providers

### DIFF
--- a/Configuration/ConfigurationManager.cs
+++ b/Configuration/ConfigurationManager.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Saturn.Agents.Core;
 using Saturn.Configuration.Objects;
 using Saturn.Providers;
+using Saturn.Tools.Search;
 
 namespace Saturn.Configuration
 {
@@ -121,11 +122,14 @@ namespace Saturn.Configuration
         {
             try
             {
-                if (config.ActiveProvider == null || config.Providers == null)
+                if (config.ActiveProvider == null || config.Providers == null ||
+                    config.SearchProvider == null || config.SearchProviders == null)
                 {
                     var existing = await LoadConfigurationAsync();
                     config.ActiveProvider ??= existing?.ActiveProvider;
                     config.Providers ??= existing?.Providers;
+                    config.SearchProvider ??= existing?.SearchProvider;
+                    config.SearchProviders ??= existing?.SearchProviders;
                 }
 
                 if (!string.IsNullOrWhiteSpace(config.ActiveProvider) && !string.IsNullOrWhiteSpace(config.Model))
@@ -213,9 +217,20 @@ namespace Saturn.Configuration
 
         public static ProviderSettings GetProviderSettings(PersistedAgentConfiguration? config, string providerName)
         {
+            return ReadProviderSettings(config?.Providers, providerName);
+        }
+
+        public static ProviderSettings GetSearchProviderSettings(PersistedAgentConfiguration? config, string providerName)
+        {
+            return ReadProviderSettings(config?.SearchProviders, providerName);
+        }
+
+        private static ProviderSettings ReadProviderSettings(
+            Dictionary<string, PersistedProviderConfiguration>? map, string providerName)
+        {
             var settings = new ProviderSettings();
-            if (config?.Providers != null &&
-                config.Providers.TryGetValue(providerName, out var providerConfig) &&
+            if (map != null &&
+                map.TryGetValue(providerName, out var providerConfig) &&
                 providerConfig.Settings != null)
             {
                 foreach (var kvp in providerConfig.Settings)
@@ -226,56 +241,72 @@ namespace Saturn.Configuration
             return settings;
         }
 
+        public static async Task SaveSearchProviderSelectionAsync(string providerName, ProviderSettings settings)
+        {
+            await SaveLock.WaitAsync();
+            try
+            {
+                await SaveSearchProviderSelectionLockedAsync(providerName, settings);
+            }
+            finally
+            {
+                SaveLock.Release();
+            }
+        }
+
+        private static async Task SaveSearchProviderSelectionLockedAsync(string providerName, ProviderSettings settings)
+        {
+            var config = await LoadConfigurationAsync() ?? new PersistedAgentConfiguration();
+
+            config.SearchProvider = providerName;
+            config.SearchProviders ??= new Dictionary<string, PersistedProviderConfiguration>(StringComparer.OrdinalIgnoreCase);
+
+            if (!config.SearchProviders.TryGetValue(providerName, out var providerConfig))
+            {
+                providerConfig = new PersistedProviderConfiguration();
+                config.SearchProviders[providerName] = providerConfig;
+            }
+
+            var toPersist = new Dictionary<string, string?>(settings.Values, StringComparer.OrdinalIgnoreCase);
+            if (SearchProviderRegistry.TryGet(providerName, out var provider))
+            {
+                foreach (var descriptor in provider.SettingDescriptors)
+                {
+                    if (descriptor.Kind != ProviderSettingKind.Secret ||
+                        string.IsNullOrWhiteSpace(descriptor.EnvironmentVariable))
+                    {
+                        continue;
+                    }
+
+                    var envValue = Environment.GetEnvironmentVariable(descriptor.EnvironmentVariable);
+                    if (toPersist.TryGetValue(descriptor.Key, out var saved) &&
+                        !string.IsNullOrEmpty(saved) &&
+                        string.Equals(saved, envValue, StringComparison.Ordinal))
+                    {
+                        toPersist.Remove(descriptor.Key);
+                    }
+                }
+            }
+            providerConfig.Settings = toPersist;
+
+            await SaveConfigurationLockedAsync(config);
+        }
+
         /// <summary>
         /// Returns a copy of the configuration with secret-kind provider settings encrypted,
         /// leaving the caller's in-memory configuration in plaintext.
         /// </summary>
         private static PersistedAgentConfiguration WithProtectedSecrets(PersistedAgentConfiguration config)
         {
-            if (config.Providers == null)
-            {
-                return config;
-            }
+            var protectedProviders = ProtectProviderMap(
+                config.Providers,
+                name => ProviderRegistry.TryGet(name, out var p) ? p.SettingDescriptors : null);
 
-            Dictionary<string, PersistedProviderConfiguration>? protectedProviders = null;
+            var protectedSearchProviders = ProtectProviderMap(
+                config.SearchProviders,
+                name => SearchProviderRegistry.TryGet(name, out var p) ? p.SettingDescriptors : null);
 
-            foreach (var (providerName, providerConfig) in config.Providers)
-            {
-                var settings = providerConfig.Settings;
-                if (settings == null || !ProviderRegistry.TryGet(providerName, out var provider))
-                {
-                    continue;
-                }
-
-                Dictionary<string, string?>? protectedSettings = null;
-                foreach (var descriptor in provider.SettingDescriptors)
-                {
-                    if (descriptor.Kind != ProviderSettingKind.Secret)
-                    {
-                        continue;
-                    }
-
-                    if (settings.TryGetValue(descriptor.Key, out var value) &&
-                        !string.IsNullOrEmpty(value) &&
-                        !SecretProtector.IsProtected(value))
-                    {
-                        protectedSettings ??= new Dictionary<string, string?>(settings, StringComparer.OrdinalIgnoreCase);
-                        protectedSettings[descriptor.Key] = SecretProtector.Protect(value, AppDataPath);
-                    }
-                }
-
-                if (protectedSettings != null)
-                {
-                    protectedProviders ??= new Dictionary<string, PersistedProviderConfiguration>(config.Providers, StringComparer.OrdinalIgnoreCase);
-                    protectedProviders[providerName] = new PersistedProviderConfiguration
-                    {
-                        Settings = protectedSettings,
-                        Model = providerConfig.Model
-                    };
-                }
-            }
-
-            if (protectedProviders == null)
+            if (protectedProviders == null && protectedSearchProviders == null)
             {
                 return config;
             }
@@ -295,8 +326,65 @@ namespace Saturn.Configuration
                 RequireCommandApproval = config.RequireCommandApproval,
                 EnableUserRules = config.EnableUserRules,
                 ActiveProvider = config.ActiveProvider,
-                Providers = protectedProviders
+                Providers = protectedProviders ?? config.Providers,
+                SearchProvider = config.SearchProvider,
+                SearchProviders = protectedSearchProviders ?? config.SearchProviders
             };
+        }
+
+        /// <summary>
+        /// Returns a copy of <paramref name="map"/> with every secret-kind setting encrypted, or
+        /// null if there was nothing to protect (letting the caller keep the original reference).
+        /// </summary>
+        private static Dictionary<string, PersistedProviderConfiguration>? ProtectProviderMap(
+            Dictionary<string, PersistedProviderConfiguration>? map,
+            Func<string, IReadOnlyList<ProviderSettingDescriptor>?> descriptorLookup)
+        {
+            if (map == null)
+            {
+                return null;
+            }
+
+            Dictionary<string, PersistedProviderConfiguration>? protectedMap = null;
+
+            foreach (var (providerName, providerConfig) in map)
+            {
+                var settings = providerConfig.Settings;
+                var descriptors = descriptorLookup(providerName);
+                if (settings == null || descriptors == null)
+                {
+                    continue;
+                }
+
+                Dictionary<string, string?>? protectedSettings = null;
+                foreach (var descriptor in descriptors)
+                {
+                    if (descriptor.Kind != ProviderSettingKind.Secret)
+                    {
+                        continue;
+                    }
+
+                    if (settings.TryGetValue(descriptor.Key, out var value) &&
+                        !string.IsNullOrEmpty(value) &&
+                        !SecretProtector.IsProtected(value))
+                    {
+                        protectedSettings ??= new Dictionary<string, string?>(settings, StringComparer.OrdinalIgnoreCase);
+                        protectedSettings[descriptor.Key] = SecretProtector.Protect(value, AppDataPath);
+                    }
+                }
+
+                if (protectedSettings != null)
+                {
+                    protectedMap ??= new Dictionary<string, PersistedProviderConfiguration>(map, StringComparer.OrdinalIgnoreCase);
+                    protectedMap[providerName] = new PersistedProviderConfiguration
+                    {
+                        Settings = protectedSettings,
+                        Model = providerConfig.Model
+                    };
+                }
+            }
+
+            return protectedMap;
         }
 
         public static string? GetProviderModel(PersistedAgentConfiguration? config, string providerName)

--- a/Configuration/Objects/PersistedAgentConfiguration.cs
+++ b/Configuration/Objects/PersistedAgentConfiguration.cs
@@ -24,6 +24,10 @@ namespace Saturn.Configuration.Objects
         public string? ActiveProvider { get; set; }
 
         public Dictionary<string, PersistedProviderConfiguration>? Providers { get; set; }
+
+        public string? SearchProvider { get; set; }
+
+        public Dictionary<string, PersistedProviderConfiguration>? SearchProviders { get; set; }
     }
 
     public class PersistedProviderConfiguration

--- a/Program.cs
+++ b/Program.cs
@@ -284,7 +284,7 @@ Operating Principles
                     "write_file", "search_and_replace", "delete_file",
                     "create_agent", "hand_off_to_agent", "get_agent_status",
                     "wait_for_agent", "get_task_result", "terminate_agent", "execute_command",
-                    "get_command_output", "kill_command", "web_fetch",
+                    "get_command_output", "kill_command", "web_fetch", "web_search",
                     "list_tasks", "create_task", "update_task", "complete_task",
                     "wait_for_task", "claim_task", "dispatch_task", "list_due_tasks",
                     "update_todos"
@@ -298,7 +298,7 @@ Operating Principles
             {
                 "list_tasks", "create_task", "update_task", "complete_task",
                 "wait_for_task", "claim_task", "dispatch_task", "list_due_tasks",
-                "update_todos"
+                "update_todos", "web_search"
             };
 
             if (persistedConfig != null)

--- a/Saturn.Tests/Providers/ConfigurationManagerFileTests.cs
+++ b/Saturn.Tests/Providers/ConfigurationManagerFileTests.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace Saturn.Tests.Providers
 {
+    [Collection("Configuration")]
     public class ConfigurationManagerFileTests : IDisposable
     {
         private readonly string _configDir;

--- a/Saturn.Tests/Providers/ConfigurationManagerSearchTests.cs
+++ b/Saturn.Tests/Providers/ConfigurationManagerSearchTests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Saturn.Configuration;
+using Saturn.Configuration.Objects;
+using Saturn.Providers;
+using Xunit;
+
+namespace Saturn.Tests.Providers
+{
+    [Collection("Configuration")]
+    public class ConfigurationManagerSearchTests : IDisposable
+    {
+        private readonly string _configDir;
+
+        public ConfigurationManagerSearchTests()
+        {
+            _configDir = Path.Combine(Path.GetTempPath(), "SaturnSearchTests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_configDir);
+            Environment.SetEnvironmentVariable("SATURN_CONFIG_DIR", _configDir);
+        }
+
+        public void Dispose()
+        {
+            Environment.SetEnvironmentVariable("SATURN_CONFIG_DIR", null);
+            try { Directory.Delete(_configDir, recursive: true); } catch { }
+        }
+
+        private string ConfigFile => Path.Combine(_configDir, "agent-config.json");
+
+        [Fact]
+        public async Task SaveSearchProviderSelection_EncryptsApiKeyAtRest_RoundTripsPlaintext()
+        {
+            var settings = new ProviderSettings();
+            settings.Set("apiKey", "sk-tavily-123");
+            await ConfigurationManager.SaveSearchProviderSelectionAsync("tavily", settings);
+
+            var raw = await File.ReadAllTextAsync(ConfigFile);
+            raw.Should().NotContain("sk-tavily-123");
+            raw.Should().Contain("enc:v1:");
+
+            var config = await ConfigurationManager.LoadConfigurationAsync();
+            config!.SearchProvider.Should().Be("tavily");
+            config.SearchProviders!["tavily"].Settings!["apiKey"].Should().StartWith("enc:v1:");
+
+            ConfigurationManager.GetSearchProviderSettings(config, "tavily").Get("apiKey").Should().Be("sk-tavily-123");
+        }
+
+        [Fact]
+        public async Task SearchConfig_SurvivesSaveThatProtectsAnLlmSecret()
+        {
+            // Regression for the WithProtectedSecrets copy-constructor: a save that encrypts an
+            // LLM secret must not drop the search block.
+            var searchSettings = new ProviderSettings();
+            searchSettings.Set("apiKey", "sk-brave-xyz");
+            await ConfigurationManager.SaveSearchProviderSelectionAsync("brave", searchSettings);
+
+            var llmSettings = new ProviderSettings();
+            llmSettings.Set("apiKey", "sk-openrouter-abc");
+            await ConfigurationManager.SaveProviderSelectionAsync("openrouter", llmSettings, "anthropic/claude-sonnet-4");
+
+            var reloaded = await ConfigurationManager.LoadConfigurationAsync();
+            reloaded!.SearchProvider.Should().Be("brave");
+            ConfigurationManager.GetSearchProviderSettings(reloaded, "brave").Get("apiKey").Should().Be("sk-brave-xyz");
+            ConfigurationManager.GetProviderSettings(reloaded, "openrouter").Get("apiKey").Should().Be("sk-openrouter-abc");
+        }
+
+        [Fact]
+        public async Task SaveConfiguration_WithNullSearchFields_PreservesExistingSearchBlock()
+        {
+            var searchSettings = new ProviderSettings();
+            searchSettings.Set("apiKey", "sk-serper-1");
+            await ConfigurationManager.SaveSearchProviderSelectionAsync("serper", searchSettings);
+
+            // A routine agent-config save (e.g. temperature change) leaves search fields null.
+            await ConfigurationManager.SaveConfigurationAsync(new PersistedAgentConfiguration
+            {
+                Name = "Assistant",
+                Model = "some-model"
+            });
+
+            var reloaded = await ConfigurationManager.LoadConfigurationAsync();
+            reloaded!.SearchProvider.Should().Be("serper");
+            ConfigurationManager.GetSearchProviderSettings(reloaded, "serper").Get("apiKey").Should().Be("sk-serper-1");
+        }
+    }
+}

--- a/Saturn.Tests/Search/SearchProviderTests.cs
+++ b/Saturn.Tests/Search/SearchProviderTests.cs
@@ -13,8 +13,34 @@ using Xunit;
 
 namespace Saturn.Tests.Search
 {
-    public class SearchProviderTests
+    [Collection("Configuration")]
+    public class SearchProviderTests : IDisposable
     {
+        private static readonly string[] ProviderEnvVars =
+            { "TAVILY_API_KEY", "BRAVE_API_KEY", "SERPER_API_KEY", "SERPAPI_API_KEY", "EXA_API_KEY" };
+
+        private readonly Dictionary<string, string?> _savedEnv = new();
+
+        public SearchProviderTests()
+        {
+            // ResolveApiKey falls back to these env vars, so clear them for determinism
+            // regardless of the host environment; the collection serializes us against
+            // other tests that set them.
+            foreach (var name in ProviderEnvVars)
+            {
+                _savedEnv[name] = Environment.GetEnvironmentVariable(name);
+                Environment.SetEnvironmentVariable(name, null);
+            }
+        }
+
+        public void Dispose()
+        {
+            foreach (var kvp in _savedEnv)
+            {
+                Environment.SetEnvironmentVariable(kvp.Key, kvp.Value);
+            }
+        }
+
         private static (HttpClient http, List<(HttpRequestMessage Request, string Body)> log) Stub(
             string responseBody, HttpStatusCode status = HttpStatusCode.OK)
         {

--- a/Saturn.Tests/Search/SearchProviderTests.cs
+++ b/Saturn.Tests/Search/SearchProviderTests.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Saturn.Providers;
+using Saturn.Tests.Providers;
+using Saturn.Tools.Search;
+using Saturn.Tools.Search.Providers;
+using Xunit;
+
+namespace Saturn.Tests.Search
+{
+    public class SearchProviderTests
+    {
+        private static (HttpClient http, List<(HttpRequestMessage Request, string Body)> log) Stub(
+            string responseBody, HttpStatusCode status = HttpStatusCode.OK)
+        {
+            var log = new List<(HttpRequestMessage, string)>();
+            var handler = new StubHttpHandler(_ => StubHttpHandler.Json(responseBody, status), log);
+            return (new HttpClient(handler), log);
+        }
+
+        private static ProviderSettings Key(string value)
+        {
+            var s = new ProviderSettings();
+            s.Set(SearchProviderBase.ApiKeySetting, value);
+            return s;
+        }
+
+        [Fact]
+        public async Task Tavily_BuildsPostWithBearer_ParsesResults()
+        {
+            var (http, log) = Stub("""{"results":[{"title":"T","url":"https://a.com","content":"body"}]}""");
+            var provider = new TavilySearchProvider();
+
+            var response = await provider.SearchAsync("hello world", 5, Key("sk-tav"), http);
+
+            var (request, body) = log.Single();
+            request.Method.Should().Be(HttpMethod.Post);
+            request.RequestUri!.ToString().Should().Be("https://api.tavily.com/search");
+            request.Headers.Authorization!.Scheme.Should().Be("Bearer");
+            request.Headers.Authorization.Parameter.Should().Be("sk-tav");
+            body.Should().Contain("\"query\":\"hello world\"").And.Contain("\"max_results\":5");
+
+            response.Provider.Should().Be("Tavily");
+            response.Results.Should().ContainSingle();
+            response.Results[0].Should().Be(new SearchResult("T", "https://a.com", "body"));
+        }
+
+        [Fact]
+        public async Task Brave_BuildsGetWithTokenHeader_StripsHtml()
+        {
+            var (http, log) = Stub("""{"web":{"results":[{"title":"Ti","url":"https://b.com","description":"a <strong>bold</strong> hit"}]}}""");
+            var provider = new BraveSearchProvider();
+
+            var response = await provider.SearchAsync("c# tips", 3, Key("brave-key"), http);
+
+            var (request, _) = log.Single();
+            request.Method.Should().Be(HttpMethod.Get);
+            request.RequestUri!.AbsoluteUri.Should().StartWith("https://api.search.brave.com/res/v1/web/search?q=c%23");
+            request.RequestUri!.AbsoluteUri.Should().Contain("count=3");
+            request.Headers.GetValues("X-Subscription-Token").Single().Should().Be("brave-key");
+
+            response.Results.Single().Snippet.Should().Be("a bold hit");
+        }
+
+        [Fact]
+        public async Task Serper_BuildsPostWithApiKeyHeader_ParsesOrganic()
+        {
+            var (http, log) = Stub("""{"organic":[{"title":"S","link":"https://s.com","snippet":"snip"}]}""");
+            var provider = new SerperSearchProvider();
+
+            var response = await provider.SearchAsync("query", 4, Key("serper-key"), http);
+
+            var (request, body) = log.Single();
+            request.Method.Should().Be(HttpMethod.Post);
+            request.RequestUri!.ToString().Should().Be("https://google.serper.dev/search");
+            request.Headers.GetValues("X-API-KEY").Single().Should().Be("serper-key");
+            body.Should().Contain("\"q\":\"query\"").And.Contain("\"num\":4");
+
+            response.Results.Single().Should().Be(new SearchResult("S", "https://s.com", "snip"));
+        }
+
+        [Fact]
+        public async Task SerpApi_BuildsGetWithApiKeyQueryParam()
+        {
+            var (http, log) = Stub("""{"organic_results":[{"title":"G","link":"https://g.com","snippet":"gs"}]}""");
+            var provider = new SerpApiSearchProvider();
+
+            var response = await provider.SearchAsync("a b", 2, Key("serp-key"), http);
+
+            var (request, _) = log.Single();
+            request.Method.Should().Be(HttpMethod.Get);
+            request.RequestUri!.AbsoluteUri.Should().StartWith("https://serpapi.com/search.json?engine=google&q=a");
+            request.RequestUri!.AbsoluteUri.Should().Contain("num=2").And.Contain("api_key=serp-key");
+
+            response.Results.Single().Url.Should().Be("https://g.com");
+        }
+
+        [Fact]
+        public async Task Exa_BuildsPostWithApiKeyHeader_TruncatesText()
+        {
+            var longText = new string('x', 800);
+            var (http, log) = Stub($$"""{"results":[{"title":"E","url":"https://e.com","text":"{{longText}}"}]}""");
+            var provider = new ExaSearchProvider();
+
+            var response = await provider.SearchAsync("q", 6, Key("exa-key"), http);
+
+            var (request, body) = log.Single();
+            request.Method.Should().Be(HttpMethod.Post);
+            request.RequestUri!.ToString().Should().Be("https://api.exa.ai/search");
+            request.Headers.GetValues("x-api-key").Single().Should().Be("exa-key");
+            body.Should().Contain("\"numResults\":6").And.Contain("\"contents\"");
+
+            response.Results.Single().Snippet.Length.Should().BeLessThan(longText.Length);
+            response.Results.Single().Snippet.Should().EndWith("…");
+        }
+
+        [Fact]
+        public async Task MalformedEntriesAreSkipped()
+        {
+            // Second entry has no url and must be dropped without throwing.
+            var (http, _) = Stub("""{"results":[{"title":"ok","url":"https://ok.com","content":"c"},{"title":"bad"}]}""");
+            var provider = new TavilySearchProvider();
+
+            var response = await provider.SearchAsync("q", 5, Key("k"), http);
+
+            response.Results.Should().ContainSingle();
+            response.Results[0].Url.Should().Be("https://ok.com");
+        }
+
+        [Fact]
+        public async Task Unauthorized_ThrowsWithApiKeyMessage()
+        {
+            var (http, _) = Stub("""{"error":"nope"}""", HttpStatusCode.Unauthorized);
+            var provider = new BraveSearchProvider();
+
+            var act = () => provider.SearchAsync("q", 5, Key("bad"), http);
+
+            (await act.Should().ThrowAsync<HttpRequestException>())
+                .Which.Message.Should().Contain("API key");
+        }
+
+        [Fact]
+        public async Task ServerError_ThrowsWithStatus()
+        {
+            var (http, _) = Stub("boom", HttpStatusCode.InternalServerError);
+            var provider = new SerperSearchProvider();
+
+            var act = () => provider.SearchAsync("q", 5, Key("k"), http);
+
+            (await act.Should().ThrowAsync<HttpRequestException>())
+                .Which.Message.Should().Contain("500");
+        }
+
+        [Fact]
+        public async Task MissingApiKey_ThrowsInvalidOperation()
+        {
+            var (http, _) = Stub("{}");
+            var provider = new TavilySearchProvider();
+
+            var act = () => provider.SearchAsync("q", 5, new ProviderSettings(), http);
+
+            await act.Should().ThrowAsync<InvalidOperationException>();
+        }
+
+        [Fact]
+        public void EveryProvider_ExposesSecretApiKeyDescriptor()
+        {
+            foreach (var provider in SearchProviderRegistry.All)
+            {
+                var descriptor = provider.SettingDescriptors.Should().ContainSingle().Subject;
+                descriptor.Key.Should().Be("apiKey");
+                descriptor.Kind.Should().Be(ProviderSettingKind.Secret);
+                descriptor.EnvironmentVariable.Should().NotBeNullOrWhiteSpace();
+            }
+        }
+
+        [Fact]
+        public void Registry_ContainsAllFiveProviders()
+        {
+            SearchProviderRegistry.All.Select(p => p.Name).Should()
+                .BeEquivalentTo(new[] { "tavily", "brave", "serper", "serpapi", "exa" });
+        }
+    }
+}

--- a/Saturn.Tests/TestHelpers/ConfigurationCollection.cs
+++ b/Saturn.Tests/TestHelpers/ConfigurationCollection.cs
@@ -1,0 +1,13 @@
+using Xunit;
+
+namespace Saturn.Tests.TestHelpers
+{
+    /// <summary>
+    /// Serializes test classes that manipulate the process-wide SATURN_CONFIG_DIR and provider
+    /// API-key environment variables, which would otherwise race under xUnit's parallel runner.
+    /// </summary>
+    [CollectionDefinition("Configuration")]
+    public class ConfigurationCollection
+    {
+    }
+}

--- a/Saturn.Tests/Tools/WebSearchToolTests.cs
+++ b/Saturn.Tests/Tools/WebSearchToolTests.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Saturn.Tests.Providers;
+using Saturn.Tools;
+using Xunit;
+
+namespace Saturn.Tests.Tools
+{
+    [Collection("Configuration")]
+    public class WebSearchToolTests : IDisposable
+    {
+        private static readonly string[] ProviderEnvVars =
+            { "TAVILY_API_KEY", "BRAVE_API_KEY", "SERPER_API_KEY", "SERPAPI_API_KEY", "EXA_API_KEY" };
+
+        private readonly string _configDir;
+        private readonly Dictionary<string, string?> _savedEnv = new();
+
+        public WebSearchToolTests()
+        {
+            _configDir = Path.Combine(Path.GetTempPath(), "SaturnWebSearchTests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_configDir);
+            Environment.SetEnvironmentVariable("SATURN_CONFIG_DIR", _configDir);
+
+            // Snapshot and clear provider keys so tests are deterministic regardless of host env.
+            foreach (var name in ProviderEnvVars)
+            {
+                _savedEnv[name] = Environment.GetEnvironmentVariable(name);
+                Environment.SetEnvironmentVariable(name, null);
+            }
+        }
+
+        public void Dispose()
+        {
+            WebSearchTool.HttpClientOverride = null;
+            Environment.SetEnvironmentVariable("SATURN_CONFIG_DIR", null);
+            foreach (var kvp in _savedEnv)
+            {
+                Environment.SetEnvironmentVariable(kvp.Key, kvp.Value);
+            }
+            try { Directory.Delete(_configDir, recursive: true); } catch { }
+        }
+
+        private static void StubHttp(string body, HttpStatusCode status = HttpStatusCode.OK)
+        {
+            var log = new List<(HttpRequestMessage, string)>();
+            WebSearchTool.HttpClientOverride = new HttpClient(
+                new StubHttpHandler(_ => StubHttpHandler.Json(body, status), log));
+        }
+
+        [Fact]
+        public async Task NoProviderConfigured_ReturnsActionableError()
+        {
+            var tool = new WebSearchTool();
+
+            var result = await tool.ExecuteAsync(new Dictionary<string, object> { ["query"] = "anything" });
+
+            result.Success.Should().BeFalse();
+            result.Error.Should().Contain("TAVILY_API_KEY");
+            result.Error.Should().Contain("Search Provider");
+        }
+
+        [Fact]
+        public async Task EmptyQuery_ReturnsError()
+        {
+            var tool = new WebSearchTool();
+
+            var result = await tool.ExecuteAsync(new Dictionary<string, object> { ["query"] = "  " });
+
+            result.Success.Should().BeFalse();
+            result.Error.Should().Contain("empty");
+        }
+
+        [Fact]
+        public async Task ProviderOverrideWithEnvKey_ReturnsFormattedResults()
+        {
+            Environment.SetEnvironmentVariable("TAVILY_API_KEY", "sk-env");
+            StubHttp("""{"results":[{"title":"Hit","url":"https://x.com","content":"snippet text"}]}""");
+            var tool = new WebSearchTool();
+
+            var result = await tool.ExecuteAsync(new Dictionary<string, object>
+            {
+                ["query"] = "saturn",
+                ["provider"] = "tavily"
+            });
+
+            result.Success.Should().BeTrue();
+            result.FormattedOutput.Should().Contain("Web search via Tavily");
+            result.FormattedOutput.Should().Contain("1. Hit");
+            result.FormattedOutput.Should().Contain("https://x.com");
+            result.FormattedOutput.Should().Contain("snippet text");
+        }
+
+        [Fact]
+        public async Task UnknownProviderOverride_ReturnsError()
+        {
+            var tool = new WebSearchTool();
+
+            var result = await tool.ExecuteAsync(new Dictionary<string, object>
+            {
+                ["query"] = "q",
+                ["provider"] = "nope"
+            });
+
+            result.Success.Should().BeFalse();
+            result.Error.Should().Contain("Unknown search provider");
+        }
+
+        [Fact]
+        public async Task ZeroResults_ReportsNoResults()
+        {
+            Environment.SetEnvironmentVariable("BRAVE_API_KEY", "sk-env");
+            StubHttp("""{"web":{"results":[]}}""");
+            var tool = new WebSearchTool();
+
+            var result = await tool.ExecuteAsync(new Dictionary<string, object>
+            {
+                ["query"] = "obscure",
+                ["provider"] = "brave"
+            });
+
+            result.Success.Should().BeTrue();
+            result.FormattedOutput.Should().Contain("no results");
+        }
+    }
+}

--- a/Saturn.csproj
+++ b/Saturn.csproj
@@ -33,6 +33,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Saturn.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <EmbeddedResource Include="Web\wwwroot\**">
       <LogicalName>wwwroot/%(RecursiveDir)%(Filename)%(Extension)</LogicalName>
     </EmbeddedResource>

--- a/Tools/Search/ISearchProvider.cs
+++ b/Tools/Search/ISearchProvider.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Saturn.Providers;
+
+namespace Saturn.Tools.Search
+{
+    /// <summary>
+    /// A web search backend (Tavily, Brave, Serper, SerpAPI, Exa). Mirrors the LLM
+    /// <see cref="ILlmProvider"/> shape so the settings UI and secret persistence can be reused.
+    /// </summary>
+    public interface ISearchProvider
+    {
+        string Name { get; }
+
+        string DisplayName { get; }
+
+        IReadOnlyList<ProviderSettingDescriptor> SettingDescriptors { get; }
+
+        Task<SearchResponse> SearchAsync(
+            string query,
+            int maxResults,
+            ProviderSettings settings,
+            HttpClient http,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/Tools/Search/Providers/BraveSearchProvider.cs
+++ b/Tools/Search/Providers/BraveSearchProvider.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Saturn.Providers;
+
+namespace Saturn.Tools.Search.Providers
+{
+    public sealed class BraveSearchProvider : SearchProviderBase
+    {
+        public override string Name => "brave";
+        public override string DisplayName => "Brave Search";
+        public override string EnvironmentVariable => "BRAVE_API_KEY";
+
+        public override async Task<SearchResponse> SearchAsync(
+            string query, int maxResults, ProviderSettings settings, HttpClient http, CancellationToken cancellationToken = default)
+        {
+            var apiKey = ResolveApiKey(settings);
+
+            var url = $"https://api.search.brave.com/res/v1/web/search?q={Uri.EscapeDataString(query)}&count={maxResults}";
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            request.Headers.TryAddWithoutValidation("X-Subscription-Token", apiKey);
+            request.Headers.TryAddWithoutValidation("Accept", "application/json");
+
+            using var response = await http.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            var body = await ReadOrThrowAsync(response, cancellationToken).ConfigureAwait(false);
+
+            var results = new List<SearchResult>();
+            using var doc = JsonDocument.Parse(body);
+            if (doc.RootElement.TryGetProperty("web", out var web) &&
+                web.TryGetProperty("results", out var items) &&
+                items.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var item in items.EnumerateArray())
+                {
+                    var resultUrl = item.TryGetProperty("url", out var u) ? u.GetString() : null;
+                    if (string.IsNullOrEmpty(resultUrl)) continue;
+
+                    var title = item.TryGetProperty("title", out var t) ? t.GetString() : null;
+                    var description = item.TryGetProperty("description", out var d) ? d.GetString() : null;
+
+                    results.Add(new SearchResult(CleanSnippet(title), resultUrl, CleanSnippet(description)));
+                }
+            }
+
+            return new SearchResponse(results, DisplayName);
+        }
+    }
+}

--- a/Tools/Search/Providers/ExaSearchProvider.cs
+++ b/Tools/Search/Providers/ExaSearchProvider.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Saturn.Providers;
+
+namespace Saturn.Tools.Search.Providers
+{
+    public sealed class ExaSearchProvider : SearchProviderBase
+    {
+        public override string Name => "exa";
+        public override string DisplayName => "Exa";
+        public override string EnvironmentVariable => "EXA_API_KEY";
+
+        public override async Task<SearchResponse> SearchAsync(
+            string query, int maxResults, ProviderSettings settings, HttpClient http, CancellationToken cancellationToken = default)
+        {
+            var apiKey = ResolveApiKey(settings);
+
+            var payload = new Dictionary<string, object>
+            {
+                ["query"] = query,
+                ["numResults"] = maxResults,
+                ["contents"] = new Dictionary<string, object> { ["text"] = true }
+            };
+
+            using var request = new HttpRequestMessage(HttpMethod.Post, "https://api.exa.ai/search")
+            {
+                Content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json")
+            };
+            request.Headers.TryAddWithoutValidation("x-api-key", apiKey);
+
+            using var response = await http.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            var body = await ReadOrThrowAsync(response, cancellationToken).ConfigureAwait(false);
+
+            var results = new List<SearchResult>();
+            using var doc = JsonDocument.Parse(body);
+            if (doc.RootElement.TryGetProperty("results", out var items) && items.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var item in items.EnumerateArray())
+                {
+                    var url = item.TryGetProperty("url", out var u) ? u.GetString() : null;
+                    if (string.IsNullOrEmpty(url)) continue;
+
+                    var title = item.TryGetProperty("title", out var t) ? t.GetString() : null;
+                    var text = item.TryGetProperty("text", out var x) ? x.GetString() : null;
+
+                    results.Add(new SearchResult(title ?? url, url, Truncate(CleanSnippet(text), 500)));
+                }
+            }
+
+            return new SearchResponse(results, DisplayName);
+        }
+    }
+}

--- a/Tools/Search/Providers/SearchProviderBase.cs
+++ b/Tools/Search/Providers/SearchProviderBase.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Saturn.Providers;
+
+namespace Saturn.Tools.Search.Providers
+{
+    /// <summary>
+    /// Shared helpers for the built-in search providers: the single API-key descriptor,
+    /// error mapping, and snippet cleanup.
+    /// </summary>
+    public abstract class SearchProviderBase : ISearchProvider
+    {
+        public abstract string Name { get; }
+        public abstract string DisplayName { get; }
+        public abstract string EnvironmentVariable { get; }
+
+        public IReadOnlyList<ProviderSettingDescriptor> SettingDescriptors => new[]
+        {
+            new ProviderSettingDescriptor
+            {
+                Key = ApiKeySetting,
+                Label = "API Key",
+                Kind = ProviderSettingKind.Secret,
+                Required = true,
+                EnvironmentVariable = EnvironmentVariable
+            }
+        };
+
+        public const string ApiKeySetting = "apiKey";
+
+        public abstract Task<SearchResponse> SearchAsync(
+            string query,
+            int maxResults,
+            ProviderSettings settings,
+            HttpClient http,
+            System.Threading.CancellationToken cancellationToken = default);
+
+        protected string ResolveApiKey(ProviderSettings settings)
+        {
+            var key = SettingDescriptors[0].Resolve(settings);
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                throw new InvalidOperationException(
+                    $"{DisplayName} requires an API key. Set the {EnvironmentVariable} environment variable or configure it in settings.");
+            }
+            return key;
+        }
+
+        protected async Task<string> ReadOrThrowAsync(HttpResponseMessage response, System.Threading.CancellationToken cancellationToken)
+        {
+            var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            if (response.IsSuccessStatusCode)
+            {
+                return body;
+            }
+
+            if (response.StatusCode == HttpStatusCode.Unauthorized || response.StatusCode == HttpStatusCode.Forbidden)
+            {
+                throw new HttpRequestException($"{DisplayName} rejected the request: invalid or missing API key (HTTP {(int)response.StatusCode}).");
+            }
+
+            var detail = body.Length > 300 ? body.Substring(0, 300) : body;
+            throw new HttpRequestException($"{DisplayName} search failed: HTTP {(int)response.StatusCode} {response.ReasonPhrase}. {detail}");
+        }
+
+        private static readonly Regex TagRegex = new("<.*?>", RegexOptions.Compiled | RegexOptions.Singleline);
+
+        protected static string CleanSnippet(string? text)
+        {
+            if (string.IsNullOrEmpty(text))
+            {
+                return string.Empty;
+            }
+
+            var stripped = TagRegex.Replace(text, string.Empty);
+            return WebUtility.HtmlDecode(stripped).Trim();
+        }
+
+        protected static string Truncate(string text, int max)
+        {
+            if (string.IsNullOrEmpty(text) || text.Length <= max)
+            {
+                return text ?? string.Empty;
+            }
+            return text.Substring(0, max).TrimEnd() + "…";
+        }
+    }
+}

--- a/Tools/Search/Providers/SerpApiSearchProvider.cs
+++ b/Tools/Search/Providers/SerpApiSearchProvider.cs
@@ -19,6 +19,7 @@ namespace Saturn.Tools.Search.Providers
         {
             var apiKey = ResolveApiKey(settings);
 
+            // SerpAPI only accepts the key as a query parameter; it has no header-based auth.
             var url = $"https://serpapi.com/search.json?engine=google&q={Uri.EscapeDataString(query)}&num={maxResults}&api_key={Uri.EscapeDataString(apiKey)}";
             using var request = new HttpRequestMessage(HttpMethod.Get, url);
 

--- a/Tools/Search/Providers/SerpApiSearchProvider.cs
+++ b/Tools/Search/Providers/SerpApiSearchProvider.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Saturn.Providers;
+
+namespace Saturn.Tools.Search.Providers
+{
+    public sealed class SerpApiSearchProvider : SearchProviderBase
+    {
+        public override string Name => "serpapi";
+        public override string DisplayName => "SerpAPI";
+        public override string EnvironmentVariable => "SERPAPI_API_KEY";
+
+        public override async Task<SearchResponse> SearchAsync(
+            string query, int maxResults, ProviderSettings settings, HttpClient http, CancellationToken cancellationToken = default)
+        {
+            var apiKey = ResolveApiKey(settings);
+
+            var url = $"https://serpapi.com/search.json?engine=google&q={Uri.EscapeDataString(query)}&num={maxResults}&api_key={Uri.EscapeDataString(apiKey)}";
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+
+            using var response = await http.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            var body = await ReadOrThrowAsync(response, cancellationToken).ConfigureAwait(false);
+
+            var results = new List<SearchResult>();
+            using var doc = JsonDocument.Parse(body);
+            if (doc.RootElement.TryGetProperty("organic_results", out var items) && items.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var item in items.EnumerateArray())
+                {
+                    var resultUrl = item.TryGetProperty("link", out var l) ? l.GetString() : null;
+                    if (string.IsNullOrEmpty(resultUrl)) continue;
+
+                    var title = item.TryGetProperty("title", out var t) ? t.GetString() : null;
+                    var snippet = item.TryGetProperty("snippet", out var s) ? s.GetString() : null;
+
+                    results.Add(new SearchResult(title ?? resultUrl, resultUrl, CleanSnippet(snippet)));
+                }
+            }
+
+            return new SearchResponse(results, DisplayName);
+        }
+    }
+}

--- a/Tools/Search/Providers/SerperSearchProvider.cs
+++ b/Tools/Search/Providers/SerperSearchProvider.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Saturn.Providers;
+
+namespace Saturn.Tools.Search.Providers
+{
+    public sealed class SerperSearchProvider : SearchProviderBase
+    {
+        public override string Name => "serper";
+        public override string DisplayName => "Serper";
+        public override string EnvironmentVariable => "SERPER_API_KEY";
+
+        public override async Task<SearchResponse> SearchAsync(
+            string query, int maxResults, ProviderSettings settings, HttpClient http, CancellationToken cancellationToken = default)
+        {
+            var apiKey = ResolveApiKey(settings);
+
+            var payload = new Dictionary<string, object>
+            {
+                ["q"] = query,
+                ["num"] = maxResults
+            };
+
+            using var request = new HttpRequestMessage(HttpMethod.Post, "https://google.serper.dev/search")
+            {
+                Content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json")
+            };
+            request.Headers.TryAddWithoutValidation("X-API-KEY", apiKey);
+
+            using var response = await http.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            var body = await ReadOrThrowAsync(response, cancellationToken).ConfigureAwait(false);
+
+            var results = new List<SearchResult>();
+            using var doc = JsonDocument.Parse(body);
+            if (doc.RootElement.TryGetProperty("organic", out var items) && items.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var item in items.EnumerateArray())
+                {
+                    var url = item.TryGetProperty("link", out var l) ? l.GetString() : null;
+                    if (string.IsNullOrEmpty(url)) continue;
+
+                    var title = item.TryGetProperty("title", out var t) ? t.GetString() : null;
+                    var snippet = item.TryGetProperty("snippet", out var s) ? s.GetString() : null;
+
+                    results.Add(new SearchResult(title ?? url, url, CleanSnippet(snippet)));
+                }
+            }
+
+            return new SearchResponse(results, DisplayName);
+        }
+    }
+}

--- a/Tools/Search/Providers/TavilySearchProvider.cs
+++ b/Tools/Search/Providers/TavilySearchProvider.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Saturn.Providers;
+
+namespace Saturn.Tools.Search.Providers
+{
+    public sealed class TavilySearchProvider : SearchProviderBase
+    {
+        public override string Name => "tavily";
+        public override string DisplayName => "Tavily";
+        public override string EnvironmentVariable => "TAVILY_API_KEY";
+
+        public override async Task<SearchResponse> SearchAsync(
+            string query, int maxResults, ProviderSettings settings, HttpClient http, CancellationToken cancellationToken = default)
+        {
+            var apiKey = ResolveApiKey(settings);
+
+            var payload = new Dictionary<string, object>
+            {
+                ["query"] = query,
+                ["max_results"] = maxResults
+            };
+
+            using var request = new HttpRequestMessage(HttpMethod.Post, "https://api.tavily.com/search")
+            {
+                Content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json")
+            };
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+
+            using var response = await http.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            var body = await ReadOrThrowAsync(response, cancellationToken).ConfigureAwait(false);
+
+            var results = new List<SearchResult>();
+            using var doc = JsonDocument.Parse(body);
+            if (doc.RootElement.TryGetProperty("results", out var items) && items.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var item in items.EnumerateArray())
+                {
+                    var url = item.TryGetProperty("url", out var u) ? u.GetString() : null;
+                    if (string.IsNullOrEmpty(url)) continue;
+
+                    var title = item.TryGetProperty("title", out var t) ? t.GetString() : null;
+                    var content = item.TryGetProperty("content", out var c) ? c.GetString() : null;
+
+                    results.Add(new SearchResult(title ?? url, url, CleanSnippet(content)));
+                }
+            }
+
+            return new SearchResponse(results, DisplayName);
+        }
+    }
+}

--- a/Tools/Search/SearchProviderRegistry.cs
+++ b/Tools/Search/SearchProviderRegistry.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Saturn.Tools.Search.Providers;
+
+namespace Saturn.Tools.Search
+{
+    public static class SearchProviderRegistry
+    {
+        private static readonly object _lock = new();
+        private static readonly Dictionary<string, ISearchProvider> _providers = new(StringComparer.OrdinalIgnoreCase);
+
+        static SearchProviderRegistry()
+        {
+            Register(new TavilySearchProvider());
+            Register(new BraveSearchProvider());
+            Register(new SerperSearchProvider());
+            Register(new SerpApiSearchProvider());
+            Register(new ExaSearchProvider());
+        }
+
+        public static void Register(ISearchProvider provider)
+        {
+            if (provider == null) throw new ArgumentNullException(nameof(provider));
+            lock (_lock)
+            {
+                _providers[provider.Name] = provider;
+            }
+        }
+
+        public static bool TryGet(string name, out ISearchProvider provider)
+        {
+            lock (_lock)
+            {
+                return _providers.TryGetValue(name ?? string.Empty, out provider!);
+            }
+        }
+
+        public static ISearchProvider Get(string name)
+        {
+            if (TryGet(name, out var provider))
+            {
+                return provider;
+            }
+
+            lock (_lock)
+            {
+                var known = _providers.Count == 0 ? "(none registered)" : string.Join(", ", _providers.Keys);
+                throw new InvalidOperationException($"Unknown search provider '{name}'. Available providers: {known}.");
+            }
+        }
+
+        public static IReadOnlyList<ISearchProvider> All
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return _providers.Values.OrderBy(p => p.DisplayName, StringComparer.OrdinalIgnoreCase).ToList();
+                }
+            }
+        }
+
+        public static void Clear()
+        {
+            lock (_lock)
+            {
+                _providers.Clear();
+            }
+        }
+    }
+}

--- a/Tools/Search/SearchTypes.cs
+++ b/Tools/Search/SearchTypes.cs
@@ -1,0 +1,8 @@
+using System.Collections.Generic;
+
+namespace Saturn.Tools.Search
+{
+    public sealed record SearchResult(string Title, string Url, string Snippet);
+
+    public sealed record SearchResponse(IReadOnlyList<SearchResult> Results, string Provider);
+}

--- a/Tools/WebSearchTool.cs
+++ b/Tools/WebSearchTool.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Saturn.Configuration;
+using Saturn.Providers;
+using Saturn.Tools.Core;
+using Saturn.Tools.Search;
+
+namespace Saturn.Tools
+{
+    public class WebSearchTool : ToolBase
+    {
+        private const int DefaultMaxResults = 8;
+        private const int MinResults = 1;
+        private const int MaxResults = 20;
+
+        public override string Name => "web_search";
+
+        public override string Description => @"Searches the web and returns a ranked list of titles, URLs, and snippets.
+
+When to use:
+- Finding current information, news, or documentation not in your training data
+- Discovering URLs to then read in full with web_fetch
+- Researching libraries, APIs, error messages, or how-to guidance
+
+How to use:
+- Set 'query' to your search terms
+- Optionally set 'max_results' (default 8) or 'provider' to override the configured search provider
+
+Requires a configured search provider (Tavily, Brave, Serper, SerpAPI, or Exa). If none is configured the tool returns instructions for configuring one.";
+
+        private static readonly HttpClient DefaultHttpClient = new(new SocketsHttpHandler
+        {
+            AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
+        })
+        {
+            Timeout = TimeSpan.FromSeconds(30)
+        };
+
+        // Test seam: allows tests to inject a stubbed HttpClient.
+        internal static HttpClient? HttpClientOverride { get; set; }
+
+        private static HttpClient Http => HttpClientOverride ?? DefaultHttpClient;
+
+        protected override Dictionary<string, object> GetParameterProperties()
+        {
+            return new Dictionary<string, object>
+            {
+                { "query", new Dictionary<string, object>
+                    {
+                        { "type", "string" },
+                        { "description", "The search query" }
+                    }
+                },
+                { "max_results", new Dictionary<string, object>
+                    {
+                        { "type", "integer" },
+                        { "default", DefaultMaxResults },
+                        { "description", $"Maximum number of results to return (default {DefaultMaxResults}, {MinResults}-{MaxResults})" }
+                    }
+                },
+                { "provider", new Dictionary<string, object>
+                    {
+                        { "type", "string" },
+                        { "enum", SearchProviderRegistry.All.Select(p => p.Name).ToArray() },
+                        { "description", "Override the configured search provider for this one search" }
+                    }
+                }
+            };
+        }
+
+        protected override string[] GetRequiredParameters() => new[] { "query" };
+
+        public override string GetDisplaySummary(Dictionary<string, object> parameters)
+        {
+            var query = GetParameter<string>(parameters, "query", "");
+            return string.IsNullOrEmpty(query) ? "Searching the web" : $"Searching web: {TruncateString(query, 50)}";
+        }
+
+        public override async Task<ToolResult> ExecuteAsync(Dictionary<string, object> parameters)
+        {
+            var query = GetParameter<string>(parameters, "query");
+            if (string.IsNullOrWhiteSpace(query))
+            {
+                return CreateErrorResult("Query cannot be empty");
+            }
+
+            var maxResults = Math.Clamp(GetParameter<int>(parameters, "max_results", DefaultMaxResults), MinResults, MaxResults);
+            var providerOverride = GetParameter<string?>(parameters, "provider", null);
+
+            var persisted = await ConfigurationManager.LoadConfigurationAsync();
+
+            ISearchProvider? provider = null;
+            if (!string.IsNullOrWhiteSpace(providerOverride))
+            {
+                if (!SearchProviderRegistry.TryGet(providerOverride, out provider))
+                {
+                    var known = string.Join(", ", SearchProviderRegistry.All.Select(p => p.Name));
+                    return CreateErrorResult($"Unknown search provider '{providerOverride}'. Available: {known}.");
+                }
+            }
+            else if (!string.IsNullOrWhiteSpace(persisted?.SearchProvider))
+            {
+                SearchProviderRegistry.TryGet(persisted!.SearchProvider!, out provider);
+            }
+
+            // Fall back to the first provider that already has a resolvable API key
+            // (e.g. via environment variable), so env-only setups work with zero config.
+            provider ??= SearchProviderRegistry.All.FirstOrDefault(p => HasApiKey(p, persisted));
+
+            if (provider == null)
+            {
+                return CreateErrorResult(NoProviderMessage());
+            }
+
+            var settings = ConfigurationManager.GetSearchProviderSettings(persisted, provider.Name);
+            if (!HasApiKey(provider, persisted))
+            {
+                return CreateErrorResult($"Search provider '{provider.DisplayName}' has no API key. " + NoProviderMessage());
+            }
+
+            try
+            {
+                var response = await provider.SearchAsync(query, maxResults, settings, Http);
+                return CreateSuccessResult(response, FormatResults(query, response));
+            }
+            catch (TaskCanceledException)
+            {
+                return CreateErrorResult($"Web search timed out after 30 seconds ({provider.DisplayName}).");
+            }
+            catch (HttpRequestException ex)
+            {
+                return CreateErrorResult(ex.Message);
+            }
+            catch (Exception ex)
+            {
+                return CreateErrorResult($"Web search failed ({provider.DisplayName}): {ex.Message}");
+            }
+        }
+
+        private static bool HasApiKey(ISearchProvider provider, Configuration.Objects.PersistedAgentConfiguration? persisted)
+        {
+            var settings = ConfigurationManager.GetSearchProviderSettings(persisted, provider.Name);
+            var descriptor = provider.SettingDescriptors.FirstOrDefault(d => d.Kind == ProviderSettingKind.Secret);
+            return descriptor != null && !string.IsNullOrWhiteSpace(descriptor.Resolve(settings));
+        }
+
+        private static string NoProviderMessage()
+        {
+            return "No web search provider is configured. Configure one in the TUI (Agent menu > Search Provider...), " +
+                   "the web UI (Settings > Web Search), or set an environment variable: " +
+                   "TAVILY_API_KEY, BRAVE_API_KEY, SERPER_API_KEY, SERPAPI_API_KEY, or EXA_API_KEY.";
+        }
+
+        private static string FormatResults(string query, SearchResponse response)
+        {
+            if (response.Results.Count == 0)
+            {
+                return $"Web search via {response.Provider}: \"{query}\" returned no results.";
+            }
+
+            var sb = new StringBuilder();
+            sb.AppendLine($"Web search via {response.Provider}: \"{query}\" ({response.Results.Count} results)");
+            sb.AppendLine();
+
+            var index = 1;
+            foreach (var result in response.Results)
+            {
+                sb.AppendLine($"{index}. {result.Title}");
+                sb.AppendLine($"   {result.Url}");
+                if (!string.IsNullOrEmpty(result.Snippet))
+                {
+                    sb.AppendLine($"   {result.Snippet}");
+                }
+                sb.AppendLine();
+                index++;
+            }
+
+            return sb.ToString().TrimEnd();
+        }
+    }
+}

--- a/UI/ChatInterface.cs
+++ b/UI/ChatInterface.cs
@@ -199,6 +199,7 @@ namespace Saturn.UI
                     new MenuItem("_Modes...", "", async () => await ShowModeSelectionDialogAsync()),
                     null,
                     new MenuItem("_Provider...", "", async () => await ShowProviderDialogAsync()),
+                    new MenuItem("Searc_h Provider...", "", async () => await ShowSearchProviderDialogAsync()),
                     new MenuItem("_Select Model...", "", async () => await ShowModelSelectionDialog()),
                     new MenuItem("_Temperature...", "", () => ShowTemperatureDialog()),
                     new MenuItem("_Max Tokens...", "", () => ShowMaxTokensDialog()),
@@ -886,6 +887,13 @@ namespace Saturn.UI
             {
             }
             return "Not connected";
+        }
+
+        private async Task ShowSearchProviderDialogAsync()
+        {
+            var persisted = await ConfigurationManager.LoadConfigurationAsync();
+            var dialog = new SearchProviderSettingsDialog(persisted);
+            Application.Run(dialog);
         }
 
         private async Task ShowProviderDialogAsync()

--- a/UI/Dialogs/SearchProviderSettingsDialog.cs
+++ b/UI/Dialogs/SearchProviderSettingsDialog.cs
@@ -1,0 +1,273 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Terminal.Gui;
+using Saturn.Configuration;
+using Saturn.Configuration.Objects;
+using Saturn.Providers;
+using Saturn.Tools.Search;
+
+namespace Saturn.UI.Dialogs
+{
+    public class SearchProviderSettingsDialog : Dialog
+    {
+        private PersistedAgentConfiguration? persistedConfig;
+        private readonly List<ISearchProvider> providers;
+
+        private RadioGroup providerRadio = null!;
+        private View settingsArea = null!;
+        private Label statusLabel = null!;
+        private Button testButton = null!;
+        private Button applyButton = null!;
+        private Button cancelButton = null!;
+        private readonly List<(ProviderSettingDescriptor Descriptor, TextField Field)> settingFields = new();
+        private bool isBusy;
+
+        public bool Applied { get; private set; }
+
+        public override bool ProcessKey(KeyEvent keyEvent)
+        {
+            if (isBusy && keyEvent.Key == Key.Esc)
+            {
+                return true;
+            }
+            return base.ProcessKey(keyEvent);
+        }
+
+        public SearchProviderSettingsDialog(PersistedAgentConfiguration? persistedConfig)
+            : base("Web Search Provider", 78, 24)
+        {
+            ColorScheme = Colors.Dialog;
+            this.persistedConfig = persistedConfig;
+            providers = SearchProviderRegistry.All.ToList();
+
+            InitializeComponents();
+        }
+
+        private void InitializeComponents()
+        {
+            var providerLabel = new Label("Provider:")
+            {
+                X = 1,
+                Y = 1
+            };
+
+            providerRadio = new RadioGroup(providers.Select(p => (NStack.ustring)p.DisplayName).ToArray())
+            {
+                X = 1,
+                Y = 2
+            };
+
+            var activeIndex = providers.FindIndex(p =>
+                string.Equals(p.Name, persistedConfig?.SearchProvider, StringComparison.OrdinalIgnoreCase));
+            if (activeIndex >= 0)
+            {
+                providerRadio.SelectedItem = activeIndex;
+            }
+
+            providerRadio.SelectedItemChanged += (args) => RebuildSettingFields();
+
+            var separator = new Label(new string('─', 76))
+            {
+                X = 0,
+                Y = 2 + providers.Count + 1,
+                Width = Dim.Fill()
+            };
+
+            settingsArea = new View()
+            {
+                X = 1,
+                Y = Pos.Bottom(separator) + 1,
+                Width = Dim.Fill(1),
+                Height = 9
+            };
+
+            statusLabel = new Label("")
+            {
+                X = 1,
+                Y = Pos.Bottom(settingsArea) + 1,
+                Width = Dim.Fill(1),
+                Height = 2
+            };
+
+            testButton = new Button("_Test Search")
+            {
+                X = Pos.Center() - 20,
+                Y = Pos.Bottom(statusLabel) + 1
+            };
+            testButton.Clicked += () => OnTestClicked();
+
+            applyButton = new Button("_Apply", true)
+            {
+                X = Pos.Right(testButton) + 2,
+                Y = Pos.Top(testButton)
+            };
+            applyButton.Clicked += () => OnApplyClicked();
+
+            cancelButton = new Button("_Cancel")
+            {
+                X = Pos.Right(applyButton) + 2,
+                Y = Pos.Top(testButton)
+            };
+            cancelButton.Clicked += () => Application.RequestStop();
+
+            Add(providerLabel, providerRadio, separator, settingsArea, statusLabel,
+                testButton, applyButton, cancelButton);
+
+            RebuildSettingFields();
+        }
+
+        private ISearchProvider SelectedProvider => providers[Math.Max(0, providerRadio.SelectedItem)];
+
+        private void RebuildSettingFields()
+        {
+            var oldViews = settingsArea.Subviews.ToList();
+            settingsArea.RemoveAll();
+            foreach (var view in oldViews)
+            {
+                view.Dispose();
+            }
+            settingFields.Clear();
+
+            var provider = SelectedProvider;
+            var saved = ConfigurationManager.GetSearchProviderSettings(persistedConfig, provider.Name);
+
+            int y = 0;
+            foreach (var descriptor in provider.SettingDescriptors)
+            {
+                var label = new Label($"{descriptor.Label}:")
+                {
+                    X = 0,
+                    Y = y
+                };
+
+                var field = new TextField(saved.Get(descriptor.Key) ?? "")
+                {
+                    X = 28,
+                    Y = y,
+                    Width = Dim.Fill(1),
+                    Secret = descriptor.Kind == ProviderSettingKind.Secret
+                };
+
+                settingsArea.Add(label, field);
+                settingFields.Add((descriptor, field));
+                y++;
+
+                var hints = new List<string>();
+                if (!string.IsNullOrWhiteSpace(descriptor.EnvironmentVariable))
+                {
+                    var envSet = !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(descriptor.EnvironmentVariable));
+                    hints.Add(envSet
+                        ? $"blank = env {descriptor.EnvironmentVariable}"
+                        : $"env: {descriptor.EnvironmentVariable}");
+                }
+                if (!string.IsNullOrWhiteSpace(descriptor.DefaultValue))
+                {
+                    hints.Add($"default: {descriptor.DefaultValue}");
+                }
+
+                if (hints.Count > 0)
+                {
+                    var hintLabel = new Label($"  ({string.Join(" | ", hints)})")
+                    {
+                        X = 0,
+                        Y = y,
+                        Width = Dim.Fill(1),
+                        ColorScheme = Colors.Menu
+                    };
+                    settingsArea.Add(hintLabel);
+                    y++;
+                }
+
+                y++;
+            }
+
+            statusLabel.Text = "";
+            settingsArea.SetNeedsDisplay();
+        }
+
+        private ProviderSettings CollectSettings()
+        {
+            var settings = new ProviderSettings();
+            foreach (var (descriptor, field) in settingFields)
+            {
+                settings.Set(descriptor.Key, field.Text?.ToString());
+            }
+            return settings;
+        }
+
+        private void SetBusy(bool busy)
+        {
+            isBusy = busy;
+            testButton.Enabled = !busy;
+            applyButton.Enabled = !busy;
+            cancelButton.Enabled = !busy;
+        }
+
+        private void SetStatus(string message)
+        {
+            Application.MainLoop.Invoke(() =>
+            {
+                statusLabel.Text = message;
+                Application.Refresh();
+            });
+        }
+
+        private async void OnTestClicked()
+        {
+            var provider = SelectedProvider;
+            var settings = CollectSettings();
+
+            SetBusy(true);
+            SetStatus($"Testing search via {provider.DisplayName}...");
+
+            try
+            {
+                var response = await provider.SearchAsync("saturn agent test", 1, settings, SearchHttpClient);
+                SetStatus($"{provider.DisplayName} OK — {response.Results.Count} result(s) returned.");
+            }
+            catch (Exception ex)
+            {
+                SetStatus(ex.Message);
+            }
+            finally
+            {
+                Application.MainLoop.Invoke(() => SetBusy(false));
+            }
+        }
+
+        private async void OnApplyClicked()
+        {
+            var provider = SelectedProvider;
+            var settings = CollectSettings();
+
+            SetBusy(true);
+            SetStatus($"Saving {provider.DisplayName}...");
+
+            try
+            {
+                await ConfigurationManager.SaveSearchProviderSelectionAsync(provider.Name, settings);
+                Applied = true;
+                persistedConfig = await ConfigurationManager.LoadConfigurationAsync();
+                Application.MainLoop.Invoke(() =>
+                {
+                    SetBusy(false);
+                    if (Application.Current == this)
+                    {
+                        Application.RequestStop();
+                    }
+                });
+            }
+            catch (Exception ex)
+            {
+                SetStatus(ex.Message);
+                Application.MainLoop.Invoke(() => SetBusy(false));
+            }
+        }
+
+        private static readonly System.Net.Http.HttpClient SearchHttpClient = new()
+        {
+            Timeout = TimeSpan.FromSeconds(30)
+        };
+    }
+}

--- a/Web/ApiModels.cs
+++ b/Web/ApiModels.cs
@@ -54,6 +54,8 @@ namespace Saturn.Web
 
     public record ProviderSwitchRequest(string Provider, Dictionary<string, string?>? Settings, string? Model);
 
+    public record SearchProviderSwitchRequest(string? Provider, Dictionary<string, string?>? Settings);
+
     public record ModelSwitchRequest(string Model);
 
     public record AgentConfigUpdateRequest(

--- a/Web/WebServer.cs
+++ b/Web/WebServer.cs
@@ -22,6 +22,7 @@ using Saturn.Data;
 using Saturn.Data.Tasks;
 using Saturn.Providers;
 using Saturn.Tools.Core;
+using Saturn.Tools.Search;
 
 namespace Saturn.Web
 {
@@ -421,6 +422,66 @@ namespace Saturn.Web
                 await Saturn.Configuration.ConfigurationManager.SaveProviderSelectionAsync(provider.Name, settings, model);
                 _hub.Publish("provider.changed", new { provider = _clientSource.ActiveProviderName, model });
                 return Results.Ok(new { provider = _clientSource.ActiveProviderName, model, connected = _clientSource.IsConnected });
+            });
+
+            api.MapGet("/search-providers", async () =>
+            {
+                var persisted = await Saturn.Configuration.ConfigurationManager.LoadConfigurationAsync();
+                return Results.Ok(SearchProviderRegistry.All.Select(p =>
+                {
+                    var saved = Saturn.Configuration.ConfigurationManager.GetSearchProviderSettings(persisted, p.Name);
+                    return new
+                    {
+                        name = p.Name,
+                        displayName = p.DisplayName,
+                        active = string.Equals(persisted?.SearchProvider, p.Name, StringComparison.OrdinalIgnoreCase),
+                        settings = p.SettingDescriptors.Select(d => new
+                        {
+                            key = d.Key,
+                            label = d.Label,
+                            kind = d.Kind.ToString().ToLowerInvariant(),
+                            required = d.Required,
+                            defaultValue = d.DefaultValue,
+                            environmentVariable = d.EnvironmentVariable,
+                            configured = !string.IsNullOrWhiteSpace(d.Resolve(saved)),
+                            // Secrets are never echoed back to the browser.
+                            value = d.Kind == ProviderSettingKind.Secret ? null : saved.Get(d.Key)
+                        })
+                    };
+                }));
+            });
+
+            api.MapPost("/search-providers/switch", async (SearchProviderSwitchRequest request) =>
+            {
+                if (!SearchProviderRegistry.TryGet(request.Provider ?? "", out var provider))
+                {
+                    return Results.NotFound(new { error = $"Unknown search provider '{request.Provider}'" });
+                }
+
+                var persisted = await Saturn.Configuration.ConfigurationManager.LoadConfigurationAsync();
+                var settings = Saturn.Configuration.ConfigurationManager.GetSearchProviderSettings(persisted, provider.Name);
+                if (request.Settings != null)
+                {
+                    foreach (var kvp in request.Settings)
+                    {
+                        // Only overwrite with non-empty values so a blank secret field keeps the stored key.
+                        if (!string.IsNullOrWhiteSpace(kvp.Value))
+                        {
+                            settings.Set(kvp.Key, kvp.Value);
+                        }
+                    }
+                }
+
+                var missing = provider.SettingDescriptors
+                    .FirstOrDefault(d => d.Required && string.IsNullOrWhiteSpace(d.Resolve(settings)));
+                if (missing != null)
+                {
+                    return Results.BadRequest(new { error = $"{missing.Label} is required for {provider.DisplayName}." });
+                }
+
+                await Saturn.Configuration.ConfigurationManager.SaveSearchProviderSelectionAsync(provider.Name, settings);
+                _hub.Publish("search.provider.changed", new { provider = provider.Name });
+                return Results.Ok(new { provider = provider.Name, configured = true });
             });
 
             api.MapPost("/model", async (ModelSwitchRequest request) =>

--- a/Web/wwwroot/app.js
+++ b/Web/wwwroot/app.js
@@ -1373,6 +1373,7 @@ async function loadSettings() {
 
   await Promise.all([
     withPanelFallback(loadProviderPanel, "#prov-settings"),
+    withPanelFallback(loadSearchProviderPanel, "#search-prov-settings"),
     withPanelFallback(loadGenerationPanel, null),
     withPanelFallback(loadToolsPanel, "#tool-grid"),
     withPanelFallback(loadSubAgentPanel, null),
@@ -1465,6 +1466,57 @@ $("#model-apply").addEventListener("click", async () => {
     await Promise.all([loadSettings(), loadOverview()]);
   } catch (err) {
     toast(`<b>Error:</b> ${esc(err.message)}`);
+  }
+});
+
+/* ---- search provider panel ---- */
+
+let searchProviderData = [];
+
+async function loadSearchProviderPanel() {
+  searchProviderData = await api.get("/search-providers");
+  const select = $("#search-prov-select");
+  select.innerHTML = searchProviderData
+    .map((p) => `<option value="${esc(p.name)}" ${p.active ? "selected" : ""}>${esc(p.displayName)}</option>`)
+    .join("");
+  renderSearchProviderSettings(select.value);
+}
+
+function renderSearchProviderSettings(providerName) {
+  const provider = searchProviderData.find((p) => p.name === providerName);
+  if (!provider) return;
+  $("#search-prov-settings").innerHTML = provider.settings
+    .map(
+      (d) => `
+      <label class="field"><span>${esc(d.label)}${d.required ? " *" : ""}${d.configured ? " · configured" : ""}${d.environmentVariable ? ` (env: ${esc(d.environmentVariable)})` : ""}</span>
+        <input class="input search-prov-setting" data-key="${esc(d.key)}" type="${d.kind === "secret" ? "password" : d.kind === "number" ? "number" : "text"}"
+          style="width:100%" placeholder="${esc(d.kind === "secret" && d.configured ? "(unchanged)" : d.defaultValue || "")}"
+          value="${esc(d.value || "")}">
+      </label>`
+    )
+    .join("");
+}
+
+$("#search-prov-select").addEventListener("change", (e) => renderSearchProviderSettings(e.target.value));
+
+$("#search-prov-apply").addEventListener("click", async () => {
+  const settings = {};
+  $$(".search-prov-setting").forEach((i) => {
+    if (i.value.trim() !== "") settings[i.dataset.key] = i.value.trim();
+  });
+  $("#search-prov-status").textContent = "Saving…";
+  $("#search-prov-apply").disabled = true;
+  try {
+    const r = await api.post("/search-providers/switch", {
+      provider: $("#search-prov-select").value,
+      settings,
+    });
+    $("#search-prov-status").textContent = `Search provider set to ${r.provider}`;
+    await loadSearchProviderPanel();
+  } catch (err) {
+    $("#search-prov-status").textContent = `Failed: ${err.message}`;
+  } finally {
+    $("#search-prov-apply").disabled = false;
   }
 });
 

--- a/Web/wwwroot/index.html
+++ b/Web/wwwroot/index.html
@@ -252,6 +252,17 @@
         </div>
 
         <div class="panel">
+          <div class="panel-head"><h2>Web Search</h2></div>
+          <label class="field"><span>Provider</span>
+            <select id="search-prov-select" class="input select" style="width:100%"></select></label>
+          <div id="search-prov-settings"></div>
+          <div class="field-row">
+            <button class="btn primary" id="search-prov-apply">Save search provider</button>
+          </div>
+          <p class="hint" id="search-prov-status"></p>
+        </div>
+
+        <div class="panel">
           <div class="panel-head"><h2>Generation</h2></div>
           <div class="field-row" style="margin-bottom:12px">
             <label class="field" style="flex:1;margin:0"><span>Temperature</span><input class="input" id="gen-temp" type="number" step="0.05" min="0" max="2" style="width:100%"></label>


### PR DESCRIPTION
Adds a single web_search agent tool backed by Tavily, Brave, Serper, SerpAPI, or Exa.

- Active provider and API key are user-configurable in both the TUI (Agent > Search Provider) and the web UI (Settings > Web Search)
- Keys fall back to per-provider env vars and are encrypted at rest like the LLM provider keys
- Enabled by default; returns an actionable error when no provider is configured
- Tests cover per-provider request/parse, tool selection, and the encrypted config round-trip