### PR TITLE
Forward the cancellation token on non-streaming execute paths

### DIFF
--- a/Agents/Core/AgentBase.cs
+++ b/Agents/Core/AgentBase.cs
@@ -122,7 +122,7 @@ namespace Saturn.Agents.Core
         {
             if (!Configuration.EnableStreaming)
             {
-                var result = await Execute<T>(input);
+                var result = await Execute<T>(input, cancellationToken);
                 if (onChunk != null && result is Message msg)
                 {
                     await onChunk(new StreamChunk

--- a/UI/ChatInterface.cs
+++ b/UI/ChatInterface.cs
@@ -712,7 +712,7 @@ namespace Saturn.UI
                         }
                         else
                         {
-                            Message response = await agent.Execute<Message>(message);
+                            Message response = await agent.Execute<Message>(message, cancellationTokenSource.Token);
                             var responseText = response.Content.ToString();
                             var renderedResponse = markdownRenderer.RenderToTerminal(responseText);
 


### PR DESCRIPTION
Cancel requests now work correctly when streaming is disabled. The non-streaming code paths were dropping the cancellation token, allowing the full tool loop including retries to run to completion instead of being cancelled.

Generated by The Saturn Pipeline