### PR TITLE
Emit the completed event when update_task sets a terminal status

### DIFF
--- a/Data/Tasks/TaskStore.cs
+++ b/Data/Tasks/TaskStore.cs
@@ -135,6 +135,7 @@ namespace Saturn.Data.Tasks
             }
 
             var originalScope = task.Scope;
+            var wasTerminal = TaskStatuses.IsTerminal(task.Status);
 
             if (spec.Title != null && !string.IsNullOrWhiteSpace(spec.Title)) task.Title = spec.Title.Trim();
             if (spec.Notes != null) task.Notes = string.IsNullOrWhiteSpace(spec.Notes) ? null : spec.Notes.Trim();
@@ -209,7 +210,8 @@ namespace Saturn.Data.Tasks
                 await RepoOf(task).SetDependenciesAsync(task.Id, spec.BlockedBy.Distinct().ToList());
             }
 
-            OnTaskChanged?.Invoke("updated", task);
+            var becameTerminal = !wasTerminal && TaskStatuses.IsTerminal(task.Status);
+            OnTaskChanged?.Invoke(becameTerminal ? "completed" : "updated", task);
             return task;
         }
 

--- a/Saturn.Tests/Tasks/TaskStoreTests.cs
+++ b/Saturn.Tests/Tasks/TaskStoreTests.cs
@@ -187,6 +187,22 @@ namespace Saturn.Tests.Tasks
         }
 
         [Fact]
+        public async Task UpdateAsync_SettingStatusToDone_FiresCompletedEvent()
+        {
+            var task = await CreateTaskAsync("finish via update");
+
+            var changes = new List<(string Change, string Status)>();
+            _store.OnTaskChanged += (change, changedTask) => changes.Add((change, changedTask.Status));
+
+            var updated = await _store.UpdateAsync(task.Id, new TaskUpdateSpec { Status = TaskStatuses.Done });
+
+            updated!.Status.Should().Be(TaskStatuses.Done);
+
+            // update_task must trigger the same unblock sweep as complete_task.
+            changes.Should().ContainSingle(c => c.Change == "completed" && c.Status == TaskStatuses.Done);
+        }
+
+        [Fact]
         public async Task UpdateAsync_ScopeChange_MovesTaskBetweenDatabases()
         {
             var task = await CreateTaskAsync("mover");


### PR DESCRIPTION
Marking a task done through update_task never woke up dependent tasks, since TaskStore.UpdateAsync always fired an "updated" event and WebServer only runs the unblock sweep on "completed" events. Only complete_task went through that path before.

This change tracks whether a status change moves a task into a terminal state (done, failed, cancelled) and fires "completed" in that case instead, matching complete_task's behavior. Added a regression test covering update_task setting status to done.

Generated by The Saturn Pipeline