### PR TITLE
Make the OpenRouter request timeout configurable

### DIFF
--- a/Providers/OpenRouter/OpenRouterProvider.cs
+++ b/Providers/OpenRouter/OpenRouterProvider.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Saturn.OpenRouter;
@@ -10,6 +11,9 @@ namespace Saturn.Providers
     {
         public const string ProviderName = "openrouter";
         public const string ApiKeySetting = "apiKey";
+        public const string TimeoutSetting = "timeoutSeconds";
+
+        private const int DefaultTimeoutSeconds = 600;
 
         public string Name => ProviderName;
         public string DisplayName => "OpenRouter";
@@ -23,6 +27,13 @@ namespace Saturn.Providers
                 Kind = ProviderSettingKind.Secret,
                 Required = true,
                 EnvironmentVariable = "OPENROUTER_API_KEY"
+            },
+            new ProviderSettingDescriptor
+            {
+                Key = TimeoutSetting,
+                Label = "Request timeout (seconds)",
+                Kind = ProviderSettingKind.Number,
+                DefaultValue = DefaultTimeoutSeconds.ToString()
             }
         };
 
@@ -36,11 +47,18 @@ namespace Saturn.Providers
                     "or switch to a local provider with SATURN_PROVIDER=lmstudio.");
             }
 
+            var timeoutText = SettingDescriptors.First(d => d.Key == TimeoutSetting).Resolve(settings);
+            if (!int.TryParse(timeoutText, out var timeoutSeconds) || timeoutSeconds <= 0)
+            {
+                timeoutSeconds = DefaultTimeoutSeconds;
+            }
+
             var client = new OpenRouterClient(new OpenRouterOptions
             {
                 ApiKey = apiKey,
                 Referer = "https://github.com/xyOz-dev/Saturn",
-                Title = "Saturn"
+                Title = "Saturn",
+                Timeout = TimeSpan.FromSeconds(timeoutSeconds)
             });
 
             return Task.FromResult<ILlmClient>(new OpenRouterLlmClient(client));


### PR DESCRIPTION
OpenRouter requests were always capped at the hardcoded 100 second default, so any completion that took longer than that died with a TaskCanceledException that the retry logic never caught. This adds a timeoutSeconds setting to OpenRouterProvider, mirroring the pattern already used by the LM Studio provider, with a 600 second default.

Generated by The Saturn Pipeline