### PR TITLE
Fix tool path validation, shell escaping, and agent lifecycle bugs

### DIFF
--- a/Agents/Core/AgentBase.cs
+++ b/Agents/Core/AgentBase.cs
@@ -99,10 +99,10 @@ namespace Saturn.Agents.Core
             TrimHistory();
         }
 
-        public virtual async Task<T> Execute<T>(object input)
+        public virtual async Task<T> Execute<T>(object input, CancellationToken cancellationToken = default)
         {
             var messages = PrepareMessages(input?.ToString() ?? string.Empty);
-            var responseMessage = await ExecuteWithTools(messages);
+            var responseMessage = await ExecuteWithTools(messages, cancellationToken);
             var finalMessage = ProcessResponse(responseMessage);
             return (T)(object)finalMessage;
         }
@@ -343,7 +343,7 @@ namespace Saturn.Agents.Core
             }
         }
 
-        protected async Task<AssistantMessageResponse> ExecuteWithTools(List<Message> initialMessages)
+        protected async Task<AssistantMessageResponse> ExecuteWithTools(List<Message> initialMessages, CancellationToken cancellationToken = default)
         {
             var client = Configuration.ClientSource.Current;
 
@@ -353,6 +353,8 @@ namespace Saturn.Agents.Core
 
             while (continueProcessing)
             {
+                cancellationToken.ThrowIfCancellationRequested();
+
                 if (!ValidateToolMessageSequence(currentMessages))
                 {
 
@@ -415,6 +417,8 @@ namespace Saturn.Agents.Core
                             
                         }
                     }
+
+                    cancellationToken.ThrowIfCancellationRequested();
 
                     var toolResults = await HandleToolCalls(validToolCalls);
 

--- a/Agents/MultiAgent/AgentManager.cs
+++ b/Agents/MultiAgent/AgentManager.cs
@@ -12,12 +12,13 @@ using Saturn.Config;
 using Saturn.Data;
 using Saturn.OpenRouter.Models.Api.Chat;
 using Saturn.Providers;
+using Saturn.Tools.Core;
 
 namespace Saturn.Agents.MultiAgent
 {
     public class AgentManager
     {
-        private static AgentManager? _instance;
+        private static readonly Lazy<AgentManager> _lazyInstance = new Lazy<AgentManager>(() => new AgentManager());
         private readonly ConcurrentDictionary<string, SubAgentContext> _runningAgents;
         private readonly ConcurrentDictionary<string, AgentTaskResult> _completedTasks;
         private readonly ConcurrentDictionary<string, ReviewerContext> _reviewers;
@@ -25,13 +26,22 @@ namespace Saturn.Agents.MultiAgent
         private ILlmClientSource _clientSource = null!;
         private const int DefaultMaxConcurrentAgents = 50;
         private const int AbsoluteMaxConcurrentAgents = 200;
+
+        // Agent-lifecycle and orchestrator-only tools; sub-agents must not see these
+        // (recursive create_agent, terminating siblings, or waiting on their own task).
+        private static readonly HashSet<string> SubAgentExcludedTools = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "create_agent", "hand_off_to_agent", "terminate_agent",
+            "wait_for_agent", "get_agent_status", "get_task_result",
+            "claim_task", "dispatch_task", "list_due_tasks"
+        };
         private int _maxConcurrentAgents = DefaultMaxConcurrentAgents;
         private readonly object _agentRegistrationLock = new object();
         private string? _parentSessionId;
         private string? _parentModel;
         private bool _parentEnableUserRules = true;
         
-        public static AgentManager Instance => _instance ??= new AgentManager();
+        public static AgentManager Instance => _lazyInstance.Value;
         
         public event Action<string, string, string>? OnAgentStatusChanged;
         public event Action<string, string>? OnAgentCreated;
@@ -46,10 +56,7 @@ namespace Saturn.Agents.MultiAgent
         
         public void Initialize(ILlmClientSource clientSource)
         {
-            if (_instance != null)
-            {
-                _instance._clientSource = clientSource;
-            }
+            _clientSource = clientSource;
         }
         
         public void SetParentSessionId(string? sessionId)
@@ -136,6 +143,9 @@ Your report is consumed by an orchestrator agent, so keep it factual and free of
                     MaxTokens = maxTokens ?? 4096,
                     TopP = topP ?? 0.95,
                     EnableTools = enableTools,
+                    ToolNames = ToolRegistry.Instance.GetAllNames()
+                        .Where(name => !SubAgentExcludedTools.Contains(name))
+                        .ToList(),
                     MaintainHistory = true,
                     MaxHistoryMessages = 20
                 };
@@ -170,16 +180,32 @@ Your report is consumed by an orchestrator agent, so keep it factual and free of
             }
 
             var taskId = $"task_{Guid.NewGuid():N}".Substring(0, 12);
+            var cancellation = new CancellationTokenSource();
 
-            agentContext.Status = AgentStatus.Working;
-            agentContext.CurrentTask = new AgentTask
+            lock (_agentRegistrationLock)
             {
-                Id = taskId,
-                Description = task,
-                Context = context,
-                StartedAt = DateTime.Now,
-                Status = TaskStatus.Running
-            };
+                if (agentContext.Agent == null)
+                {
+                    throw new InvalidOperationException($"Agent {agentId} is still initializing; retry shortly");
+                }
+
+                if (agentContext.Status != AgentStatus.Idle)
+                {
+                    throw new InvalidOperationException(
+                        $"Agent {agentId} is busy (status: {agentContext.Status}, task: {agentContext.CurrentTask?.Id ?? "unknown"}); wait for it to finish before handing off another task");
+                }
+
+                agentContext.Status = AgentStatus.Working;
+                agentContext.Cancellation = cancellation;
+                agentContext.CurrentTask = new AgentTask
+                {
+                    Id = taskId,
+                    Description = task,
+                    Context = context,
+                    StartedAt = DateTime.Now,
+                    Status = TaskStatus.Running
+                };
+            }
 
             OnAgentStatusChanged?.Invoke(agentId, agentContext.Name, "Working");
 
@@ -187,7 +213,22 @@ Your report is consumed by an orchestrator agent, so keep it factual and free of
             // agent runs; a fast-completing agent would otherwise race past it.
             if (onBeforeStart != null)
             {
-                await onBeforeStart(taskId);
+                try
+                {
+                    await onBeforeStart(taskId);
+                }
+                catch
+                {
+                    lock (_agentRegistrationLock)
+                    {
+                        agentContext.Status = AgentStatus.Idle;
+                        agentContext.CurrentTask = null;
+                        agentContext.Cancellation = null;
+                    }
+                    cancellation.Dispose();
+                    OnAgentStatusChanged?.Invoke(agentId, agentContext.Name, "Idle");
+                    throw;
+                }
             }
 
             _ = Task.Run(async () =>
@@ -204,7 +245,7 @@ Your report is consumed by an orchestrator agent, so keep it factual and free of
                         }
                     }
                     
