### PR TITLE
Treat dollar signs literally in non-regex search_and_replace replacements

### DIFF
--- a/Saturn.Tests/Tools/ToolBugRegressionTests.cs
+++ b/Saturn.Tests/Tools/ToolBugRegressionTests.cs
@@ -257,6 +257,25 @@ namespace Saturn.Tests.Tools
             bytes.Take(3).Should().NotEqual(new byte[] { 0xEF, 0xBB, 0xBF });
         }
 
+        [Fact]
+        public async Task SearchAndReplace_LiteralMode_TreatsReplacementDollarSignsLiterally()
+        {
+            _fileHelper.CreateFile("dollars.txt", "price: $99.99\n");
+
+            var tool = new SearchAndReplaceTool();
+            var result = await tool.ExecuteAsync(new Dictionary<string, object>
+            {
+                { "searchPattern", "price" },
+                { "replacement", "cost: $0" },
+                { "filePattern", "dollars.txt" },
+                { "regex", false }
+            });
+
+            result.Success.Should().BeTrue(result.Error);
+            _fileHelper.ReadFile("dollars.txt").Should().Contain("cost: $0");
+            _fileHelper.ReadFile("dollars.txt").Should().NotContain("cost: price");
+        }
+
         #endregion
 
         #region Grep result budget

--- a/Tools/SearchAndReplaceTool.cs
+++ b/Tools/SearchAndReplaceTool.cs
@@ -155,18 +155,24 @@ Safety features:
             {
                 replacement = "";
             }
-            
+
+            // Escape dollar signs in replacement string for literal mode to prevent regex substitution tokens
+            if (!useRegex)
+            {
+                replacement = replacement.Replace("$", "$$");
+            }
+
             try
             {
                 ValidatePathSecurity(basePath);
-                
+
                 var files = await FindMatchingFiles(filePattern, basePath, exclude, maxFiles);
-                
+
                 if (files.Count == 0)
                 {
                     return CreateSuccessResult(new { Files = 0 }, $"No files found matching pattern '{filePattern}'");
                 }
-                
+
                 var regex = BuildSearchRegex(searchPattern, useRegex, caseSensitive, wholeWord);
                 var results = await ProcessFiles(files, regex, replacement, dryRun);
                 


### PR DESCRIPTION
﻿In literal mode (regex=false), dollar signs in the replacement string were being interpreted as regex substitution tokens like $0, $$, and ${name}. This caused incorrect replacements such as "price" replaced with "cost: $0.99" becoming "cost: price.99" instead of "cost: $0.99". The fix escapes dollar signs when regex mode is disabled so they are treated as literal characters.

Generated by The Saturn Pipeline
