### PR TITLE
Use symlink-aware path validation in delete_file, read_file and grep

### DIFF
--- a/Tools/DeleteFileTool.cs
+++ b/Tools/DeleteFileTool.cs
@@ -101,16 +101,17 @@ Safety features:
             {
                 var fullPath = Path.GetFullPath(path);
 
-                var workingDirectory = Path.GetFullPath(Directory.GetCurrentDirectory());
-                var relativeToWorkingDir = Path.GetRelativePath(workingDirectory, fullPath);
-                if (relativeToWorkingDir == ".." ||
-                    relativeToWorkingDir.StartsWith(".." + Path.DirectorySeparatorChar) ||
-                    relativeToWorkingDir.StartsWith(".." + Path.AltDirectorySeparatorChar) ||
-                    Path.IsPathRooted(relativeToWorkingDir))
+                try
                 {
-                    return CreateErrorResult($"Access denied: Path '{path}' is outside the working directory");
+                    PathSecurity.ValidateInsideWorkingDirectory(path);
+                }
+                catch (SecurityException ex)
+                {
+                    return CreateErrorResult(ex.Message);
                 }
 
+                var workingDirectory = Path.GetFullPath(Directory.GetCurrentDirectory());
+                var relativeToWorkingDir = Path.GetRelativePath(workingDirectory, fullPath);
                 if (relativeToWorkingDir == ".")
                 {
                     return CreateErrorResult("Access denied: Cannot delete the working directory itself");

--- a/Tools/GrepTool.cs
+++ b/Tools/GrepTool.cs
@@ -186,17 +186,7 @@ Examples:
 
         private void ValidatePathSecurity(string path)
         {
-            var fullPath = Path.GetFullPath(path);
-            var currentDirectory = Path.GetFullPath(Directory.GetCurrentDirectory());
-
-            var relative = Path.GetRelativePath(currentDirectory, fullPath);
-            if (Path.IsPathRooted(relative) ||
-                relative == ".." ||
-                relative.StartsWith(".." + Path.DirectorySeparatorChar, StringComparison.Ordinal) ||
-                relative.StartsWith(".." + Path.AltDirectorySeparatorChar, StringComparison.Ordinal))
-            {
-                throw new System.Security.SecurityException($"Access denied: Path '{path}' is outside the working directory");
-            }
+            PathSecurity.ValidateInsideWorkingDirectory(path);
         }
 
         private void SearchFile(string filePath, Regex regex, List<GrepResult> results, int maxResults, List<string> skippedFiles)

--- a/Tools/ReadFileTool.cs
+++ b/Tools/ReadFileTool.cs
@@ -161,17 +161,7 @@ Examples:
         
         private void ValidatePathSecurity(string path)
         {
-            var fullPath = Path.GetFullPath(path);
-            var currentDirectory = Path.GetFullPath(Directory.GetCurrentDirectory());
-
-            var relative = Path.GetRelativePath(currentDirectory, fullPath);
-            if (Path.IsPathRooted(relative) ||
-                relative == ".." ||
-                relative.StartsWith(".." + Path.DirectorySeparatorChar, StringComparison.Ordinal) ||
-                relative.StartsWith(".." + Path.AltDirectorySeparatorChar, StringComparison.Ordinal))
-            {
-                throw new System.Security.SecurityException($"Access denied: Path '{path}' is outside the working directory");
-            }
+            PathSecurity.ValidateInsideWorkingDirectory(path);
         }
 
         private async Task<FileContent> ReadFileContent(string path, Encoding encoding, int? startLine, int? endLine, bool includeLineNumbers)


### PR DESCRIPTION
delete_file, read_file, and grep each carried their own lexical-only path check while write_file, apply_diff, glob, and list_files already used the symlink-aware validator in PathSecurity. A junction placed inside the workspace could let these three escape it, which was especially risky for delete_file since it recurses through directories. All three now delegate to PathSecurity.ValidateInsideWorkingDirectory, and delete_file keeps its separate guard against deleting the working directory itself.

Generated by The Saturn Pipeline