-                    var result = await agentContext.Agent.Execute<Message>(input);
+                    var result = await agentContext.Agent.Execute<Message>(input, cancellation.Token);
                     
                     if (SubAgentPreferences.Instance.EnableReviewStage)
                     {
@@ -227,7 +268,7 @@ Your report is consumed by an orchestrator agent, so keep it factual and free of
                             OnAgentStatusChanged?.Invoke(agentId, agentContext.Name, $"Revising (Attempt {agentContext.RevisionCount})");
                             
                             var revisionInput = $"Please revise your previous work based on this feedback:\n{reviewDecision.Feedback}\n\nOriginal task: {task}";
-                            var revisedResult = await agentContext.Agent.Execute<Message>(revisionInput);
+                            var revisedResult = await agentContext.Agent.Execute<Message>(revisionInput, cancellation.Token);
                             currentResult = revisedResult.Content.ToString();
                             
                             agentContext.Status = AgentStatus.BeingReviewed;
@@ -263,6 +304,10 @@ Your report is consumed by an orchestrator agent, so keep it factual and free of
                     {
                         CompleteTask(taskId, agentId, agentContext, true, result.Content.ToString());
                     }
+                }
+                catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
+                {
+                    CompleteTask(taskId, agentId, agentContext, false, "Task terminated before completion");
                 }
                 catch (Exception ex)
                 {
@@ -540,6 +585,29 @@ Your decision:";
         
         private void CompleteTask(string taskId, string agentId, SubAgentContext agentContext, bool success, string result)
         {
+            DateTime? startedAt = null;
+            var becameIdle = false;
+
+            lock (_agentRegistrationLock)
+            {
+                var currentTask = agentContext.CurrentTask;
+                if (currentTask != null && currentTask.Id == taskId)
+                {
+                    startedAt = currentTask.StartedAt;
+                    currentTask.Status = success ? TaskStatus.Completed : TaskStatus.Failed;
+                    agentContext.CurrentTask = null;
+                    agentContext.RevisionCount = 0;
+                    agentContext.Cancellation?.Dispose();
+                    agentContext.Cancellation = null;
+
+                    if (agentContext.Status != AgentStatus.Terminated)
+                    {
+                        agentContext.Status = AgentStatus.Idle;
+                        becameIdle = _runningAgents.ContainsKey(agentId);
+                    }
+                }
+            }
+
             var taskResult = new AgentTaskResult
             {
                 TaskId = taskId,
@@ -548,24 +616,39 @@ Your decision:";
                 Success = success,
                 Result = result,
                 CompletedAt = DateTime.Now,
-                Duration = DateTime.Now - agentContext.CurrentTask!.StartedAt
+                Duration = startedAt.HasValue ? DateTime.Now - startedAt.Value : TimeSpan.Zero
             };
-            
+
+            // Always record the result, even for a terminated or superseded task,
+            // so callers waiting on the task id resolve instead of timing out.
             _completedTasks[taskId] = taskResult;
-            agentContext.CurrentTask!.Status = success ? TaskStatus.Completed : TaskStatus.Failed;
-            agentContext.Status = AgentStatus.Idle;
-            agentContext.CurrentTask = null;
-            agentContext.RevisionCount = 0;
-            
+
             OnTaskCompleted?.Invoke(taskId, taskResult);
-            OnAgentStatusChanged?.Invoke(agentId, agentContext.Name, "Idle");
+            if (becameIdle)
+            {
+                OnAgentStatusChanged?.Invoke(agentId, agentContext.Name, "Idle");
+            }
         }
-        
+
         public void TerminateAgent(string agentId)
         {
             if (_runningAgents.TryRemove(agentId, out var context))
             {
-                context.Status = AgentStatus.Terminated;
+                CancellationTokenSource? cancellation;
+                lock (_agentRegistrationLock)
+                {
+                    context.Status = AgentStatus.Terminated;
+                    cancellation = context.Cancellation;
+                }
+
+                try
+                {
+                    cancellation?.Cancel();
+                }
+                catch (ObjectDisposedException)
+                {
+                }
+
                 OnAgentStatusChanged?.Invoke(agentId, context.Name, "Terminated");
             }
         }

--- a/Agents/MultiAgent/AgentManager.cs
+++ b/Agents/MultiAgent/AgentManager.cs
@@ -219,14 +219,26 @@ Your report is consumed by an orchestrator agent, so keep it factual and free of
                 }
                 catch
                 {
+                    var rolledBackToIdle = false;
                     lock (_agentRegistrationLock)
                     {
-                        agentContext.Status = AgentStatus.Idle;
-                        agentContext.CurrentTask = null;
-                        agentContext.Cancellation = null;
+                        // TerminateAgent may have run while the callback was awaited;
+                        // never resurrect a terminated agent, and only roll back the
+                        // task this handoff created.
+                        if (agentContext.Status != AgentStatus.Terminated &&
+                            agentContext.CurrentTask?.Id == taskId)
+                        {
+                            agentContext.Status = AgentStatus.Idle;
+                            agentContext.CurrentTask = null;
+                            agentContext.Cancellation = null;
+                            rolledBackToIdle = true;
+                        }
                     }
                     cancellation.Dispose();
-                    OnAgentStatusChanged?.Invoke(agentId, agentContext.Name, "Idle");
+                    if (rolledBackToIdle)
+                    {
+                        OnAgentStatusChanged?.Invoke(agentId, agentContext.Name, "Idle");
+                    }
                     throw;
                 }
             }
@@ -623,11 +635,14 @@ Your decision:";
             // so callers waiting on the task id resolve instead of timing out.
             _completedTasks[taskId] = taskResult;
 
-            OnTaskCompleted?.Invoke(taskId, taskResult);
+            // Publish the idle transition before completion handlers run: a handler
+            // may immediately hand off another task, and its "Working" event must
+            // not be followed by a stale "Idle".
             if (becameIdle)
             {
                 OnAgentStatusChanged?.Invoke(agentId, agentContext.Name, "Idle");
             }
+            OnTaskCompleted?.Invoke(taskId, taskResult);
         }
 
         public void TerminateAgent(string agentId)

--- a/Agents/MultiAgent/Objects/SubAgentContext.cs
+++ b/Agents/MultiAgent/Objects/SubAgentContext.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Saturn.Agents.MultiAgent.Objects
@@ -16,5 +17,6 @@ namespace Saturn.Agents.MultiAgent.Objects
         public DateTime CreatedAt { get; set; }
         public AgentTask? CurrentTask { get; set; }
         public int RevisionCount { get; set; } = 0;
+        public CancellationTokenSource? Cancellation { get; set; }
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -34,9 +34,10 @@ namespace Saturn
                     await Task.Delay(1000);
                 }
 
-                var (agent, client) = await CreateAgent();
+                var isWebMode = TryParseWebOptions(args, out var port);
+                var (agent, client) = await CreateAgent(isWebMode);
 
-                if (TryParseWebOptions(args, out var port))
+                if (isWebMode)
                 {
                     agent.IsOrchestrator = true;
                     // Long-horizon web sessions benefit from a deeper context window.
@@ -104,7 +105,7 @@ namespace Saturn
             }
         }
 
-        static async Task<(Agent, ILlmClientSource)> CreateAgent()
+        static async Task<(Agent, ILlmClientSource)> CreateAgent(bool isWebMode)
         {
             ProviderRegistry.Register(new OpenRouterProvider());
             ProviderRegistry.Register(new LMStudioProvider());
@@ -157,7 +158,108 @@ namespace Saturn
             var agentConfig = new Saturn.Agents.Core.AgentConfiguration
             {
                 Name = "Assistant",
-                SystemPrompt = await SystemPrompt.Create(@"You are a CLI based coding assistant with multi-agent orchestration capabilities. Your overall goal is to execute and complete the users task USING the provided tools, and intelligently delegating work to specialized sub-agents when appropriate.
+                SystemPrompt = await SystemPrompt.Create(BuildSystemPromptText(isWebMode), includeDirectories: true, includeUserRules: enableUserRules),
+                ClientSource = manager,
+                Model = model,
+                Temperature = temperature,
+                MaxTokens = 4096,
+                TopP = 0.25,
+                MaintainHistory = true,
+                MaxHistoryMessages = 10,
+                EnableTools = true,
+                EnableStreaming = true,
+                RequireCommandApproval = true,
+                EnableUserRules = enableUserRules,
+                ToolNames = BuildDefaultToolNames(isWebMode),
+            };
+
+            // Persisted configs predate newer tools; backfill only those.
+            // Re-adding the full default set would silently restore tools
+            // the user deliberately removed (e.g. execute_command).
+            var backfillTools = new List<string> { "update_todos", "web_search" };
+            if (isWebMode)
+            {
+                backfillTools.AddRange(WebModeTaskTools);
+            }
+
+            if (persistedConfig != null)
+            {
+                ConfigurationManager.ApplyToAgentConfiguration(agentConfig, persistedConfig);
+
+                agentConfig.Model = model;
+
+                agentConfig.ToolNames = agentConfig.ToolNames
+                    .Union(backfillTools, StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+            }
+            else
+            {
+                await ConfigurationManager.SaveConfigurationAsync(
+                    ConfigurationManager.FromAgentConfiguration(agentConfig));
+            }
+
+            if (!isWebMode)
+            {
+                // The task system only runs in web mode; its tools error out in the
+                // TUI, so don't offer them to the model there.
+                agentConfig.ToolNames = agentConfig.ToolNames
+                    .Where(name => !WebModeTaskTools.Contains(name, StringComparer.OrdinalIgnoreCase))
+                    .ToList();
+            }
+
+            await ConfigurationManager.SaveProviderSelectionAsync(providerName, providerSettings, model);
+
+            if (agentConfig.Model.Contains("gpt-5", StringComparison.OrdinalIgnoreCase))
+            {
+                agentConfig.Temperature = 1.0;
+            }
+
+            return (new Agent(agentConfig), manager);
+        }
+
+        private static readonly string[] WebModeTaskTools =
+        {
+            "list_tasks", "create_task", "update_task", "complete_task",
+            "wait_for_task", "claim_task", "dispatch_task", "list_due_tasks"
+        };
+
+        static List<string> BuildDefaultToolNames(bool isWebMode)
+        {
+            var toolNames = new List<string>
+            {
+                "apply_diff", "grep", "glob", "read_file", "list_files",
+                "write_file", "search_and_replace", "delete_file",
+                "create_agent", "hand_off_to_agent", "get_agent_status",
+                "wait_for_agent", "get_task_result", "terminate_agent", "execute_command",
+                "get_command_output", "kill_command", "web_fetch", "web_search",
+                "update_todos"
+            };
+
+            if (isWebMode)
+            {
+                toolNames.AddRange(WebModeTaskTools);
+            }
+
+            return toolNames;
+        }
+
+        static string BuildSystemPromptText(bool isWebMode)
+        {
+            var taskSystemSection = isWebMode ? @"Task System
+- The user maintains durable todo lists via the task tools: list_tasks, create_task, update_task, complete_task, wait_for_task, claim_task, dispatch_task, list_due_tasks.
+- Scopes: 'global' (machine-wide), 'project' (this repository, named boards), 'agent' (per-agent lists).
+- [Saturn Scheduler] messages are automated wake-ups: a recurring task fired, a task unblocked, a dispatched task completed, or an agent-available task is ready. Act on them using the task tools, then report concisely.
+- Tasks flagged requires-approval: call claim_task and WAIT for the user's decision (you will be woken). Never work on user-handoff-only tasks.
+- For long-running dependencies prefer wait_for_task over polling: register, end your turn, and you will be re-prompted with the result when it completes.
+- Keep the task list accurate: complete_task when work finishes, create_task for follow-ups you discover.
+
+" : "";
+
+            var todoScratchpadNote = isWebMode
+                ? "; use the task tools for the user's durable todo lists"
+                : "";
+
+            return @"You are a CLI based coding assistant with multi-agent orchestration capabilities. Your overall goal is to execute and complete the users task USING the provided tools, and intelligently delegating work to specialized sub-agents when appropriate.
 
 Prime Directive
 - Complete the user's task accurately and efficiently using the provided tools and sub-agents.
@@ -176,15 +278,7 @@ Prime Directive
 2) Output Rules:
    - **NEVER** Use emojis.
 
-Task System (web mode)
-- The user maintains durable todo lists via the task tools: list_tasks, create_task, update_task, complete_task, wait_for_task, claim_task, dispatch_task, list_due_tasks.
-- Scopes: 'global' (machine-wide), 'project' (this repository, named boards), 'agent' (per-agent lists).
-- [Saturn Scheduler] messages are automated wake-ups: a recurring task fired, a task unblocked, a dispatched task completed, or an agent-available task is ready. Act on them using the task tools, then report concisely.
-- Tasks flagged requires-approval: call claim_task and WAIT for the user's decision (you will be woken). Never work on user-handoff-only tasks.
-- For long-running dependencies prefer wait_for_task over polling: register, end your turn, and you will be re-prompted with the result when it completes.
-- Keep the task list accurate: complete_task when work finishes, create_task for follow-ups you discover.
-
-Multi-Agent Orchestration
+" + taskSystemSection + @"Multi-Agent Orchestration
 1) When to use sub-agents:
    - Background tasks: Long-running operations that don't need immediate attention
    - Parallel work: Multiple independent tasks that can run simultaneously
@@ -231,9 +325,9 @@ Operating Principles
 2) Planning
    - Make a brief plan before edits or commands. Keep the plan to 3–7 bullets.
    - Track multi-step work with update_todos: write the step list up front, keep exactly one item in_progress, and mark steps completed immediately.
