### PR TITLE
Keep cancelled run entries out of a freshly started session

### DIFF
--- a/Web/OrchestratorService.cs
+++ b/Web/OrchestratorService.cs
@@ -31,6 +31,7 @@ namespace Saturn.Web
         private CancellationTokenSource? _cts;
         private int _busy;
         private bool _parentWired;
+        private int _sessionEpoch;
 
         public event Action? OnIdle;
 
@@ -118,6 +119,8 @@ namespace Saturn.Web
             var cts = new CancellationTokenSource();
             _cts = cts;
 
+            var epoch = Volatile.Read(ref _sessionEpoch);
+
             _ = Task.Run(async () =>
             {
                 var buffer = new StringBuilder();
@@ -135,15 +138,24 @@ namespace Saturn.Web
                         return Task.CompletedTask;
                     }, cts.Token);
 
-                    AddEntry("assistant", buffer.ToString());
+                    if (Volatile.Read(ref _sessionEpoch) == epoch)
+                    {
+                        AddEntry("assistant", buffer.ToString());
+                    }
                 }
                 catch (OperationCanceledException)
                 {
-                    AddEntry("system", "Response cancelled.");
+                    if (Volatile.Read(ref _sessionEpoch) == epoch)
+                    {
+                        AddEntry("system", "Response cancelled.");
+                    }
                 }
                 catch (Exception ex)
                 {
-                    AddEntry("system", $"Error: {ex.Message}");
+                    if (Volatile.Read(ref _sessionEpoch) == epoch)
+                    {
+                        AddEntry("system", $"Error: {ex.Message}");
+                    }
                 }
                 finally
                 {
@@ -216,6 +228,7 @@ namespace Saturn.Web
         public void StartNewSession()
         {
             Cancel();
+            Interlocked.Increment(ref _sessionEpoch);
             _agent.ClearHistory();
             _parentWired = false;
             lock (_transcriptLock)

--- a/Web/OrchestratorService.cs
+++ b/Web/OrchestratorService.cs
@@ -31,7 +31,7 @@ namespace Saturn.Web
         private CancellationTokenSource? _cts;
         private int _busy;
         private bool _parentWired;
-        private int _sessionEpoch;
+        private int _sessionEpoch; // guarded by _transcriptLock
 
         public event Action? OnIdle;
 
@@ -119,7 +119,11 @@ namespace Saturn.Web
             var cts = new CancellationTokenSource();
             _cts = cts;
 
-            var epoch = Volatile.Read(ref _sessionEpoch);
+            int epoch;
+            lock (_transcriptLock)
+            {
+                epoch = _sessionEpoch;
+            }
 
             _ = Task.Run(async () =>
             {
@@ -138,24 +142,15 @@ namespace Saturn.Web
                         return Task.CompletedTask;
                     }, cts.Token);
 
-                    if (Volatile.Read(ref _sessionEpoch) == epoch)
-                    {
-                        AddEntry("assistant", buffer.ToString());
-                    }
+                    AddEntryIfCurrent(epoch, "assistant", buffer.ToString());
                 }
                 catch (OperationCanceledException)
                 {
-                    if (Volatile.Read(ref _sessionEpoch) == epoch)
-                    {
-                        AddEntry("system", "Response cancelled.");
-                    }
+                    AddEntryIfCurrent(epoch, "system", "Response cancelled.");
                 }
                 catch (Exception ex)
                 {
-                    if (Volatile.Read(ref _sessionEpoch) == epoch)
-                    {
-                        AddEntry("system", $"Error: {ex.Message}");
-                    }
+                    AddEntryIfCurrent(epoch, "system", $"Error: {ex.Message}");
                 }
                 finally
                 {
@@ -228,14 +223,30 @@ namespace Saturn.Web
         public void StartNewSession()
         {
             Cancel();
-            Interlocked.Increment(ref _sessionEpoch);
             _agent.ClearHistory();
             _parentWired = false;
             lock (_transcriptLock)
             {
+                _sessionEpoch++;
                 _transcript.Clear();
             }
             _hub.Publish("orchestrator.cleared");
+        }
+
+        private void AddEntryIfCurrent(int epoch, string role, string content, string source = "user")
+        {
+            var entry = new TranscriptEntry { Role = role, Content = content, Source = source };
+            lock (_transcriptLock)
+            {
+                // A new session may have started while this run was unwinding;
+                // its entries belong to the old transcript and must not leak in.
+                if (_sessionEpoch != epoch)
+                {
+                    return;
+                }
+                _transcript.Add(entry);
+            }
+            _hub.Publish("orchestrator.message", entry);
         }
 
         private void AddEntry(string role, string content, string source = "user")


### PR DESCRIPTION
When a new session starts while a run is still cancelling, that run's catch block used to append a stray Response cancelled entry into the freshly cleared transcript. This added a session generation counter so cancelled or errored runs from a prior session no longer write into the new one.

Generated by The Saturn Pipeline