### PR TITLE
Read file contents under the apply_diff file locks

### DIFF
--- a/Tools/ApplyDiffTool.cs
+++ b/Tools/ApplyDiffTool.cs
@@ -137,14 +137,10 @@ The format also supports '*** Add File: path' (every content line prefixed with 
                 
                 await ValidateFilesForReading(filesNeeded);
                 await ValidateFilesForAdding(filesToAdd);
-                
-                var currentFiles = await LoadCurrentFiles(filesNeeded);
 
-                var operations = ParsePatchText(patchText, currentFiles);
-                
                 var allFiles = filesNeeded.Union(filesToAdd).ToList();
                 var lockedFiles = new List<string>();
-                
+
                 try
                 {
                     foreach (var file in allFiles)
@@ -160,7 +156,11 @@ The format also supports '*** Add File: path' (every content line prefixed with 
                             lockedFiles.Add(absPath);
                         }
                     }
-                    
+
+                    var currentFiles = await LoadCurrentFiles(filesNeeded);
+
+                    var operations = ParsePatchText(patchText, currentFiles);
+
                     var commit = ConvertToCommit(operations, currentFiles);
                 
                 var stats = CalculateStatistics(commit);


### PR DESCRIPTION
The apply_diff tool loaded file contents and parsed the patch before acquiring the per-file locks, so the lock only protected the write. Two concurrent apply_diff calls on the same file could both read the same starting content, and the second call would silently overwrite the first one's change while both reported success. Content is now loaded and the patch parsed after the locks are held, so reads and writes are serialized together.

Generated by The Saturn Pipeline