-   - The update_todos list is your private, session-scoped scratchpad; use the task tools for the user's durable todo lists.
+   - The update_todos list is your private, session-scoped scratchpad" + todoScratchpadNote + @".
    - Identify opportunities for parallel execution with sub-agents.
-   - Track delegated work to avoid duplication - mark tasks as delegated.
+   - Track delegated work in your todo list (note the sub-agent task id) to avoid duplication.
    - If requirements are ambiguous, ask targeted clarifying questions.
    - When collecting sub-agent results, integrate don't recreate.
 
@@ -267,64 +361,7 @@ Operating Principles
    - Be mindful of the number of concurrent sub-agents.
    - Monitor agent status to avoid resource exhaustion.
    - Avoid redundant work - if a sub-agent did it, it's done.
-   - Efficiency means trusting delegation, not redoing completed tasks.", includeDirectories: true, includeUserRules: enableUserRules),
-                ClientSource = manager,
-                Model = model,
-                Temperature = temperature,
-                MaxTokens = 4096,
-                TopP = 0.25,
-                MaintainHistory = true,
-                MaxHistoryMessages = 10,
-                EnableTools = true,
-                EnableStreaming = true,
-                RequireCommandApproval = true,
-                EnableUserRules = enableUserRules,
-                ToolNames = new List<string>() {
-                    "apply_diff", "grep", "glob", "read_file", "list_files",
-                    "write_file", "search_and_replace", "delete_file",
-                    "create_agent", "hand_off_to_agent", "get_agent_status",
-                    "wait_for_agent", "get_task_result", "terminate_agent", "execute_command",
-                    "get_command_output", "kill_command", "web_fetch", "web_search",
-                    "list_tasks", "create_task", "update_task", "complete_task",
-                    "wait_for_task", "claim_task", "dispatch_task", "list_due_tasks",
-                    "update_todos"
-                },
-            };
-
-            // Persisted configs predate newer tools; backfill only those.
-            // Re-adding the full default set would silently restore tools
-            // the user deliberately removed (e.g. execute_command).
-            var backfillTools = new[]
-            {
-                "list_tasks", "create_task", "update_task", "complete_task",
-                "wait_for_task", "claim_task", "dispatch_task", "list_due_tasks",
-                "update_todos", "web_search"
-            };
-
-            if (persistedConfig != null)
-            {
-                ConfigurationManager.ApplyToAgentConfiguration(agentConfig, persistedConfig);
-
-                agentConfig.Model = model;
-
-                agentConfig.ToolNames = agentConfig.ToolNames
-                    .Union(backfillTools, StringComparer.OrdinalIgnoreCase)
-                    .ToList();
-            }
-            else
-            {
-                await ConfigurationManager.SaveConfigurationAsync(
-                    ConfigurationManager.FromAgentConfiguration(agentConfig));
-            }
-
-            await ConfigurationManager.SaveProviderSelectionAsync(providerName, providerSettings, model);
-
-            if (agentConfig.Model.Contains("gpt-5", StringComparison.OrdinalIgnoreCase))
-            {
-                agentConfig.Temperature = 1.0;
-            }
-
-            return (new Agent(agentConfig), manager);
+   - Efficiency means trusting delegation, not redoing completed tasks.";
         }
 
         static async Task<string> ResolveStartupModelAsync(

--- a/Saturn.Tests/Tools/ApplyDiffToolTests.cs
+++ b/Saturn.Tests/Tools/ApplyDiffToolTests.cs
@@ -324,7 +324,7 @@ Content C");
             var result = await _tool.ExecuteAsync(parameters);
 
             result.Success.Should().BeFalse();
-            result.Error.Should().Contain("Path traversal");
+            result.Error.Should().Contain("outside the working directory");
         }
 
         [Fact]

--- a/Saturn.Tests/Tools/ToolBugRegressionTests.cs
+++ b/Saturn.Tests/Tools/ToolBugRegressionTests.cs
@@ -29,10 +29,13 @@ namespace Saturn.Tests.Tools
         {
             Directory.SetCurrentDirectory(_originalDirectory);
 
-            var siblingDirectory = _fileHelper.TestDirectory + "Sibling";
-            if (Directory.Exists(siblingDirectory))
+            foreach (var suffix in new[] { "Sibling", "Outside" })
             {
-                Directory.Delete(siblingDirectory, true);
+                var outsideDirectory = _fileHelper.TestDirectory + suffix;
+                if (Directory.Exists(outsideDirectory))
+                {
+                    Directory.Delete(outsideDirectory, true);
+                }
             }
 
             _fileHelper.Dispose();
@@ -67,6 +70,56 @@ namespace Saturn.Tests.Tools
             var act = () => PathSecurity.ValidateInsideWorkingDirectory("../outside.txt");
 
             act.Should().Throw<System.Security.SecurityException>();
+        }
+
+        [Fact]
+        public void PathSecurity_SymlinkedDirectoryPointingOutside_IsRejected()
+        {
+            var outsideDirectory = _fileHelper.TestDirectory + "Outside";
+            Directory.CreateDirectory(outsideDirectory);
+
+            var linkPath = _fileHelper.GetPath("link_dir");
+            if (!TryCreateDirectoryLink(linkPath, outsideDirectory))
+            {
+                // Creating links needs elevation or developer mode on some systems;
+                // without it there is nothing to test.
+                return;
+            }
+
+            var act = () => PathSecurity.ValidateInsideWorkingDirectory(
+                Path.Combine(linkPath, "escape.txt"));
+
+            act.Should().Throw<System.Security.SecurityException>()
+                .WithMessage("*outside the working directory*");
+        }
+
+        private static bool TryCreateDirectoryLink(string linkPath, string targetPath)
+        {
+            try
+            {
+                Directory.CreateSymbolicLink(linkPath, targetPath);
+                return true;
+            }
+            catch (Exception)
+            {
+            }
+
+            if (!System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
+                    System.Runtime.InteropServices.OSPlatform.Windows))
+            {
+                return false;
+            }
+
+            // Junctions do not require elevation on Windows.
+            var psi = new System.Diagnostics.ProcessStartInfo(
+                "cmd.exe", $"/c mklink /J \"{linkPath}\" \"{targetPath}\"")
+            {
+                CreateNoWindow = true,
+                UseShellExecute = false
+            };
+            using var process = System.Diagnostics.Process.Start(psi);
+            process!.WaitForExit();
+            return Directory.Exists(linkPath);
         }
 
         [Fact]
@@ -227,6 +280,28 @@ namespace Saturn.Tests.Tools
             result.Success.Should().BeTrue(result.Error);
             var results = result.RawData as System.Collections.IEnumerable;
             results!.Cast<object>().Count().Should().Be(10);
+        }
+
+        #endregion
+
+        #region Glob directories
+
+        [Fact]
+        public async Task Glob_IncludeDirectories_ReturnsMatchingDirectories()
+        {
+            _fileHelper.CreateDirectory("src/models");
+            _fileHelper.CreateFile("src/models/user.cs", "class User {}");
+
+            var tool = new GlobTool();
+            var result = await tool.ExecuteAsync(new Dictionary<string, object>
+            {
+                { "pattern", "src/**" },
+                { "includeDirectories", true }
+            });
+
+            result.Success.Should().BeTrue(result.Error);
+            result.FormattedOutput.Should().Contain("models");
+            result.FormattedOutput.Should().Contain("user.cs");
         }
 
         #endregion

