### PR TITLE
Fix Stop and resend race clobbering the active turn state

### DIFF
--- a/UI/ChatInterface.cs
+++ b/UI/ChatInterface.cs
@@ -516,8 +516,14 @@ namespace Saturn.UI
             {
                 if (isProcessing && cancellationTokenSource != null)
                 {
-                    cancellationTokenSource.Cancel();
-                    
+                    try
+                    {
+                        cancellationTokenSource.Cancel();
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                    }
+
                     AgentManager.Instance.TerminateAllAgents();
                     
                     sendButton.Text = "Send";
@@ -595,7 +601,8 @@ namespace Saturn.UI
                 return;
 
             isProcessing = true;
-            cancellationTokenSource = new CancellationTokenSource();
+            var cts = new CancellationTokenSource();
+            cancellationTokenSource = cts;
 
             try
             {
@@ -665,7 +672,7 @@ namespace Saturn.UI
                                         });
                                     }
                                 },
-                                cancellationTokenSource.Token);
+                                cts.Token);
 
                             Application.MainLoop.Invoke(() =>
                             {
@@ -775,15 +782,18 @@ namespace Saturn.UI
             }
             finally
             {
-                sendButton.Text = "Send";
-                sendButton.Enabled = true;
-                inputField.ReadOnly = false;
-                isProcessing = false;
-                cancellationTokenSource?.Dispose();
-                cancellationTokenSource = null;
-                UpdateAgentStatus("Ready");
-                inputField.SetFocus();
-                Application.Refresh();
+                if (ReferenceEquals(cancellationTokenSource, cts))
+                {
+                    cancellationTokenSource = null;
+                    isProcessing = false;
+                    sendButton.Text = "Send";
+                    sendButton.Enabled = true;
+                    inputField.ReadOnly = false;
+                    UpdateAgentStatus("Ready");
+                    inputField.SetFocus();
+                    Application.Refresh();
+                }
+                cts.Dispose();
             }
         }
 


### PR DESCRIPTION
Cancelling a message and immediately sending a new one used to let the cancelled turn's cleanup run after the new turn started, disposing the new cancellation token and marking the UI idle while a response was still streaming. ProcessMessage now captures its own cancellation token source in a local variable and only resets shared UI state in its finally block if it is still the current turn. The Stop button also guards its cancel call against a disposed token source now that cleanup can race it.

Generated by The Saturn Pipeline