### PR TITLE
Prevent execute_command hanging on child processes holding output pipes

### DIFF
--- a/Saturn.Tests/Tools/ExecuteCommandToolTests.cs
+++ b/Saturn.Tests/Tools/ExecuteCommandToolTests.cs
@@ -37,6 +37,30 @@ namespace Saturn.Tests.Tools
         }
 
         [Fact]
+        public async Task DetachedChildHoldingPipe_ReturnsPromptlyWithoutTimeout()
+        {
+            var tool = NewTool();
+
+            var command = IsWindows
+                ? "echo parent_done & start /b ping -n 30 127.0.0.1"
+                : "sleep 30 & echo parent_done";
+
+            var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+            var result = await tool.ExecuteAsync(new Dictionary<string, object>
+            {
+                ["command"] = command,
+                ["timeout"] = 60
+            });
+            stopwatch.Stop();
+
+            result.Success.Should().BeTrue();
+            result.FormattedOutput.Should().Contain("parent_done");
+            result.FormattedOutput.Should().NotContain("TIMED OUT");
+            result.FormattedOutput.Should().Contain("holding the output stream");
+            stopwatch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(20));
+        }
+
+        [Fact]
         public async Task Background_StartsPollsAndCompletes()
         {
             var tool = NewTool();

--- a/Tools/ExecuteCommandTool.cs
+++ b/Tools/ExecuteCommandTool.cs
@@ -284,17 +284,22 @@ Prefer the dedicated file tools (read_file, write_file, grep, glob, list_files) 
             }
             catch (OperationCanceledException)
             {
-                timedOut = true;
-                try
-                {
-                    process.Kill(entireProcessTree: true);
-                }
-                catch { }
+                timedOut = !process.HasExited;
 
-                try { await process.WaitForExitAsync(); } catch { }
+                if (!process.HasExited)
+                {
+                    try
+                    {
+                        process.Kill(entireProcessTree: true);
+                    }
+                    catch { }
+                }
+
+                try { process.WaitForExit(5000); } catch { }
             }
 
-            try { process.WaitForExit(); } catch { }
+            var drained = false;
+            try { drained = process.WaitForExit(2000); } catch { }
 
             stopwatch.Stop();
 
@@ -308,8 +313,13 @@ Prefer the dedicated file tools (read_file, write_file, grep, glob, list_files) 
                 errorBuilder.AppendLine("... [capture limit reached; subsequent error output was discarded] ...");
             }
 
+            if (!timedOut && process.HasExited && !drained)
+            {
+                outputBuilder.AppendLine("... [a child process is still holding the output stream; output may be incomplete and background children may still be running] ...");
+            }
+
             int exitCode;
-            try { exitCode = process.ExitCode; } catch { exitCode = -1; }
+            try { exitCode = process.HasExited ? process.ExitCode : -1; } catch { exitCode = -1; }
 
             return new CommandResult
             {

--- a/Tools/ExecuteCommandTool.cs
+++ b/Tools/ExecuteCommandTool.cs
@@ -266,6 +266,10 @@ Prefer the dedicated file tools (read_file, write_file, grep, glob, list_files) 
                 };
             }
 
+            var exitTcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+            process.EnableRaisingEvents = true;
+            process.Exited += (sender, e) => exitTcs.TrySetResult(null);
+
             process.Start();
 
             if (captureOutput)
@@ -278,9 +282,13 @@ Prefer the dedicated file tools (read_file, write_file, grep, glob, list_files) 
             cts.CancelAfter(timeout);
 
             var timedOut = false;
+            var pipeHeldOpen = false;
             try
             {
-                await process.WaitForExitAsync(cts.Token);
+                // Wait on process exit rather than WaitForExitAsync alone: WaitForExitAsync
+                // also waits for the redirected output pipes to reach EOF, which never
+                // happens while a detached child holds them open (e.g. "cmd /c start /b ...").
+                await exitTcs.Task.WaitAsync(cts.Token);
             }
             catch (OperationCanceledException)
             {
@@ -298,8 +306,15 @@ Prefer the dedicated file tools (read_file, write_file, grep, glob, list_files) 
                 try { process.WaitForExit(5000); } catch { }
             }
 
-            var drained = false;
-            try { drained = process.WaitForExit(2000); } catch { }
+            if (captureOutput)
+            {
+                // Give the redirected streams a short grace period to flush buffered
+                // output. If a lingering child still holds the pipe open, this times
+                // out instead of hanging until the overall timeout.
+                using var drainCts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+                try { await process.WaitForExitAsync(drainCts.Token); }
+                catch (OperationCanceledException) { pipeHeldOpen = true; }
+            }
 
             stopwatch.Stop();
 
@@ -313,7 +328,7 @@ Prefer the dedicated file tools (read_file, write_file, grep, glob, list_files) 
                 errorBuilder.AppendLine("... [capture limit reached; subsequent error output was discarded] ...");
             }
 
-            if (!timedOut && process.HasExited && !drained)
+            if (!timedOut && pipeHeldOpen)
             {
                 outputBuilder.AppendLine("... [a child process is still holding the output stream; output may be incomplete and background children may still be running] ...");
             }


### PR DESCRIPTION
When a command spawns a detached child that inherits the output pipe handles (like `cmd /c start /b node server.js`), the shell exits quickly but the pipe stays open. WaitForExitAsync and the parameterless WaitForExit both wait on pipe EOF rather than just process exit, so the agent used to hang or misreport the run as timed out even though the process was long gone. This switches to bounded waits and only marks a run as timed out when the process genuinely hasn't exited, while noting in the output when a lingering child may still be holding the stream open.

Generated by The Saturn Pipeline