--- a/Saturn.Tests/Tools/ToolBugRegressionTests.cs
+++ b/Saturn.Tests/Tools/ToolBugRegressionTests.cs
@@ -1,0 +1,285 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Saturn.Tests.TestHelpers;
+using Saturn.Tools;
+using Saturn.Tools.Core;
+using Xunit;
+
+namespace Saturn.Tests.Tools
+{
+    [Collection("WorkingDirectory")]
+    public class ToolBugRegressionTests : IDisposable
+    {
+        private readonly FileTestHelper _fileHelper;
+        private readonly string _originalDirectory;
+
+        public ToolBugRegressionTests()
+        {
+            _fileHelper = new FileTestHelper($"ToolBugRegression_{Guid.NewGuid():N}");
+            _originalDirectory = Directory.GetCurrentDirectory();
+            Directory.SetCurrentDirectory(_fileHelper.TestDirectory);
+        }
+
+        public void Dispose()
+        {
+            Directory.SetCurrentDirectory(_originalDirectory);
+
+            var siblingDirectory = _fileHelper.TestDirectory + "Sibling";
+            if (Directory.Exists(siblingDirectory))
+            {
+                Directory.Delete(siblingDirectory, true);
+            }
+
+            _fileHelper.Dispose();
+        }
+
+        #region PathSecurity
+
+        [Fact]
+        public void PathSecurity_SiblingDirectoryWithSamePrefix_IsRejected()
+        {
+            var siblingDirectory = _fileHelper.TestDirectory + "Sibling";
+            Directory.CreateDirectory(siblingDirectory);
+
+            var act = () => PathSecurity.ValidateInsideWorkingDirectory(
+                Path.Combine(siblingDirectory, "escape.txt"));
+
+            act.Should().Throw<System.Security.SecurityException>()
+                .WithMessage("*outside the working directory*");
+        }
+
+        [Fact]
+        public void PathSecurity_PathInsideWorkingDirectory_IsAllowed()
+        {
+            var act = () => PathSecurity.ValidateInsideWorkingDirectory("sub/dir/file.txt");
+
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void PathSecurity_ParentTraversal_IsRejected()
+        {
+            var act = () => PathSecurity.ValidateInsideWorkingDirectory("../outside.txt");
+
+            act.Should().Throw<System.Security.SecurityException>();
+        }
+
+        [Fact]
+        public async Task WriteFile_SiblingDirectoryWithSamePrefix_IsRejected()
+        {
+            var siblingDirectory = _fileHelper.TestDirectory + "Sibling";
+            Directory.CreateDirectory(siblingDirectory);
+
+            var tool = new WriteFileTool();
+            var result = await tool.ExecuteAsync(new Dictionary<string, object>
+            {
+                { "path", Path.Combine(siblingDirectory, "escape.txt") },
+                { "content", "should not be written" }
+            });
+
+            result.Success.Should().BeFalse();
+            File.Exists(Path.Combine(siblingDirectory, "escape.txt")).Should().BeFalse();
+        }
+
+        #endregion
+
+        #region GetParameter conversions
+
+        private class ParameterProbeTool : ToolBase
+        {
+            public override string Name => "parameter_probe";
+            public override string Description => "test helper";
+            protected override Dictionary<string, object> GetParameterProperties() => new();
+            protected override string[] GetRequiredParameters() => Array.Empty<string>();
+            public override Task<ToolResult> ExecuteAsync(Dictionary<string, object> parameters) =>
+                Task.FromResult(CreateSuccessResult(new object(), "ok"));
+
+            public T Probe<T>(Dictionary<string, object> parameters, string key, T defaultValue = default!) =>
+                GetParameter(parameters, key, defaultValue);
+        }
+
+        [Fact]
+        public void GetParameter_ListOfObjects_ConvertsToStringArray()
+        {
+            var tool = new ParameterProbeTool();
+            var parameters = new Dictionary<string, object>
+            {
+                { "exclude", new List<object> { "**/generated/**", "bin" } }
+            };
+
+            var value = tool.Probe(parameters, "exclude", Array.Empty<string>());
+
+            value.Should().BeEquivalentTo("**/generated/**", "bin");
+        }
+
+        [Fact]
+        public void GetParameter_ListOfObjects_ConvertsToStringList()
+        {
+            var tool = new ParameterProbeTool();
+            var parameters = new Dictionary<string, object>
+            {
+                { "items", new List<object> { "a", "b" } }
+            };
+
+            var value = tool.Probe(parameters, "items", new List<string>());
+
+            value.Should().Equal("a", "b");
+        }
+
+        [Fact]
+        public void GetParameter_DoubleValue_ConvertsToNullableInt()
+        {
+            var tool = new ParameterProbeTool();
+            var parameters = new Dictionary<string, object>
+            {
+                { "startLine", 50.0 }
+            };
+
+            var value = tool.Probe<int?>(parameters, "startLine", null);
+
+            value.Should().Be(50);
+        }
+
+        #endregion
+
+        #region SearchAndReplace
+
+        [Fact]
+        public async Task SearchAndReplace_MatchAtFileStart_DoesNotThrow()
+        {
+            _fileHelper.CreateFile("start.txt", "using System;\nusing System.IO;\n");
+
+            var tool = new SearchAndReplaceTool();
+            var result = await tool.ExecuteAsync(new Dictionary<string, object>
+            {
+                { "searchPattern", "using System;" },
+                { "replacement", "using System.Text;" },
+                { "filePattern", "start.txt" }
+            });
+
+            result.Success.Should().BeTrue(result.Error);
+            _fileHelper.ReadFile("start.txt").Should().StartWith("using System.Text;");
+        }
+
+        [Fact]
+        public async Task SearchAndReplace_CrlfFile_PreservesLineEndings()
+        {
+            var content = "line one\r\nline two\r\nline three\r\n";
+            _fileHelper.CreateFile("crlf.txt", content);
+
+            var tool = new SearchAndReplaceTool();
+            var result = await tool.ExecuteAsync(new Dictionary<string, object>
+            {
+                { "searchPattern", "two" },
+                { "replacement", "2" },
+                { "filePattern", "crlf.txt" }
+            });
+
+            result.Success.Should().BeTrue(result.Error);
+            var written = File.ReadAllText(_fileHelper.GetPath("crlf.txt"));
+            written.Should().Be("line one\r\nline 2\r\nline three\r\n");
+            written.Should().NotContain("\r\r\n");
+        }
+
+        [Fact]
+        public async Task SearchAndReplace_BomlessFile_DoesNotGainBom()
+        {
+            File.WriteAllBytes(_fileHelper.GetPath("nobom.txt"), Encoding.UTF8.GetBytes("hello world\n"));
+
+            var tool = new SearchAndReplaceTool();
+            var result = await tool.ExecuteAsync(new Dictionary<string, object>
+            {
+                { "searchPattern", "world" },
+                { "replacement", "there" },
+                { "filePattern", "nobom.txt" }
+            });
+
+            result.Success.Should().BeTrue(result.Error);
+            var bytes = File.ReadAllBytes(_fileHelper.GetPath("nobom.txt"));
+            bytes.Take(3).Should().NotEqual(new byte[] { 0xEF, 0xBB, 0xBF });
+        }
+
+        #endregion
+
+        #region Grep result budget
+
+        [Fact]
+        public async Task Grep_LaterFilesStillSearched_WhenEarlierFileHasManyMatches()
+        {
+            var manyMatches = string.Join("\n", Enumerable.Repeat("match here", 8));
+            var fewMatches = string.Join("\n", Enumerable.Repeat("match there", 5));
+            _fileHelper.CreateFile("a_many.txt", manyMatches);
+            _fileHelper.CreateFile("b_few.txt", fewMatches);
+
+            var tool = new GrepTool();
+            var result = await tool.ExecuteAsync(new Dictionary<string, object>
+            {
+                { "pattern", "match" },
+                { "path", "." },
+                { "maxResults", 10 }
+            });
+
+            result.Success.Should().BeTrue(result.Error);
+            var results = result.RawData as System.Collections.IEnumerable;
+            results!.Cast<object>().Count().Should().Be(10);
+        }
+
+        #endregion
+
+        #region ApplyDiff multiple update sections
+
+        [Fact]
+        public async Task ApplyDiff_TwoUpdateSectionsForSameFile_AppliesBoth()
+        {
+            _fileHelper.CreateFile("multi.txt", "alpha\nbravo\ncharlie\ndelta\n");
+
+            var patchText = @"*** Update File: multi.txt
+@@ alpha @@
+-bravo
++BRAVO
+*** Update File: multi.txt
+@@ charlie @@
+-delta
++DELTA";
+
+            var tool = new ApplyDiffTool();
+            var result = await tool.ExecuteAsync(new Dictionary<string, object>
+            {
+                { "patchText", patchText }
+            });
+
+            result.Success.Should().BeTrue(result.Error);
+            var written = _fileHelper.ReadFile("multi.txt");
+            written.Should().Contain("BRAVO");
+            written.Should().Contain("DELTA");
+        }
+
+        #endregion
+
+        #region ReadFile line counting
+
+        [Fact]
+        public async Task ReadFile_WithEndLine_ReportsAccurateTotalLines()
+        {
+            _fileHelper.CreateLargeFile("large.txt", 100);
+
+            var tool = new ReadFileTool();
+            var result = await tool.ExecuteAsync(new Dictionary<string, object>
+            {
+                { "path", "large.txt" },
+                { "startLine", 1 },
+                { "endLine", 10 }
+            });
+
+            result.Success.Should().BeTrue(result.Error);
+            result.FormattedOutput.Should().Contain("10 of 100 total");
+        }
+
+        #endregion
+    }
+}

--- a/Tools/ApplyDiffTool.cs
+++ b/Tools/ApplyDiffTool.cs
@@ -42,9 +42,12 @@ Updating an existing file:
  }
 
 Rules:
