### PR TITLE
Restrict recursive delete_file with a pattern to matching files

### DIFF
--- a/Saturn.Tests/Tools/DeleteFileToolTests.cs
+++ b/Saturn.Tests/Tools/DeleteFileToolTests.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using FluentAssertions;
+using Saturn.Tests.TestHelpers;
+using Saturn.Tools;
+using Xunit;
+
+namespace Saturn.Tests.Tools
+{
+    [Collection("WorkingDirectory")]
+    public class DeleteFileToolTests : IDisposable
+    {
+        private readonly FileTestHelper _fileHelper;
+        private readonly string _originalDirectory;
+
+        public DeleteFileToolTests()
+        {
+            _fileHelper = new FileTestHelper($"DeleteFileToolTests_{Guid.NewGuid():N}");
+            _originalDirectory = Directory.GetCurrentDirectory();
+            Directory.SetCurrentDirectory(_fileHelper.TestDirectory);
+        }
+
+        public void Dispose()
+        {
+            Directory.SetCurrentDirectory(_originalDirectory);
+            _fileHelper.Dispose();
+        }
+
+        [Fact]
+        public async System.Threading.Tasks.Task RecursiveWithPattern_DeletesOnlyMatchingFiles_LeavesDirectoriesIntact()
+        {
+            _fileHelper.CreateFile(Path.Combine("logs", "a.log"), "a");
+            _fileHelper.CreateFile(Path.Combine("logs", "b.log"), "b");
+            _fileHelper.CreateFile(Path.Combine("logs", "keep.txt"), "keep");
+            _fileHelper.CreateFile(Path.Combine("logs", "nested", "c.log"), "c");
+            _fileHelper.CreateFile(Path.Combine("logs", "nested", "keep2.txt"), "keep2");
+
+            var tool = new DeleteFileTool();
+
+            var result = await tool.ExecuteAsync(new Dictionary<string, object>
+            {
+                ["path"] = "logs",
+                ["pattern"] = "*.log",
+                ["recursive"] = true
+            });
+
+            result.Success.Should().BeTrue();
+
+            File.Exists(_fileHelper.GetPath(Path.Combine("logs", "a.log"))).Should().BeFalse();
+            File.Exists(_fileHelper.GetPath(Path.Combine("logs", "b.log"))).Should().BeFalse();
+            File.Exists(_fileHelper.GetPath(Path.Combine("logs", "nested", "c.log"))).Should().BeFalse();
+
+            File.Exists(_fileHelper.GetPath(Path.Combine("logs", "keep.txt"))).Should().BeTrue();
+            File.Exists(_fileHelper.GetPath(Path.Combine("logs", "nested", "keep2.txt"))).Should().BeTrue();
+            Directory.Exists(_fileHelper.GetPath("logs")).Should().BeTrue();
+            Directory.Exists(_fileHelper.GetPath(Path.Combine("logs", "nested"))).Should().BeTrue();
+        }
+    }
+}

--- a/Tools/DeleteFileTool.cs
+++ b/Tools/DeleteFileTool.cs
@@ -129,18 +129,34 @@ Safety features:
                     return CreateSuccessResult(deletionInfo, dryRunMessage);
                 }
                 
-                var deletedItems = await PerformDeletion(deletionInfo.ItemsToDelete, force);
-                
+                var (deletedItems, failedItems) = await PerformDeletion(deletionInfo.ItemsToDelete, force);
+
                 var result = new
                 {
                     DeletedFiles = deletedItems.Count(i => i.Type == "file"),
                     DeletedDirectories = deletedItems.Count(i => i.Type == "directory"),
                     TotalSize = deletedItems.Sum(i => i.Size),
-                    Items = deletedItems.Select(i => i.Path).ToList()
+                    Items = deletedItems.Select(i => i.Path).ToList(),
+                    FailedItems = failedItems.Select(f => f.Path).ToList()
                 };
 
