### PR TITLE
Record a run when completing a recurring task that has not fired

### DIFF
--- a/Data/Tasks/TaskRepository.cs
+++ b/Data/Tasks/TaskRepository.cs
@@ -349,9 +349,9 @@ namespace Saturn.Data.Tasks
             }, ct);
         }
 
-        public Task SetLatestRunOutcomeAsync(string taskId, string outcome, CancellationToken ct = default)
+        public Task<int> SetLatestRunOutcomeAsync(string taskId, string outcome, CancellationToken ct = default)
         {
-            return WithWriteLockAsync<object?>(async () =>
+            return WithWriteLockAsync(async () =>
             {
                 using var connection = CreateConnection();
                 using var cmd = new SqliteCommand(@"
@@ -360,8 +360,7 @@ namespace Saturn.Data.Tasks
                     connection);
                 cmd.Parameters.AddWithValue("@TaskId", taskId);
                 cmd.Parameters.AddWithValue("@Outcome", outcome);
-                await cmd.ExecuteNonQueryAsync(ct);
-                return null;
+                return await cmd.ExecuteNonQueryAsync(ct);
             }, ct);
         }
 

--- a/Data/Tasks/TaskStore.cs
+++ b/Data/Tasks/TaskStore.cs
@@ -321,8 +321,23 @@ namespace Saturn.Data.Tasks
 
             if (task.IsRecurring)
             {
-                await RepoOf(task).SetLatestRunOutcomeAsync(task.Id,
-                    note ?? (success ? TaskStatuses.Done : TaskStatuses.Failed));
+                var outcome = note ?? (success ? TaskStatuses.Done : TaskStatuses.Failed);
+                var repo = RepoOf(task);
+                var updated = await repo.SetLatestRunOutcomeAsync(task.Id, outcome);
+                if (updated == 0)
+                {
+                    // No TaskRuns row exists yet (the task has never fired via the
+                    // due-recurrence sweep). Record a run directly so dependents
+                    // relying on HasCompletedRunAsync don't stay blocked forever.
+                    var now = DateTime.UtcNow;
+                    await repo.InsertRunAsync(new TaskRun
+                    {
+                        TaskId = task.Id,
+                        ScheduledFor = now,
+                        FiredAt = now,
+                        Outcome = outcome
+                    });
+                }
                 task.Status = TaskStatuses.Pending;
                 task.ClaimStatus = ClaimStatuses.None;
                 task.ClaimedBy = null;

--- a/Saturn.Tests/Tasks/TaskStoreTests.cs
+++ b/Saturn.Tests/Tasks/TaskStoreTests.cs
@@ -150,6 +150,31 @@ namespace Saturn.Tests.Tasks
         }
 
         [Fact]
+        public async Task CompleteAsync_RecurringTaskThatNeverFired_RecordsRunAndUnblocksDependents()
+        {
+            var recurring = await CreateTaskAsync("nightly job", s =>
+            {
+                s.RecurrenceKind = RecurrenceKinds.Interval;
+                s.RecurrenceIntervalSeconds = 3600;
+            });
+            var dependent = await CreateTaskAsync("after nightly", s => s.BlockedBy = new List<string> { recurring.Id });
+
+            // No TaskRuns row exists yet: the due-recurrence sweep never fired this task.
+            (await _store.Project.GetRunsAsync(recurring.Id)).Should().BeEmpty();
+
+            var completed = await _store.CompleteAsync(recurring.Id, success: true);
+
+            completed!.Status.Should().Be(TaskStatuses.Pending);
+
+            var runs = await _store.Project.GetRunsAsync(recurring.Id);
+            runs.Should().ContainSingle().Which.Outcome.Should().NotBeNull();
+
+            (await _store.IsBlockedAsync(dependent.Id)).Should().BeFalse();
+            var blockers = await _store.GetBlockersAsync(dependent.Id);
+            blockers.Should().ContainSingle().Which.Satisfied.Should().BeTrue();
+        }
+
+        [Fact]
         public async Task CompleteAsync_RecurringTask_ResetsToPendingAndRecordsOutcome()
         {
             var recurring = await CreateTaskAsync("hourly job", s =>


### PR DESCRIPTION
Completing a recurring task that has never fired via the due-recurrence sweep recorded nothing, since the update targeted a TaskRuns row that did not exist yet. Dependents blocked on that task stayed blocked forever even though completion reported success.

SetLatestRunOutcomeAsync now returns the affected row count, and CompleteAsync inserts a run directly when no existing row was updated. Added a regression test covering completion of a never-fired recurring task and its dependent's blocker state.

Generated by The Saturn Pipeline