-- The context line (@@ ... @@) must appear exactly once in the file
+- The context line (@@ ... @@) locates the change; if it appears multiple times in the file, the hunk body is used to pick the right occurrence (pure insertions with no '-' lines need a unique context line)
 - Lines starting with a space are unchanged context, '-' lines are removed, '+' lines are added
-- Context and '-' lines must match the file content exactly, including indentation
+- Context and '-' lines must match the file content exactly, including indentation. NEVER include line-number prefixes from read_file output
+- Blank lines inside a hunk must still carry their prefix (a single space for context)
+- File paths must be inside the current working directory
+- Prefer a single '*** Update File:' section per file with multiple hunks; multiple sections for the same file are applied in order
 
 The format also supports '*** Add File: path' (every content line prefixed with '+') and '*** Delete File: path' when you need them in a combined patch.";
         
@@ -462,8 +465,15 @@ The format also supports '*** Add File: path' (every content line prefixed with 
                 else if (op.Type == OperationType.Update && op.Hunks != null)
                 {
                     var originalContent = currentFiles.ContainsKey(op.FilePath) ? currentFiles[op.FilePath] : "";
-                    var lineEnding = DetectLineEnding(originalContent);
-                    var lines = originalContent.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None).ToList();
+
+                    // A later Update section for the same file builds on the earlier
+                    // section's result instead of silently discarding it.
+                    var baseContent = changes.TryGetValue(op.FilePath, out var priorChange) && priorChange.Type == ChangeType.Update
+                        ? priorChange.NewContent ?? originalContent
+                        : originalContent;
+
+                    var lineEnding = DetectLineEnding(baseContent);
+                    var lines = baseContent.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None).ToList();
                     
                     foreach (var hunk in op.Hunks)
                     {
@@ -674,21 +684,10 @@ The format also supports '*** Add File: path' (every content line prefixed with 
             {
                 throw new ArgumentException("File path cannot be null or empty");
             }
-            
-            if (filePath.Contains("..") || filePath.Contains("~"))
-            {
-                throw new SecurityException($"Invalid file path: {filePath}. Path traversal attempts are not allowed.");
-            }
-            
+
             try
             {
-                var fullPath = Path.GetFullPath(filePath);
-                var currentDirectory = Path.GetFullPath(Directory.GetCurrentDirectory());
-                
-                if (!fullPath.StartsWith(currentDirectory, StringComparison.OrdinalIgnoreCase))
-                {
-                    throw new SecurityException($"Access denied: Path '{filePath}' is outside the working directory.");
-                }
+                PathSecurity.ValidateInsideWorkingDirectory(filePath);
             }
             catch (Exception ex) when (!(ex is SecurityException))
             {

--- a/Tools/Core/PathSecurity.cs
+++ b/Tools/Core/PathSecurity.cs
@@ -16,14 +16,85 @@ namespace Saturn.Tools.Core
             var fullPath = Path.GetFullPath(path);
             var workingDirectory = Path.GetFullPath(Directory.GetCurrentDirectory());
 
-            var relative = Path.GetRelativePath(workingDirectory, fullPath);
+            // Lexical check first: cheap, and catches plain traversal even when
+            // the filesystem cannot be probed.
+            EnsureRelativeStaysInside(workingDirectory, fullPath, path);
+
+            // Then compare the real locations so a symlink, junction, or other
+            // reparse point inside the workspace cannot smuggle the path outside.
+            var resolvedPath = ResolveRealPath(fullPath);
+            var resolvedWorkingDirectory = ResolveRealPath(workingDirectory);
+            EnsureRelativeStaysInside(resolvedWorkingDirectory, resolvedPath, path);
+        }
+
+        private static void EnsureRelativeStaysInside(string baseDirectory, string fullPath, string originalPath)
+        {
+            var relative = Path.GetRelativePath(baseDirectory, fullPath);
             if (Path.IsPathRooted(relative) ||
                 relative == ".." ||
                 relative.StartsWith(".." + Path.DirectorySeparatorChar, StringComparison.Ordinal) ||
                 relative.StartsWith(".." + Path.AltDirectorySeparatorChar, StringComparison.Ordinal))
             {
-                throw new SecurityException($"Access denied: Path '{path}' is outside the working directory");
+                throw new SecurityException($"Access denied: Path '{originalPath}' is outside the working directory");
             }
+        }
+
+        private static string ResolveRealPath(string fullPath)
+        {
+            var root = Path.GetPathRoot(fullPath);
+            if (string.IsNullOrEmpty(root))
+            {
+                return fullPath;
+            }
+
+            var segments = fullPath.Substring(root.Length).Split(
+                new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar },
+                StringSplitOptions.RemoveEmptyEntries);
+
+            var current = root;
+            for (int i = 0; i < segments.Length; i++)
+            {
+                current = Path.Combine(current, segments[i]);
+
+                FileSystemInfo info;
+                if (Directory.Exists(current))
+                {
+                    info = new DirectoryInfo(current);
+                }
+                else if (File.Exists(current))
+                {
+                    info = new FileInfo(current);
+                }
+                else
+                {
+                    // The remainder does not exist yet (e.g. a file about to be
+                    // created); nothing further can be a link.
+                    for (int j = i + 1; j < segments.Length; j++)
+                    {
+                        current = Path.Combine(current, segments[j]);
+                    }
+                    break;
+                }
+
+                try
+                {
+                    var target = info.ResolveLinkTarget(returnFinalTarget: true);
+                    if (target != null)
+                    {
+                        current = target.FullName;
+                    }
+                }
+                catch (IOException)
+                {
+                    // Broken or cyclic link; keep the lexical path and let the
+                    // caller's IO fail naturally.
+                }
+                catch (UnauthorizedAccessException)
+                {
+                }
+            }
+
+            return Path.GetFullPath(current);
         }
     }
 }

--- a/Tools/Core/PathSecurity.cs
+++ b/Tools/Core/PathSecurity.cs
@@ -1,0 +1,29 @@
+using System;
+using System.IO;
+using System.Security;
+
+namespace Saturn.Tools.Core
+{
+    public static class PathSecurity
+    {
+        public static void ValidateInsideWorkingDirectory(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                throw new ArgumentException("Path cannot be null or empty");
+            }
+
+            var fullPath = Path.GetFullPath(path);
+            var workingDirectory = Path.GetFullPath(Directory.GetCurrentDirectory());
+
+            var relative = Path.GetRelativePath(workingDirectory, fullPath);
+            if (Path.IsPathRooted(relative) ||
+                relative == ".." ||
+                relative.StartsWith(".." + Path.DirectorySeparatorChar, StringComparison.Ordinal) ||
+                relative.StartsWith(".." + Path.AltDirectorySeparatorChar, StringComparison.Ordinal))
+            {
+                throw new SecurityException($"Access denied: Path '{path}' is outside the working directory");
+            }
+        }
+    }
+}

--- a/Tools/Core/ToolBase.cs
+++ b/Tools/Core/ToolBase.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
 
@@ -28,24 +29,40 @@ namespace Saturn.Tools.Core
         
         protected T GetParameter<T>(Dictionary<string, object> parameters, string key, T defaultValue = default!)
         {
-            if (parameters.TryGetValue(key, out var value))
+            if (!parameters.TryGetValue(key, out var value) || value == null)
             {
-                if (value is T typedValue)
+                return defaultValue;
+            }
+
+            if (value is T typedValue)
+            {
+                return typedValue;
+            }
+
+            var targetType = typeof(T);
+
+            if (value is List<object> list)
+            {
+                if (targetType == typeof(string[]))
                 {
-                    return typedValue;
+                    return (T)(object)list.Select(item => item?.ToString() ?? string.Empty).ToArray();
                 }
-                
-                try
+
+                if (targetType == typeof(List<string>))
                 {
-                    return (T)Convert.ChangeType(value, typeof(T));
-                }
-                catch
-                {
-                    return defaultValue;
+                    return (T)(object)list.Select(item => item?.ToString() ?? string.Empty).ToList();
                 }
             }
-            
-            return defaultValue;
+
+            try
+            {
+                var conversionType = Nullable.GetUnderlyingType(targetType) ?? targetType;
+                return (T)Convert.ChangeType(value, conversionType);
+            }
+            catch
+            {
+                return defaultValue;
+            }
         }
         
         protected ToolResult CreateSuccessResult(object data, string? formattedOutput = null)

