### PR TITLE
Stop wake throttling from losing recurrence occurrences and unblock notices

### DIFF
--- a/Core/Tasks/TaskCoordinator.cs
+++ b/Core/Tasks/TaskCoordinator.cs
@@ -143,7 +143,12 @@ namespace Saturn.Core.Tasks
                         $"Recurring task '{task.Title}' ({task.Id}) is due.{missedNote} " +
                         $"Notes: {task.Notes ?? "(none)"}. Use list_tasks/claim_task/dispatch_task to act on it, " +
                         "and complete_task when the work is done.",
-                        $"recur:{task.Id}:{scheduledFor:yyyy-MM-ddTHH:mm}");
+                        $"recur:{task.Id}:{scheduledFor:yyyy-MM-ddTHH:mm}",
+                        // The budget was already checked before the claim above; going
+                        // through the throttled path again could drop the wake if a
+                        // critical wake consumed the budget in between, losing the
+                        // occurrence after NextRunAt has irreversibly advanced.
+                        critical: true);
                 }
             }
         }

--- a/Core/Tasks/TaskCoordinator.cs
+++ b/Core/Tasks/TaskCoordinator.cs
@@ -49,14 +49,10 @@ namespace Saturn.Core.Tasks
             // The hourly cap only throttles proactive nudges (recurrences, ready
             // tasks). Completions, claim results and recovery notices must always
             // land or their continuations are lost.
-            if (!critical)
+            if (!critical && !await HasWakeBudgetAsync())
             {
-                var recentCount = await _store.Project.CountRecentWakesAsync(DateTime.UtcNow.AddHours(-1));
-                if (recentCount >= _settings.MaxWakesPerHour)
-                {
-                    _hub.Publish("wake.suppressed", new { kind, taskId, reason = $"MaxWakesPerHour ({_settings.MaxWakesPerHour}) reached" });
-                    return false;
-                }
+                _hub.Publish("wake.suppressed", new { kind, taskId, reason = $"MaxWakesPerHour ({_settings.MaxWakesPerHour}) reached" });
+                return false;
             }
 
             var enqueued = await _store.Project.TryEnqueueWakeAsync(new WakeItem
@@ -73,6 +69,12 @@ namespace Saturn.Core.Tasks
                 _ = SafePumpAsync();
             }
             return enqueued;
+        }
+
+        private async Task<bool> HasWakeBudgetAsync()
+        {
+            var recentCount = await _store.Project.CountRecentWakesAsync(DateTime.UtcNow.AddHours(-1));
+            return recentCount < _settings.MaxWakesPerHour;
         }
 
         public async Task PumpWakeQueueAsync()
@@ -102,6 +104,16 @@ namespace Saturn.Core.Tasks
             {
                 foreach (var task in await repo.GetDueRecurringAsync(now))
                 {
+                    // Check the wake budget before claiming: claiming advances
+                    // NextRunAt irreversibly, so if the wake would be dropped by
+                    // the hourly cap, leave the occurrence unclaimed so the next
+                    // sweep retries it once budget frees up.
+                    if (!await HasWakeBudgetAsync())
+                    {
+                        _hub.Publish("wake.suppressed", new { kind = WakeKinds.RecurrenceDue, taskId = task.Id, reason = $"MaxWakesPerHour ({_settings.MaxWakesPerHour}) reached; occurrence left unclaimed for retry" });
+                        continue;
+                    }
+
                     var scheduledFor = task.NextRunAt!.Value;
                     var next = RecurrenceCalculator.GetNextOccurrenceUtc(
                         task.RecurrenceKind, task.RecurrenceIntervalSeconds, task.RecurrenceCron, now);
@@ -180,7 +192,8 @@ namespace Saturn.Core.Tasks
                     task.Id,
                     $"Task '{task.Title}' ({task.Id}) is no longer blocked — its dependency '{completed.Title}' ({completed.Id}) completed. " +
                     "It can now be worked on.",
-                    $"unblock:{task.Id}:{completed.Id}");
+                    $"unblock:{task.Id}:{completed.Id}",
+                    critical: true);
             }
         }
 


### PR DESCRIPTION
Recurring tasks were claimed and their run rows inserted before the wake notification was enqueued, so when the hourly wake cap was exhausted the occurrence was silently lost with no retry path. The budget is now checked before claiming, so an exhausted cap leaves the occurrence unclaimed for the next sweep to pick up. Task-unblocked notifications are now marked critical, matching the other completion-continuation wakes that must always land.

Generated by The Saturn Pipeline