### PR TITLE
Error on malformed hunk headers instead of silently applying nothing

### DIFF
--- a/Saturn.Tests/Tools/ApplyDiffToolTests.cs
+++ b/Saturn.Tests/Tools/ApplyDiffToolTests.cs
@@ -666,5 +666,55 @@ Just some random text";
         }
 
         #endregion
+
+        #region Malformed Hunk Headers
+
+        [Fact]
+        public async Task ExecuteAsync_HunkHeaderWithTrailingWhitespace_AppliesPatch()
+        {
+            _fileHelper.CreateFile("trailing.txt", "Original content");
+
+            var hunkHeaderWithTrailingSpace = "@@ Original content @@" + "   ";
+            var patchText = "*** Update File: trailing.txt\n"
+                + hunkHeaderWithTrailingSpace + "\n"
+                + "-Original content\n"
+                + "+Updated content";
+
+            var parameters = new Dictionary<string, object>
+            {
+                { "patchText", patchText }
+            };
+
+            var result = await _tool.ExecuteAsync(parameters);
+
+            result.Success.Should().BeTrue();
+            result.FormattedOutput.Should().Contain("1 addition");
+            result.FormattedOutput.Should().Contain("1 removal");
+            _fileHelper.ReadFile("trailing.txt").Should().Be("Updated content");
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_MalformedHunkLine_ReturnsError()
+        {
+            _fileHelper.CreateFile("malformed.txt", "Original content");
+
+            var patchText = @"*** Update File: malformed.txt
+this is not a hunk header
+-Original content
++Updated content";
+
+            var parameters = new Dictionary<string, object>
+            {
+                { "patchText", patchText }
+            };
+
+            var result = await _tool.ExecuteAsync(parameters);
+
+            result.Success.Should().BeFalse();
+            result.Error.Should().Contain("Malformed patch");
+            _fileHelper.ReadFile("malformed.txt").Should().Be("Original content");
+        }
+
+        #endregion
     }
 }

--- a/Saturn.Tests/Tools/ApplyDiffToolTests.cs
+++ b/Saturn.Tests/Tools/ApplyDiffToolTests.cs
@@ -715,6 +715,47 @@ this is not a hunk header
             _fileHelper.ReadFile("malformed.txt").Should().Be("Original content");
         }
 
+        [Fact]
+        public async Task ExecuteAsync_UpdateSectionWithoutHunks_ReturnsError()
+        {
+            _fileHelper.CreateFile("nohunks.txt", "Original content");
+
+            var patchText = "*** Update File: nohunks.txt\n\n";
+
+            var parameters = new Dictionary<string, object>
+            {
+                { "patchText", patchText }
+            };
+
+            var result = await _tool.ExecuteAsync(parameters);
+
+            result.Success.Should().BeFalse();
+            result.Error.Should().Contain("contains no hunks");
+            _fileHelper.ReadFile("nohunks.txt").Should().Be("Original content");
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_HunkHeaderMissingClosingMarker_ReturnsError()
+        {
+            _fileHelper.CreateFile("unclosed.txt", "Original content");
+
+            var patchText = @"*** Update File: unclosed.txt
+@@ Original content
+-Original content
++Updated content";
+
+            var parameters = new Dictionary<string, object>
+            {
+                { "patchText", patchText }
+            };
+
+            var result = await _tool.ExecuteAsync(parameters);
+
+            result.Success.Should().BeFalse();
+            result.Error.Should().Contain("Malformed patch");
+            _fileHelper.ReadFile("unclosed.txt").Should().Be("Original content");
+        }
+
         #endregion
     }
 }

--- a/Tools/ApplyDiffTool.cs
+++ b/Tools/ApplyDiffTool.cs
@@ -387,7 +387,12 @@ The format also supports '*** Add File: path' (every content line prefixed with 
                             throw new InvalidOperationException($"Malformed patch at line {i + 1}: expected a hunk header like '@@ context @@' but found: {lines[i]}");
                         }
                     }
-                    
+
+                    if (hunks.Count == 0)
+                    {
+                        throw new InvalidOperationException($"Update section for '{filePath}' contains no hunks; expected at least one '@@ context @@' hunk followed by change lines");
+                    }
+
                     operations.Add(new PatchOperation { Type = OperationType.Update, FilePath = filePath, Hunks = hunks });
                 }
                 else if (line.StartsWith("*** Add File:"))

--- a/Tools/ApplyDiffTool.cs
+++ b/Tools/ApplyDiffTool.cs
@@ -347,16 +347,17 @@ The format also supports '*** Add File: path' (every content line prefixed with 
                     
                     while (i < lines.Length && !lines[i].StartsWith("***"))
                     {
-                        if (lines[i].StartsWith("@@") && lines[i].EndsWith("@@") && lines[i].Length > 4)
+                        var trimmedLine = lines[i].TrimEnd();
+                        if (trimmedLine.StartsWith("@@") && trimmedLine.EndsWith("@@") && trimmedLine.Length > 4)
                         {
-                            var contextLine = lines[i].Substring(2, lines[i].Length - 4).Trim();
+                            var contextLine = trimmedLine.Substring(2, trimmedLine.Length - 4).Trim();
                             if (string.IsNullOrEmpty(contextLine))
                             {
                                 throw new InvalidOperationException($"Empty context line at line {i + 1}");
                             }
                             var changes = new List<PatchChange>();
                             i++;
-                            
+
                             while (i < lines.Length && !lines[i].StartsWith("@@") && !lines[i].StartsWith("***"))
                             {
                                 var changeLine = lines[i];
@@ -374,12 +375,16 @@ The format also supports '*** Add File: path' (every content line prefixed with 
                                 }
                                 i++;
                             }
-                            
+
                             hunks.Add(new PatchHunk { ContextLine = contextLine, Changes = changes });
+                        }
+                        else if (string.IsNullOrWhiteSpace(lines[i]))
+                        {
+                            i++;
                         }
                         else
                         {
-                            i++;
+                            throw new InvalidOperationException($"Malformed patch at line {i + 1}: expected a hunk header like '@@ context @@' but found: {lines[i]}");
                         }
                     }
                     


### PR DESCRIPTION
ApplyDiffTool used to silently skip hunk headers with trailing whitespace or a missing closing @@, which meant the update section parsed with zero hunks and the tool reported success without changing anything. Now a trailing-space header is tolerated and applied normally, and any other malformed header throws a clear error instead of failing silently.

Generated by The Saturn Pipeline