### PR TITLE
Surface in-body provider errors on non-streaming chat completions

### DIFF
--- a/OpenRouter/Models/Api/Chat/ChatCompletionResponse.cs
+++ b/OpenRouter/Models/Api/Chat/ChatCompletionResponse.cs
@@ -25,5 +25,8 @@ namespace Saturn.OpenRouter.Models.Api.Chat
 
         [JsonPropertyName("system_fingerprint")]
         public string? SystemFingerprint { get; set; }
+
+        [JsonPropertyName("error")]
+        public ErrorResponse.ErrorBody? Error { get; set; }
     }
 }

--- a/OpenRouter/Services/ChatCompletionsService.cs
+++ b/OpenRouter/Services/ChatCompletionsService.cs
@@ -16,13 +16,24 @@ namespace Saturn.OpenRouter.Services
             _http = http ?? throw new ArgumentNullException(nameof(http));
         }
 
-        public Task<ChatCompletionResponse?> CreateAsync(ChatCompletionRequest request, CancellationToken cancellationToken = default)
+        public async Task<ChatCompletionResponse?> CreateAsync(ChatCompletionRequest request, CancellationToken cancellationToken = default)
         {
             if (request is null) throw new ArgumentNullException(nameof(request));
             if (request.Stream == true)
                 throw new ArgumentException("Streaming is not supported by this method. Set Stream to null or false.", nameof(request));
 
-            return _http.SendJsonAsync<ChatCompletionResponse>(HttpMethod.Post, "chat/completions", request, null, cancellationToken);
+            var response = await _http.SendJsonAsync<ChatCompletionResponse>(HttpMethod.Post, "chat/completions", request, null, cancellationToken).ConfigureAwait(false);
+
+            if (response?.Error != null)
+            {
+                var status = response.Error.Code is >= 400 and <= 599
+                    ? (System.Net.HttpStatusCode)response.Error.Code.Value
+                    : System.Net.HttpStatusCode.BadGateway;
+
+                throw Errors.OpenRouterException.FromErrorBody(status, response.Error);
+            }
+
+            return response;
         }
     }
 }

--- a/OpenRouter/Services/ChatCompletionsService.cs
+++ b/OpenRouter/Services/ChatCompletionsService.cs
@@ -24,7 +24,7 @@ namespace Saturn.OpenRouter.Services
 
             var response = await _http.SendJsonAsync<ChatCompletionResponse>(HttpMethod.Post, "chat/completions", request, null, cancellationToken).ConfigureAwait(false);
 
-            if (response?.Error != null)
+            if (response?.Error != null && (response.Error.Code != null || !string.IsNullOrWhiteSpace(response.Error.Message)))
             {
                 var status = response.Error.Code is >= 400 and <= 599
                     ? (System.Net.HttpStatusCode)response.Error.Code.Value


### PR DESCRIPTION
OpenRouter can return a 200 response whose JSON body contains an error object when a provider fails after the request was already accepted. The non-streaming chat completions path had no way to detect this, so those failures were silently treated as successful empty responses instead of triggering the existing rate-limit and provider-error retry logic. This mirrors the handling already in place on the streaming path.

Generated by The Saturn Pipeline