### PR TITLE
Bound the error response body read with the caller token and a timeout

### DIFF
--- a/OpenRouter/Http/HttpClientAdapter.cs
+++ b/OpenRouter/Http/HttpClientAdapter.cs
@@ -186,9 +186,11 @@ namespace Saturn.OpenRouter.Http
             string? payload = null;
             try
             {
+                using var readCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                readCts.CancelAfter(TimeSpan.FromSeconds(30));
                 payload = response.Content is null
                     ? null
-                    : await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    : await response.Content.ReadAsStringAsync(readCts.Token).ConfigureAwait(false);
             }
             catch
             {

--- a/OpenRouter/Http/HttpClientAdapter.cs
+++ b/OpenRouter/Http/HttpClientAdapter.cs
@@ -192,6 +192,10 @@ namespace Saturn.OpenRouter.Http
                     ? null
                     : await response.Content.ReadAsStringAsync(readCts.Token).ConfigureAwait(false);
             }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
             catch
             {
 

--- a/OpenRouter/Services/CreditsService.cs
+++ b/OpenRouter/Services/CreditsService.cs
@@ -63,7 +63,7 @@ namespace Saturn.OpenRouter.Services
 
             var text = response.Content is null
                 ? null
-                : await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                : await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 
             if (string.IsNullOrWhiteSpace(text))
             {

--- a/OpenRouter/Services/GenerationService.cs
+++ b/OpenRouter/Services/GenerationService.cs
@@ -93,7 +93,7 @@ namespace Saturn.OpenRouter.Services
 
             var text = response.Content is null
                 ? null
-                : await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                : await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 
             if (string.IsNullOrWhiteSpace(text))
             {

--- a/OpenRouter/Services/ProvidersService.cs
+++ b/OpenRouter/Services/ProvidersService.cs
@@ -41,7 +41,7 @@ namespace Saturn.OpenRouter.Services
 
             var text = response.Content is null
                 ? null
-                : await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                : await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 
             if (string.IsNullOrWhiteSpace(text))
             {


### PR DESCRIPTION
The error response body read in ThrowForErrorAsync was not cancellation-aware and had no timeout. This caused requests to hang indefinitely if a server returned error headers then stalled the body.

This fix binds the body read to both the caller's cancellation token and a 30-second timeout via a linked CancellationTokenSource. Read failures are still caught and degraded to a generic error path.

Generated by The Saturn Pipeline