### PR TITLE
Stop tool selection Cancel from wiping the agent's tool list

### DIFF
--- a/UI/ChatInterface.cs
+++ b/UI/ChatInterface.cs
@@ -1448,8 +1448,8 @@ namespace Saturn.UI
         {
             var dialog = new ToolSelectionDialog(currentConfig.ToolNames);
             Application.Run(dialog);
-            
-            if (dialog.SelectedTools.Count > 0 || currentConfig.ToolNames?.Count > 0)
+
+            if (!dialog.WasCancelled)
             {
                 currentConfig.ToolNames = dialog.SelectedTools;
                 currentConfig.EnableTools = dialog.SelectedTools.Count > 0;

--- a/UI/Dialogs/ModeEditorDialog.cs
+++ b/UI/Dialogs/ModeEditorDialog.cs
@@ -346,8 +346,8 @@ namespace Saturn.UI.Dialogs
         {
             var toolDialog = new ToolSelectionDialog(selectedTools);
             Application.Run(toolDialog);
-            
-            if (toolDialog.SelectedTools != null)
+
+            if (!toolDialog.WasCancelled)
             {
                 selectedTools = toolDialog.SelectedTools;
                 UpdateToolCountLabel();

--- a/UI/Dialogs/ToolSelectionDialog.cs
+++ b/UI/Dialogs/ToolSelectionDialog.cs
@@ -20,7 +20,7 @@ namespace Saturn.UI.Dialogs
         private string[] toolDisplayNames = null!;
         
         public List<string> SelectedTools => selectedToolNames.ToList();
-        public bool WasCancelled { get; private set; }
+        public bool WasCancelled { get; private set; } = true;
         
         public ToolSelectionDialog(List<string>? currentlySelectedTools = null)
             : base("Select Tools", 70, 20)
@@ -110,7 +110,11 @@ namespace Saturn.UI.Dialogs
                 X = Pos.Right(clearAllButton) + 4,
                 Y = Pos.Top(selectAllButton)
             };
-            okButton.Clicked += () => Application.RequestStop();
+            okButton.Clicked += () =>
+            {
+                WasCancelled = false;
+                Application.RequestStop();
+            };
             
             cancelButton = new Button("_Cancel")
             {

--- a/UI/Dialogs/ToolSelectionDialog.cs
+++ b/UI/Dialogs/ToolSelectionDialog.cs
@@ -20,6 +20,7 @@ namespace Saturn.UI.Dialogs
         private string[] toolDisplayNames = null!;
         
         public List<string> SelectedTools => selectedToolNames.ToList();
+        public bool WasCancelled { get; private set; }
         
         public ToolSelectionDialog(List<string>? currentlySelectedTools = null)
             : base("Select Tools", 70, 20)
@@ -116,9 +117,9 @@ namespace Saturn.UI.Dialogs
                 X = Pos.Right(okButton) + 2,
                 Y = Pos.Top(selectAllButton)
             };
-            cancelButton.Clicked += () => 
+            cancelButton.Clicked += () =>
             {
-                selectedToolNames.Clear();
+                WasCancelled = true;
                 Application.RequestStop();
             };
             


### PR DESCRIPTION
Pressing Cancel in the tool selection dialog used to clear the selected tools list as its cancel signal. Callers couldn't tell that apart from the user deliberately picking zero tools, so hitting Cancel could silently persist an empty tool list and disable tools entirely. The dialog now exposes a WasCancelled flag, and both callers skip applying any change when it's set.

Generated by The Saturn Pipeline