### PR TITLE
Do not rebuild provider config when the existing file fails to load

### DIFF
--- a/Configuration/ConfigurationManager.cs
+++ b/Configuration/ConfigurationManager.cs
@@ -79,6 +79,51 @@ namespace Saturn.Configuration
             }
         }
 
+        /// <summary>
+        /// Loads the configuration for use as the base of a save/rewrite operation. Unlike
+        /// <see cref="LoadConfigurationAsync"/>, this does not swallow read failures for a file
+        /// that exists: a transient read error (locked file, corrupt JSON, etc.) must not be
+        /// treated the same as "no config file exists yet", since callers use the result as the
+        /// base object they overwrite the config file with. Returning null in that case would
+        /// cause the save to silently rebuild a fresh configuration and wipe out any other
+        /// providers' settings.
+        /// </summary>
+        private static async Task<PersistedAgentConfiguration?> LoadForRewriteAsync()
+        {
+            if (!File.Exists(ConfigFilePath))
+            {
+                return null;
+            }
+
+            try
+            {
+                var json = await File.ReadAllTextAsync(ConfigFilePath);
+                var config = JsonSerializer.Deserialize<PersistedAgentConfiguration>(json, JsonOptions);
+
+                if (config != null && config.RequireCommandApproval == null)
+                {
+                    config.RequireCommandApproval = true;
+                }
+
+                if (config != null && config.EnableUserRules == null)
+                {
+                    config.EnableUserRules = true;
+                }
+
+                if (config != null)
+                {
+                    MigrateLegacyProviderFields(config);
+                }
+
+                return config;
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"Failed to load existing configuration for save: {ex.Message}");
+                throw new IOException($"Refusing to save configuration: existing config file at '{ConfigFilePath}' could not be read ({ex.Message}).", ex);
+            }
+        }
+
         private static void MigrateLegacyProviderFields(PersistedAgentConfiguration config)
         {
             config.ActiveProvider ??= "openrouter";
@@ -125,7 +170,7 @@ namespace Saturn.Configuration
                 if (config.ActiveProvider == null || config.Providers == null ||
                     config.SearchProvider == null || config.SearchProviders == null)
                 {
-                    var existing = await LoadConfigurationAsync();
+                    var existing = await LoadForRewriteAsync();
                     config.ActiveProvider ??= existing?.ActiveProvider;
                     config.Providers ??= existing?.Providers;
                     config.SearchProvider ??= existing?.SearchProvider;
@@ -174,7 +219,7 @@ namespace Saturn.Configuration
 
         private static async Task SaveProviderSelectionLockedAsync(string providerName, ProviderSettings settings, string? model)
         {
-            var config = await LoadConfigurationAsync() ?? new PersistedAgentConfiguration();
+            var config = await LoadForRewriteAsync() ?? new PersistedAgentConfiguration();
 
             config.ActiveProvider = providerName;
             config.Providers ??= new Dictionary<string, PersistedProviderConfiguration>(StringComparer.OrdinalIgnoreCase);

--- a/Configuration/ConfigurationManager.cs
+++ b/Configuration/ConfigurationManager.cs
@@ -47,34 +47,10 @@ namespace Saturn.Configuration
         {
             try
             {
-                if (!File.Exists(ConfigFilePath))
-                {
-                    return null;
-                }
-
-                var json = await File.ReadAllTextAsync(ConfigFilePath);
-                var config = JsonSerializer.Deserialize<PersistedAgentConfiguration>(json, JsonOptions);
-
-                if (config != null && config.RequireCommandApproval == null)
-                {
-                    config.RequireCommandApproval = true;
-                }
-
-                if (config != null && config.EnableUserRules == null)
-                {
-                    config.EnableUserRules = true;
-                }
-
-                if (config != null)
-                {
-                    MigrateLegacyProviderFields(config);
-                }
-
-                return config;
+                return await LoadFromDiskAsync();
             }
-            catch (Exception ex)
+            catch
             {
-
                 return null;
             }
         }
@@ -90,38 +66,43 @@ namespace Saturn.Configuration
         /// </summary>
         private static async Task<PersistedAgentConfiguration?> LoadForRewriteAsync()
         {
-            if (!File.Exists(ConfigFilePath))
-            {
-                return null;
-            }
-
             try
             {
-                var json = await File.ReadAllTextAsync(ConfigFilePath);
-                var config = JsonSerializer.Deserialize<PersistedAgentConfiguration>(json, JsonOptions);
-
-                if (config != null && config.RequireCommandApproval == null)
-                {
-                    config.RequireCommandApproval = true;
-                }
-
-                if (config != null && config.EnableUserRules == null)
-                {
-                    config.EnableUserRules = true;
-                }
-
-                if (config != null)
-                {
-                    MigrateLegacyProviderFields(config);
-                }
-
-                return config;
+                return await LoadFromDiskAsync();
             }
             catch (Exception ex)
             {
                 Console.Error.WriteLine($"Failed to load existing configuration for save: {ex.Message}");
                 throw new IOException($"Refusing to save configuration: existing config file at '{ConfigFilePath}' could not be read ({ex.Message}).", ex);
             }
+        }
+
+        private static async Task<PersistedAgentConfiguration?> LoadFromDiskAsync()
+        {
+            if (!File.Exists(ConfigFilePath))
+            {
+                return null;
+            }
+
+            var json = await File.ReadAllTextAsync(ConfigFilePath);
+            var config = JsonSerializer.Deserialize<PersistedAgentConfiguration>(json, JsonOptions);
+
+            if (config != null && config.RequireCommandApproval == null)
+            {
+                config.RequireCommandApproval = true;
+            }
+
+            if (config != null && config.EnableUserRules == null)
+            {
+                config.EnableUserRules = true;
+            }
+
+            if (config != null)
+            {
+                MigrateLegacyProviderFields(config);
+            }
+
+            return config;
         }
 
         private static void MigrateLegacyProviderFields(PersistedAgentConfiguration config)
@@ -301,7 +282,7 @@ namespace Saturn.Configuration
 
         private static async Task SaveSearchProviderSelectionLockedAsync(string providerName, ProviderSettings settings)
         {
-            var config = await LoadConfigurationAsync() ?? new PersistedAgentConfiguration();
+            var config = await LoadForRewriteAsync() ?? new PersistedAgentConfiguration();
 
             config.SearchProvider = providerName;
             config.SearchProviders ??= new Dictionary<string, PersistedProviderConfiguration>(StringComparer.OrdinalIgnoreCase);

--- a/Saturn.Tests/Providers/ConfigurationManagerFileTests.cs
+++ b/Saturn.Tests/Providers/ConfigurationManagerFileTests.cs
@@ -160,6 +160,49 @@ namespace Saturn.Tests.Providers
         }
 
         [Fact]
+        public async Task SaveProviderSelection_UnreadableExistingConfig_ThrowsAndDoesNotClobberFile()
+        {
+            const string corrupt = "{ this is not valid json";
+            await File.WriteAllTextAsync(ConfigFile, corrupt);
+
+            var settings = new ProviderSettings();
+            settings.Set("apiKey", "sk-new");
+
+            var act = () => ConfigurationManager.SaveProviderSelectionAsync("openrouter", settings, "some-model");
+
+            await act.Should().ThrowAsync<IOException>();
+            (await File.ReadAllTextAsync(ConfigFile)).Should().Be(corrupt,
+                "a save must not overwrite a config file it could not read");
+        }
+
+        [Fact]
+        public async Task SaveSearchProviderSelection_UnreadableExistingConfig_ThrowsAndDoesNotClobberFile()
+        {
+            const string corrupt = "{ this is not valid json";
+            await File.WriteAllTextAsync(ConfigFile, corrupt);
+
+            var act = () => ConfigurationManager.SaveSearchProviderSelectionAsync("tavily", new ProviderSettings());
+
+            await act.Should().ThrowAsync<IOException>();
+            (await File.ReadAllTextAsync(ConfigFile)).Should().Be(corrupt);
+        }
+
+        [Fact]
+        public async Task SaveConfiguration_UnreadableExistingConfig_DoesNotClobberFile()
+        {
+            const string corrupt = "{ this is not valid json";
+            await File.WriteAllTextAsync(ConfigFile, corrupt);
+
+            await ConfigurationManager.SaveConfigurationAsync(new PersistedAgentConfiguration
+            {
+                Name = "Assistant",
+                Model = "some-model"
+            });
+
+            (await File.ReadAllTextAsync(ConfigFile)).Should().Be(corrupt);
+        }
+
+        [Fact]
         public async Task Save_LeavesNoTempFileBehind()
         {
             await ConfigurationManager.SaveConfigurationAsync(new PersistedAgentConfiguration { Name = "A", Model = "m" });

--- a/UI/ChatInterface.cs
+++ b/UI/ChatInterface.cs
@@ -968,7 +968,15 @@ namespace Saturn.UI
             agent.Configuration.Model = model;
             AgentManager.Instance.SetParentModel(model);
 
-            await ConfigurationManager.SaveProviderSelectionAsync(providerName, dialog.AppliedSettings ?? new ProviderSettings(), model);
+            try
+            {
+                await ConfigurationManager.SaveProviderSelectionAsync(providerName, dialog.AppliedSettings ?? new ProviderSettings(), model);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.ErrorQuery("Provider",
+                    $"Provider switched for this session, but saving the configuration failed:\n{ex.Message}", "OK");
+            }
             await UpdateConfiguration();
 
             chatView.Text += $"\n[Provider switched to {capabilities.ProviderName} | Model: {model}]\n";


### PR DESCRIPTION
When switching provider or model, the save path loaded the config file with a method that treated read failures the same as a missing file, then overwrote agent-config.json with a blank config on either outcome. A locked file from antivirus or a backup tool, or a corrupted JSON file, could wipe out every other provider's saved API keys and settings during a routine save. The save path now uses a dedicated loader that only returns null when the file truly does not exist, and aborts the save with an error if an existing file can't be read.

Generated by The Saturn Pipeline