--- a/Tools/DeleteFileTool.cs
+++ b/Tools/DeleteFileTool.cs
@@ -13,7 +13,7 @@ namespace Saturn.Tools
     {
         public override string Name => "delete_file";
         
-        public override string Description => @"Safely delete files or directories with optional backup.
+        public override string Description => @"Delete files or directories. Deletion is permanent - there is no backup or undo; use 'dryRun' first when unsure.
 
 When to use:
 - Removing obsolete source files

--- a/Tools/ExecuteCommandTool.cs
+++ b/Tools/ExecuteCommandTool.cs
@@ -18,6 +18,7 @@ namespace Saturn.Tools
         private const int MaxOutputLength = 1048576;
         private const int MaxCaptureLength = 8388608;
         private readonly List<CommandHistory> _commandHistory = new();
+        private readonly object _historyLock = new();
         private readonly CommandExecutorConfig _config;
         private readonly ICommandApprovalService _approvalService;
 
@@ -39,7 +40,7 @@ How commands run:
 - On Windows the command is run with 'cmd.exe /c'; on Linux/macOS with '/bin/sh -c'. Use the syntax of the current platform.
 - Commands run non-interactively with no stdin. Do not run commands that wait for user input (e.g. editors, REPLs, prompts) - they will hang until the timeout.
 - Default timeout is 120 seconds; pass 'timeout' (in seconds) for longer-running commands like builds or test suites. On timeout the process is killed and any output captured so far is still returned.
-- Output is captured up to 1 MB; the middle is elided if it is longer, keeping the start and end.
+- Output is captured up to 8 MB (a marker is appended if more was discarded). At most 1 MB is returned; the middle is elided if it is longer, keeping the start and end.
 - The user may be asked to approve each command before it runs; a denied command returns an error.
 - For long-running processes (dev servers, watchers), set 'run_in_background' to true. The tool returns a command_id immediately; poll its output with get_command_output and stop it with kill_command.
 
@@ -121,6 +122,10 @@ Prefer the dedicated file tools (read_file, write_file, grep, glob, list_files) 
                 
                 var workingDirectory = GetParameter<string>(arguments, "workingDirectory", Directory.GetCurrentDirectory());
                 var timeoutSeconds = GetParameter<int>(arguments, "timeout", _config.DefaultTimeout);
+                if (timeoutSeconds <= 0)
+                {
+                    return CreateErrorResult($"Invalid timeout: {timeoutSeconds}. It must be a positive number of seconds.");
+                }
                 var captureOutput = GetParameter<bool>(arguments, "captureOutput", true);
                 var runAsShell = GetParameter<bool>(arguments, "runAsShell", true);
                 var runInBackground = GetParameter<bool>(arguments, "run_in_background", false);
@@ -176,10 +181,13 @@ Prefer the dedicated file tools (read_file, write_file, grep, glob, list_files) 
 
                     if (_config.EnableHistory)
                     {
-                        _commandHistory.Add(historyEntry);
-                        if (_commandHistory.Count > _config.MaxHistorySize)
+                        lock (_historyLock)
                         {
-                            _commandHistory.RemoveAt(0);
+                            _commandHistory.Add(historyEntry);
+                            if (_commandHistory.Count > _config.MaxHistorySize)
+                            {
+                                _commandHistory.RemoveAt(0);
+                            }
                         }
                     }
 
@@ -192,7 +200,10 @@ Prefer the dedicated file tools (read_file, write_file, grep, glob, list_files) 
                     
                     if (_config.EnableHistory)
                     {
-                        _commandHistory.Add(historyEntry);
+                        lock (_historyLock)
+                        {
+                            _commandHistory.Add(historyEntry);
+                        }
                     }
 
                     throw;
@@ -219,21 +230,34 @@ Prefer the dedicated file tools (read_file, write_file, grep, glob, list_files) 
             var outputBuilder = new StringBuilder();
             var errorBuilder = new StringBuilder();
 
+            var outputDropped = false;
+            var errorDropped = false;
+
             if (captureOutput)
             {
                 process.OutputDataReceived += (sender, e) =>
                 {
-                    if (e.Data != null && outputBuilder.Length < MaxCaptureLength)
+                    if (e.Data == null) return;
+                    if (outputBuilder.Length < MaxCaptureLength)
                     {
                         outputBuilder.AppendLine(e.Data);
+                    }
+                    else
+                    {
+                        outputDropped = true;
                     }
                 };
 
                 process.ErrorDataReceived += (sender, e) =>
                 {
-                    if (e.Data != null && errorBuilder.Length < MaxCaptureLength)
+                    if (e.Data == null) return;
+                    if (errorBuilder.Length < MaxCaptureLength)
                     {
                         errorBuilder.AppendLine(e.Data);
+                    }
+                    else
+                    {
+                        errorDropped = true;
                     }
                 };
             }
@@ -269,6 +293,16 @@ Prefer the dedicated file tools (read_file, write_file, grep, glob, list_files) 
             try { process.WaitForExit(); } catch { }
 
             stopwatch.Stop();
+
+            if (outputDropped)
+            {
+                outputBuilder.AppendLine("... [capture limit reached; subsequent output was discarded] ...");
+            }
+
+            if (errorDropped)
+            {
+                errorBuilder.AppendLine("... [capture limit reached; subsequent error output was discarded] ...");
+            }
 
             int exitCode;
             try { exitCode = process.ExitCode; } catch { exitCode = -1; }
@@ -348,7 +382,8 @@ Prefer the dedicated file tools (read_file, write_file, grep, glob, list_files) 
                 else
                 {
                     startInfo.FileName = "/bin/sh";
-                    startInfo.Arguments = $"-c \"{command.Replace("\"", "\\\"")}\"";
+                    startInfo.ArgumentList.Add("-c");
+                    startInfo.ArgumentList.Add(command);
                 }
             }
             else
@@ -445,8 +480,20 @@ Prefer the dedicated file tools (read_file, write_file, grep, glob, list_files) 
                 + output.Substring(output.Length - tailLength);
         }
 
-        public IReadOnlyList<CommandHistory> GetCommandHistory() => _commandHistory.AsReadOnly();
+        public IReadOnlyList<CommandHistory> GetCommandHistory()
+        {
+            lock (_historyLock)
+            {
+                return _commandHistory.ToList();
+            }
+        }
 
-        public void ClearHistory() => _commandHistory.Clear();
+        public void ClearHistory()
+        {
+            lock (_historyLock)
+            {
+                _commandHistory.Clear();
+            }
+        }
     }
 }

--- a/Tools/ExecuteCommandTool.cs
+++ b/Tools/ExecuteCommandTool.cs
@@ -203,6 +203,10 @@ Prefer the dedicated file tools (read_file, write_file, grep, glob, list_files) 
                         lock (_historyLock)
                         {
                             _commandHistory.Add(historyEntry);
+                            if (_commandHistory.Count > _config.MaxHistorySize)
+                            {
+                                _commandHistory.RemoveAt(0);
+                            }
                         }
                     }
 

--- a/Tools/GetCommandOutputTool.cs
+++ b/Tools/GetCommandOutputTool.cs
@@ -14,7 +14,11 @@ namespace Saturn.Tools
 
         public override string Description => @"Read output produced by a command started with execute_command (run_in_background: true).
 
-Returns only the output generated since the last call for that command_id, along with the command's current status (running, exited, or killed) and its exit code once finished. Call it repeatedly to follow a long-running process.";
+Returns only the output generated since the last call for that command_id, along with the command's current status (running, exited, or killed) and its exit code once finished. Call it repeatedly to follow a long-running process.
+
+Notes:
+- Reads are destructive: output returned once is not returned again, and lines excluded by 'filter' are consumed and cannot be retrieved later. Omit 'filter' if you may need the full log.
+- Shortly after the status changes to exited, one more call may return final output that was still being flushed.";
 
         protected override Dictionary<string, object> GetParameterProperties()
         {

--- a/Tools/GlobTool.cs
+++ b/Tools/GlobTool.cs
@@ -25,18 +25,20 @@ When to use:
 - Checking if certain files exist in the project
 
 How to use:
-- Set 'pattern' to your glob pattern (supports *, ?, ** wildcards)
+- Set 'pattern' to your glob pattern (supports *, ?, ** wildcards; brace expansion like {json,xml} is NOT supported)
+- Multiple patterns can be separated with commas or semicolons; prefix a pattern with ! to exclude its matches
 - Use 'path' to search from a specific directory (optional)
-- Set 'includeDirectories' to true to also list folders
 - Use 'exclude' array to filter out unwanted results
 - Set 'caseSensitive' based on your needs
 - Use 'compactOutput' for just file paths
 - Set 'maxDepth' to limit recursion depth
+- This tool matches files only; use list_files to explore directories
 
 Examples:
 - Find all C# files: pattern='**/*.cs'
 - Find test files: pattern='**/*Test.cs' or pattern='**/test/**/*'
-- Find config files: pattern='**/*.{json,xml,config}'
+- Find config files: pattern='**/*.json,**/*.xml,**/*.config'
+- Exclude generated code: pattern='**/*.cs,!**/obj/**'
 - Find specific file: pattern='**/UserService.cs'
 - Find all in folder: pattern='src/models/**/*'
 
@@ -352,18 +354,7 @@ Note: Use this before grep when you need to find files first, then search within
         
         private void ValidatePathSecurity(string path)
         {
-            if (string.IsNullOrWhiteSpace(path))
-            {
-                throw new ArgumentException("Path cannot be null or empty");
-            }
-            
-            var fullPath = Path.GetFullPath(path);
-            var currentDirectory = Path.GetFullPath(Directory.GetCurrentDirectory());
-            
-            if (!fullPath.StartsWith(currentDirectory, StringComparison.OrdinalIgnoreCase))
-            {
-                throw new SecurityException($"Access denied: Path '{path}' is outside the working directory.");
-            }
+            PathSecurity.ValidateInsideWorkingDirectory(path);
         }
         
         private bool IsSymbolicLink(FileSystemInfo info)

--- a/Tools/GlobTool.cs
+++ b/Tools/GlobTool.cs
@@ -32,7 +32,7 @@ How to use:
 - Set 'caseSensitive' based on your needs
 - Use 'compactOutput' for just file paths
 - Set 'maxDepth' to limit recursion depth
-- This tool matches files only; use list_files to explore directories
+- This tool matches files by default; set includeDirectories=true to also match directories against the pattern (use list_files for tree exploration)
 
 Examples:
 - Find all C# files: pattern='**/*.cs'
@@ -278,8 +278,62 @@ Note: Use this before grep when you need to find files first, then search within
                 }
             }
             