+                if (failedItems.Count > 0)
+                {
+                    var failureMessage = $"Deleted {result.DeletedFiles} files and {result.DeletedDirectories} directories ({FormatFileSize(result.TotalSize)}), " +
+                        $"but failed to delete {failedItems.Count} item(s): " +
+                        string.Join("; ", failedItems.Select(f => $"{f.Path} ({f.Error})"));
+
+                    return new ToolResult
+                    {
+                        Success = false,
+                        RawData = result,
+                        Error = failureMessage,
+                        FormattedOutput = failureMessage
+                    };
+                }
+
                 var message = $"Deleted {result.DeletedFiles} files and {result.DeletedDirectories} directories ({FormatFileSize(result.TotalSize)})";
-                
+
                 return CreateSuccessResult(result, message);
             }
             catch (Exception ex)
@@ -220,8 +236,9 @@ Safety features:
         
         private void CollectItemsRecursive(string path, string pattern, List<DeletionItem> items)
         {
-            var searchPattern = string.IsNullOrEmpty(pattern) ? "*" : pattern;
-            
+            var hasPattern = !string.IsNullOrEmpty(pattern) && pattern != "*";
+            var searchPattern = hasPattern ? pattern : "*";
+
             foreach (var file in Directory.GetFiles(path, searchPattern, SearchOption.AllDirectories))
             {
                 var fileInfo = new FileInfo(file);
@@ -233,7 +250,13 @@ Safety features:
                     IsReadOnly = fileInfo.IsReadOnly
                 });
             }
-            
+
+            // A specific pattern only selects files - directories (including the root) are left in place.
+            if (hasPattern)
+            {
+                return;
+            }
+
             foreach (var dir in Directory.GetDirectories(path, "*", SearchOption.AllDirectories).OrderByDescending(d => d.Length))
             {
                 items.Add(new DeletionItem
@@ -244,7 +267,7 @@ Safety features:
                     IsReadOnly = false
                 });
             }
-            
+
             items.Add(new DeletionItem
             {
                 Path = path,
@@ -254,32 +277,47 @@ Safety features:
             });
         }
         
-        private async Task<List<DeletionItem>> PerformDeletion(List<DeletionItem> items, bool force)
+        private async Task<(List<DeletionItem> Deleted, List<(string Path, string Error)> Failed)> PerformDeletion(List<DeletionItem> items, bool force)
         {
             var deleted = new List<DeletionItem>();
-            
+            var failed = new List<(string Path, string Error)>();
+
             foreach (var item in items.Where(i => i.Type == "file"))
             {
-                if (item.IsReadOnly && force)
+                try
                 {
-                    File.SetAttributes(item.Path, FileAttributes.Normal);
-                }
-                
-                File.Delete(item.Path);
-                deleted.Add(item);
-            }
-            
-            foreach (var item in items.Where(i => i.Type == "directory").OrderByDescending(i => i.Path.Length))
-            {
-                if (Directory.Exists(item.Path))
-                {
-                    Directory.Delete(item.Path, false);
+                    if (item.IsReadOnly && force)
+                    {
+                        File.SetAttributes(item.Path, FileAttributes.Normal);
+                    }
+
+                    File.Delete(item.Path);
                     deleted.Add(item);
                 }
+                catch (Exception ex)
+                {
+                    failed.Add((item.Path, ex.Message));
+                }
             }
-            
+
+            foreach (var item in items.Where(i => i.Type == "directory").OrderByDescending(i => i.Path.Length))
+            {
+                try
+                {
+                    if (Directory.Exists(item.Path))
+                    {
+                        Directory.Delete(item.Path, false);
+                        deleted.Add(item);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    failed.Add((item.Path, ex.Message));
+                }
+            }
+
             await Task.CompletedTask;
-            return deleted;
+            return (deleted, failed);
         }
         
         private string FormatDryRunMessage(DeletionInfo info)


### PR DESCRIPTION
When deleting recursively with a pattern like *.log, the tool deleted the matching files but then tried to delete every subdirectory and the root path too. If a directory still had non-matching files left, Directory.Delete threw and the whole operation reported total failure even though files had already been permanently removed. Now a pattern only targets matching files and leaves directories alone, and any per-item deletion failure is reported alongside what was actually deleted instead of silently discarding that record.

Generated by The Saturn Pipeline