### PR TITLE
Tolerate string error codes in provider error payloads

### DIFF
--- a/OpenRouter/Models/Api/Common/ResponseError.cs
+++ b/OpenRouter/Models/Api/Common/ResponseError.cs
@@ -7,6 +7,7 @@ namespace Saturn.OpenRouter.Models.Api.Common
     public sealed class ResponseError
     {
         [JsonPropertyName("code")]
+        [JsonConverter(typeof(Serialization.LenientNullableIntConverter))]
         public int? Code { get; set; }
 
         [JsonPropertyName("message")]

--- a/OpenRouter/Models/Api/ErrorResponse.cs
+++ b/OpenRouter/Models/Api/ErrorResponse.cs
@@ -11,6 +11,7 @@ namespace Saturn.OpenRouter.Models.Api
         public sealed class ErrorBody
         {
             [JsonPropertyName("code")]
+            [JsonConverter(typeof(Serialization.LenientNullableIntConverter))]
             public int? Code { get; set; }
 
             [JsonPropertyName("message")]

--- a/OpenRouter/Serialization/LenientNullableIntConverter.cs
+++ b/OpenRouter/Serialization/LenientNullableIntConverter.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Saturn.OpenRouter.Serialization
+{
+    /// <summary>
+    /// Some OpenAI-compatible servers (e.g. LM Studio) emit error codes as a
+    /// string (e.g. "model_not_loaded") instead of a number. This converter
+    /// tolerates that by treating any non-numeric string (or null) as the
+    /// absence of a code, while still parsing numeric strings and JSON numbers.
+    /// </summary>
+    public sealed class LenientNullableIntConverter : JsonConverter<int?>
+    {
+        public override int? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            switch (reader.TokenType)
+            {
+                case JsonTokenType.Null:
+                    return null;
+                case JsonTokenType.Number:
+                    return reader.TryGetInt32(out var number) ? number : null;
+                case JsonTokenType.String:
+                    var text = reader.GetString();
+                    return int.TryParse(text, out var parsed) ? parsed : null;
+                default:
+                    reader.Skip();
+                    return null;
+            }
+        }
+
+        public override void Write(Utf8JsonWriter writer, int? value, JsonSerializerOptions options)
+        {
+            if (value.HasValue)
+            {
+                writer.WriteNumberValue(value.Value);
+            }
+            else
+            {
+                writer.WriteNullValue();
+            }
+        }
+    }
+}

--- a/Saturn.Tests/Providers/ErrorResponseTests.cs
+++ b/Saturn.Tests/Providers/ErrorResponseTests.cs
@@ -1,0 +1,36 @@
+using FluentAssertions;
+using Saturn.OpenRouter.Models.Api;
+using Saturn.OpenRouter.Serialization;
+using Xunit;
+
+namespace Saturn.Tests.Providers
+{
+    public class ErrorResponseTests
+    {
+        [Fact]
+        public void Deserialize_WithStringCode_SetsCodeNull()
+        {
+            const string json = """{"error":{"message":"boom","code":"model_not_loaded"}}""";
+
+            var result = Json.Deserialize<ErrorResponse>(json, Json.CreateDefaultOptions());
+
+            result.Should().NotBeNull();
+            result!.Error.Should().NotBeNull();
+            result.Error!.Code.Should().BeNull();
+            result.Error.Message.Should().Be("boom");
+        }
+
+        [Fact]
+        public void Deserialize_WithNumericCode_SetsCode()
+        {
+            const string json = """{"error":{"message":"x","code":429}}""";
+
+            var result = Json.Deserialize<ErrorResponse>(json, Json.CreateDefaultOptions());
+
+            result.Should().NotBeNull();
+            result!.Error.Should().NotBeNull();
+            result.Error!.Code.Should().Be(429);
+            result.Error.Message.Should().Be("x");
+        }
+    }
+}

--- a/Saturn.Tests/Providers/ErrorResponseTests.cs
+++ b/Saturn.Tests/Providers/ErrorResponseTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Saturn.OpenRouter.Models.Api;
+using Saturn.OpenRouter.Models.Api.Chat;
 using Saturn.OpenRouter.Serialization;
 using Xunit;
 
@@ -31,6 +32,20 @@ namespace Saturn.Tests.Providers
             result!.Error.Should().NotBeNull();
             result.Error!.Code.Should().Be(429);
             result.Error.Message.Should().Be("x");
+        }
+
+        [Fact]
+        public void Deserialize_StreamingChoiceError_WithStringCode_SetsCodeNull()
+        {
+            const string json = """{"id":"1","choices":[{"delta":{},"error":{"message":"model not loaded","code":"model_not_loaded"}}]}""";
+
+            var result = Json.Deserialize<ChatCompletionChunk>(json, Json.CreateDefaultOptions());
+
+            result.Should().NotBeNull();
+            result!.Choices.Should().NotBeNullOrEmpty();
+            result.Choices![0].Error.Should().NotBeNull();
+            result.Choices[0].Error!.Code.Should().BeNull();
+            result.Choices[0].Error!.Message.Should().Be("model not loaded");
         }
     }
 }


### PR DESCRIPTION
Some OpenAI-compatible servers like LM Studio send the error code field as a string such as model_not_loaded instead of a number. That mismatch was throwing a JsonException during deserialization, which got swallowed and made the streaming parser treat a real provider error as an ordinary chunk. This adds a lenient converter so numeric codes still parse and non-numeric codes just fall back to null, letting the existing error handling take over correctly.

Generated by The Saturn Pipeline