+            // Matcher.Execute only matches files, so directories are matched
+            // against the same patterns in a separate pass.
+            if (includeDirectories)
+            {
+                var enumerationOptions = new EnumerationOptions
+                {
+                    RecurseSubdirectories = true,
+                    IgnoreInaccessible = true,
+                    AttributesToSkip = followSymlinks ? FileAttributes.None : FileAttributes.ReparsePoint
+                };
+
+                foreach (var dirPath in Directory.EnumerateDirectories(basePath, "*", enumerationOptions))
+                {
+                    if (results.Count >= maxResults)
+                    {
+                        break;
+                    }
+
+                    var dirInfo = new DirectoryInfo(dirPath);
+                    var relativePath = Path.GetRelativePath(basePath, dirInfo.FullName).Replace('\\', '/');
+
+                    if (maxDepth >= 0 && relativePath.Count(c => c == '/') > maxDepth)
+                    {
+                        continue;
+                    }
+
+                    if (!matcher.Match(relativePath).HasMatches)
+                    {
+                        continue;
+                    }
+
+                    if (!followSymlinks && IsSymbolicLink(dirInfo))
+                    {
+                        continue;
+                    }
+
+                    if (!visitedPaths.Add(dirInfo.FullName))
+                    {
+                        continue;
+                    }
+
+                    totalMatches++;
+                    results.Add(new GlobMatch
+                    {
+                        Path = dirInfo.FullName,
+                        RelativePath = relativePath,
+                        IsDirectory = true,
+                        Size = 0,
+                        LastModified = dirInfo.LastWriteTime,
+                        IsSymbolicLink = IsSymbolicLink(dirInfo)
+                    });
+                }
+            }
+
             results.Sort((a, b) => string.Compare(a.RelativePath, b.RelativePath, StringComparison.OrdinalIgnoreCase));
-            
+
             return new GlobMatchResult { Matches = results, TotalCount = totalMatches };
         }
         

--- a/Tools/GrepTool.cs
+++ b/Tools/GrepTool.cs
@@ -176,12 +176,12 @@ Examples:
                         if (results.Count >= maxResults)
                             break;
 
-                        SearchFile(file, regex, results, maxResults - results.Count, skippedFiles);
+                        SearchFile(file, regex, results, maxResults, skippedFiles);
                     }
                 }
             });
 
-            return FormatResults(results, skippedFiles);
+            return FormatResults(results, skippedFiles, maxResults);
         }
 
         private void ValidatePathSecurity(string path)
@@ -230,7 +230,7 @@ Examples:
             }
         }
 
