### PR TITLE
Propagate cancellation through the streaming pipeline

### DIFF
--- a/Agents/Core/AgentBase.cs
+++ b/Agents/Core/AgentBase.cs
@@ -866,8 +866,10 @@ namespace Saturn.Agents.Core
             var contentBuffer = new StringBuilder();
             var toolCallBuffer = new List<OpenRouter.Models.Api.Chat.ToolCall>();
 
-            while (continueProcessing && !cancellationToken.IsCancellationRequested)
+            while (continueProcessing)
             {
+                cancellationToken.ThrowIfCancellationRequested();
+
                 if (!ValidateToolMessageSequence(currentMessages))
                 {
                     currentMessages = CleanupInvalidToolMessages(currentMessages);
@@ -890,8 +892,7 @@ namespace Saturn.Agents.Core
 
                         await foreach (var chunk in client.StreamChatAsync(request, cancellationToken))
                         {
-                            if (cancellationToken.IsCancellationRequested)
-                                break;
+                            cancellationToken.ThrowIfCancellationRequested();
 
                             var choice = chunk.Choices?.FirstOrDefault();
                             if (choice?.Delta != null)

--- a/OpenRouter/Http/SseStream.cs
+++ b/OpenRouter/Http/SseStream.cs
@@ -16,17 +16,11 @@ namespace Saturn.OpenRouter.Http
             string? currentEventName = null;
             StringBuilder? dataBuffer = null;
 
-            while (!cancellationToken.IsCancellationRequested)
+            while (true)
             {
-                string? line;
-                try
-                {
-                    line = await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false);
-                }
-                catch (OperationCanceledException)
-                {
-                    yield break;
-                }
+                // Cancellation must surface as OperationCanceledException so callers can
+                // distinguish a user-cancelled turn from a normal end-of-stream.
+                var line = await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false);
 
                 if (line is null)
                     break;

--- a/OpenRouter/Services/ChatCompletionsStreamingService.cs
+++ b/OpenRouter/Services/ChatCompletionsStreamingService.cs
@@ -45,8 +45,7 @@ namespace Saturn.OpenRouter.Services
                 headers: null,
                 cancellationToken: cancellationToken).ConfigureAwait(false))
             {
-                if (cancellationToken.IsCancellationRequested)
-                    yield break;
+                cancellationToken.ThrowIfCancellationRequested();
 
                 if (ev.IsComment)
                     continue;


### PR DESCRIPTION
Cancelling a streaming turn was silently converted into a normal end of stream at three layers. SseStream caught OperationCanceledException and yielded break, while ChatCompletionsStreamingService and ExecuteWithStreamingTools exited their loops quietly, so the agent then committed a fabricated apology message or a stale duplicate of the partial response to persisted chat history. This change lets cancellation propagate as OperationCanceledException through the whole streaming pipeline, matching the non-streaming path. Callers already handle it, with the web orchestrator logging "Response cancelled." and the TUI printing "[Cancelled]". Retry logic is unaffected since a cancel during the retry wait also throws instead of retrying.

Generated by The Saturn Pipeline