-        private ToolResult FormatResults(List<GrepResult> results, List<string> skippedFiles)
+        private ToolResult FormatResults(List<GrepResult> results, List<string> skippedFiles, int maxResults)
         {
             if (results.Count == 0)
             {
@@ -243,7 +243,8 @@ Examples:
             }
 
             var lines = new List<string>();
-            lines.Add($"Found {results.Count} match{(results.Count == 1 ? "" : "es")}:");
+            var truncationNote = results.Count >= maxResults ? " (result limit reached; more matches may exist)" : "";
+            lines.Add($"Found {results.Count} match{(results.Count == 1 ? "" : "es")}{truncationNote}:");
             lines.Add("");
             
             foreach (var result in results)

--- a/Tools/ListFilesTool.cs
+++ b/Tools/ListFilesTool.cs
@@ -213,21 +213,10 @@ Examples
             {
                 throw new ArgumentException("Path cannot be null or empty");
             }
-            
-            if (path.Contains("..") || path.Contains("~"))
-            {
-                throw new SecurityException($"Invalid path: {path}. Path traversal attempts are not allowed.");
-            }
-            
+
             try
             {
-                var fullPath = Path.GetFullPath(path);
-                var currentDirectory = Path.GetFullPath(Directory.GetCurrentDirectory());
-                
-                if (!fullPath.StartsWith(currentDirectory, StringComparison.OrdinalIgnoreCase))
-                {
-                    throw new SecurityException($"Access denied: Path '{path}' is outside the working directory.");
-                }
+                PathSecurity.ValidateInsideWorkingDirectory(path);
             }
             catch (Exception ex) when (!(ex is SecurityException))
             {

--- a/Tools/MultiAgent/TerminateAgentTool.cs
+++ b/Tools/MultiAgent/TerminateAgentTool.cs
@@ -10,7 +10,7 @@ namespace Saturn.Tools.MultiAgent
     {
         public override string Name => "terminate_agent";
         
-        public override string Description => "Terminate a sub-agent to free up capacity. Use this when an agent is no longer needed or to make room for new agents.";
+        public override string Description => "Terminate a sub-agent to free up capacity. Cancellation takes effect at the agent's next step boundary, so an in-flight model call or tool may still finish; any in-progress task is recorded as failed. Use this when an agent is no longer needed or to make room for new agents.";
         
         protected override Dictionary<string, object> GetParameterProperties()
         {

--- a/Tools/ReadFileTool.cs
+++ b/Tools/ReadFileTool.cs
@@ -29,8 +29,8 @@ How to use:
 
 Important rules:
 - You MUST read a file before attempting to edit it with apply_diff
-- For very large files, use line ranges to read relevant sections
-- The tool shows line numbers which you'll need for apply_diff context
+- For very large files, use line ranges to read relevant sections; without a range the whole file is returned
+- Line numbers in the output (the 'NNN: ' prefix) are for your reference ONLY. NEVER copy them into apply_diff patches - patches match the raw file content, without line numbers
 
 Examples:
 - Read entire file: path='src/UserService.cs'
@@ -62,7 +62,7 @@ Examples:
                 { "encoding", new Dictionary<string, object>
                     {
                         { "type", "string" },
-                        { "enum", new[] { "utf8", "utf16", "utf32", "ascii", "unicode" } },
+                        { "enum", new[] { "utf8", "utf16", "utf32", "ascii" } },
                         { "default", "utf8" },
                         { "description", "Text encoding to use. Default is utf8" }
                     }
@@ -194,13 +194,13 @@ Examples:
                     {
                         lineNumber++;
                         content.TotalLines++;
-                        
+
                         if (startLine.HasValue && lineNumber < startLine.Value)
                             continue;
-                            
+
                         if (endLine.HasValue && lineNumber > endLine.Value)
-                            break;
-                        
+                            continue;
+
                         if (includeLineNumbers)
                         {
                             content.Lines.Add($"{lineNumber,6}: {line}");
@@ -209,7 +209,7 @@ Examples:
                         {
                             content.Lines.Add(line);
                         }
-                        
+
                         content.ReadLines++;
                     }
                 }

--- a/Tools/SearchAndReplaceTool.cs
+++ b/Tools/SearchAndReplaceTool.cs
@@ -294,17 +294,14 @@ Safety features:
                 });
             }
             
+            var normalizedReplacement = replacement.Replace("\r\n", "\n").Replace("\n", lineEnding);
+
             if (!dryRun)
             {
-                var newContent = searchRegex.Replace(content, replacement);
-                
+                var newContent = searchRegex.Replace(content, normalizedReplacement);
+
                 if (newContent != originalContent)
                 {
-                    if (lineEnding != Environment.NewLine)
-                    {
-                        newContent = newContent.Replace(Environment.NewLine, lineEnding);
-                    }
-                    
                     await File.WriteAllTextAsync(filePath, newContent, encoding);
                     result.ReplacementCount = matches.Count;
                     result.Modified = true;
@@ -313,8 +310,8 @@ Safety features:
             else
             {
                 result.ReplacementCount = matches.Count;
-                
-                var newContent = searchRegex.Replace(content, replacement);
+
+                var newContent = searchRegex.Replace(content, normalizedReplacement);
                 if (newContent != originalContent)
                 {
                     result.Preview = GeneratePreview(originalContent, newContent, result.Matches);
@@ -331,16 +328,16 @@ Safety features:
         
         private int GetColumnNumber(string content, int index)
         {
-            var lastNewline = content.LastIndexOf('\n', index - 1);
+            var lastNewline = index > 0 ? content.LastIndexOf('\n', index - 1) : -1;
             return index - lastNewline;
         }
-        
+
         private string GetLineContent(string content, int index)
         {
-            var start = content.LastIndexOf('\n', index - 1) + 1;
+            var start = index > 0 ? content.LastIndexOf('\n', index - 1) + 1 : 0;
             var end = content.IndexOf('\n', index);
             if (end == -1) end = content.Length;
-            return content.Substring(start, end - start);
+            return content.Substring(start, end - start).TrimEnd('\r');
         }
         
         private string GeneratePreview(string original, string modified, List<SearchMatchInfo> matches)
@@ -428,23 +425,12 @@ Safety features:
         
         private void ValidatePathSecurity(string path)
         {
-            if (string.IsNullOrWhiteSpace(path))
-            {
-                throw new ArgumentException("Path cannot be null or empty");
-            }
-            
-            var fullPath = Path.GetFullPath(path);
-            var currentDirectory = Path.GetFullPath(Directory.GetCurrentDirectory());
-            
-            if (!fullPath.StartsWith(currentDirectory, StringComparison.OrdinalIgnoreCase))
-            {
-                throw new SecurityException($"Access denied: Path '{path}' is outside the working directory");
-            }
+            PathSecurity.ValidateInsideWorkingDirectory(path);
         }
          
         private Encoding DetectEncoding(string filePath)
         {
-            using var reader = new StreamReader(filePath, Encoding.UTF8, true);
+            using var reader = new StreamReader(filePath, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), true);
             reader.Peek();
             return reader.CurrentEncoding;
         }

--- a/Tools/WebFetchTool.cs
+++ b/Tools/WebFetchTool.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Net.Http;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -19,16 +21,56 @@ namespace Saturn.Tools
     {
         public override string Name => "web_fetch";
         
-        public override string Description => @"Fetches and processes web content from any URL. Converts HTML to readable text/markdown format.
+        public override string Description => @"Fetches and processes web content from a public URL. Converts HTML to readable text/markdown format.
 
 When to use:
 - Fetching documentation or API references
 - Researching solutions from blog posts or articles
 - Retrieving information from web resources
 - Gathering context from external sources
-- Analyzing web page content or structure";
+- Analyzing web page content or structure
+
+Limits:
+- Only public http/https URLs; localhost and private-network addresses are blocked (use execute_command with curl for local servers)
+- 30 second timeout, at most 5 redirects
+- Content is truncated to 'maxLength' characters (default 50000)
+- Successful responses are cached for 5 minutes";
 
         private const int MaxRedirects = 5;
+        private const int MaxResponseBytes = 10 * 1024 * 1024;
+
+        private static async Task<string> ReadBodyBoundedAsync(HttpResponseMessage response)
+        {
+            using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            using var stream = await response.Content.ReadAsStreamAsync();
+            using var buffered = new MemoryStream();
+
+            var buffer = new byte[81920];
+            int read;
+            while ((read = await stream.ReadAsync(buffer, 0, buffer.Length, timeout.Token)) > 0)
+            {
+                buffered.Write(buffer, 0, read);
+                if (buffered.Length > MaxResponseBytes)
+                {
+                    throw new InvalidDataException($"Response exceeded the {MaxResponseBytes / (1024 * 1024)} MB limit and was aborted");
+                }
+            }
+
+            var charset = response.Content.Headers.ContentType?.CharSet;
+            Encoding encoding;
+            try
+            {
+                encoding = string.IsNullOrWhiteSpace(charset)
+                    ? Encoding.UTF8
+                    : Encoding.GetEncoding(charset.Trim('"'));
+            }
+            catch (ArgumentException)
+            {
+                encoding = Encoding.UTF8;
+            }
+
+            return encoding.GetString(buffered.ToArray());
+        }
 
         private static readonly HttpClient _httpClient = CreateHttpClient();
 
@@ -191,7 +233,7 @@ When to use:
                     return CreateErrorResult(validationError);
                 }
 
-                var cacheKey = $"{url}|{extractionMode}|{selector}";
+                var cacheKey = $"{url}|{extractionMode}|{selector}|{maxLength}|{includeMetadata}";
                 if (useCache && _cache.TryGetValue(cacheKey, out var cached))
                 {
                     if (DateTime.UtcNow - cached.CachedAt < CacheDuration)
@@ -226,7 +268,7 @@ When to use:
                         }
                     }
 
-                    response = await _httpClient.SendAsync(request);
+                    response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
 
                     var statusCode = (int)response.StatusCode;
                     if (statusCode >= 300 && statusCode < 400 && response.Headers.Location != null)
@@ -260,8 +302,14 @@ When to use:
                     return CreateErrorResult($"HTTP {(int)response.StatusCode} {response.ReasonPhrase}");
                 }
 
-                var html = await response.Content.ReadAsStringAsync();
-                
+                var contentLength = response.Content.Headers.ContentLength;
+                if (contentLength.HasValue && contentLength.Value > MaxResponseBytes)
+                {
+                    return CreateErrorResult($"Response too large: {contentLength.Value} bytes (limit is {MaxResponseBytes / (1024 * 1024)} MB)");
+                }
+
+                var html = await ReadBodyBoundedAsync(response);
+
                 if (string.IsNullOrWhiteSpace(html))
                 {
                     return CreateErrorResult("Empty response from server");
@@ -271,8 +319,8 @@ When to use:
                 doc.LoadHtml(html);
 
                 var result = ProcessContent(doc, uri, extractionMode, selector!, maxLength, includeMetadata);
-                
-                if (useCache)
+
+                if (useCache && result.Success)
                 {
                     _cache[cacheKey] = new CachedContent
                     {
@@ -282,6 +330,10 @@ When to use:
                 }
 
                 return result;
+            }
+            catch (InvalidDataException ex)
+            {
+                return CreateErrorResult(ex.Message);
             }
             catch (TaskCanceledException)
             {

--- a/Tools/WebFetchTool.cs
+++ b/Tools/WebFetchTool.cs
@@ -39,6 +39,22 @@ Limits:
         private const int MaxRedirects = 5;
         private const int MaxResponseBytes = 10 * 1024 * 1024;
 
+        private static string BuildHeadersFingerprint(Dictionary<string, object>? headers)
+        {
+            if (headers == null || headers.Count == 0)
+            {
+                return "";
+            }
+
+            var canonical = string.Join("\n", headers
+                .OrderBy(h => h.Key, StringComparer.OrdinalIgnoreCase)
+                .Select(h => $"{h.Key}:{h.Value}"));
+
+            using var sha256 = System.Security.Cryptography.SHA256.Create();
+            var hash = sha256.ComputeHash(Encoding.UTF8.GetBytes(canonical));
+            return Convert.ToHexString(hash);
+        }
+
         private static async Task<string> ReadBodyBoundedAsync(HttpResponseMessage response)
         {
             using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
@@ -233,7 +249,9 @@ Limits:
                     return CreateErrorResult(validationError);
                 }
 
-                var cacheKey = $"{url}|{extractionMode}|{selector}|{maxLength}|{includeMetadata}";
+                // Headers are part of the key: a response fetched with auth headers
+                // must never be served to a later caller that did not supply them.
+                var cacheKey = $"{url}|{extractionMode}|{selector}|{maxLength}|{includeMetadata}|{BuildHeadersFingerprint(headers)}";
                 if (useCache && _cache.TryGetValue(cacheKey, out var cached))
                 {
                     if (DateTime.UtcNow - cached.CachedAt < CacheDuration)

--- a/Tools/WriteFileTool.cs
+++ b/Tools/WriteFileTool.cs
@@ -182,19 +182,9 @@ Safety features:
         
         private void ValidatePathSecurity(string path)
         {
-            if (string.IsNullOrWhiteSpace(path))
-            {
-                throw new ArgumentException("Path cannot be null or empty");
-            }
-            
+            PathSecurity.ValidateInsideWorkingDirectory(path);
+
             var fullPath = Path.GetFullPath(path);
-            var currentDirectory = Path.GetFullPath(Directory.GetCurrentDirectory());
-            
-            if (!fullPath.StartsWith(currentDirectory, StringComparison.OrdinalIgnoreCase))
-            {
-                throw new SecurityException($"Access denied: Path '{path}' is outside the working directory");
-            }
-            
             var invalidChars = Path.GetInvalidFileNameChars();
             var fileName = Path.GetFileName(fullPath);
             if (fileName.IndexOfAny(invalidChars) >= 0)


### PR DESCRIPTION
Fixes a batch of tool bugs found in review: prefix-only workspace path checks that allowed writes outside the working directory (now a shared PathSecurity helper), broken /bin/sh argument escaping, silently dropped array tool parameters, grep skipping files after large earlier matches, CRLF corruption and BOM injection in search_and_replace, and apply_diff discarding duplicate update sections.

Also fixes agent lifecycle issues: terminate_agent now actually cancels work, double hand-offs are rejected instead of corrupting state, and task results are always recorded so waiters resolve. Task tools and their prompt section are no longer offered in TUI mode where they always error.

Several tool descriptions were corrected to match real behavior (read_file line numbers, delete_file backup claim, glob pattern syntax, web_fetch limits, output capture caps). Adds a regression test suite covering the fixed bugs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cancellation support for agent execution, including safer task handoff/completion handling.
  * Added web-mode startup options with web-specific tool selection and prompt guidance.
  * Web fetching now enforces stricter public URL access and limits response size to 10 MB.

* **Bug Fixes**
  * Improved sandboxed path validation across file tools.
  * Fixed patching for multiple update sections, improved search/replace and grep result budgeting, and corrected read-file line counting behavior.

* **Documentation**
  * Updated tool descriptions for safety, truncation behavior, and patch/line-number rules.

* **Tests**
  * Added tool regression coverage for path security, parameter conversions, and patch/search edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->