### PR TITLE
Migrate run history when a task changes scope

### DIFF
--- a/Data/Tasks/TaskRepository.cs
+++ b/Data/Tasks/TaskRepository.cs
@@ -391,6 +391,17 @@ namespace Saturn.Data.Tasks
             }, ct);
         }
 
+        public Task<bool> DeleteRunsForTaskAsync(string taskId, CancellationToken ct = default)
+        {
+            return WithWriteLockAsync(async () =>
+            {
+                using var connection = CreateConnection();
+                using var cmd = new SqliteCommand("DELETE FROM TaskRuns WHERE TaskId = @TaskId", connection);
+                cmd.Parameters.AddWithValue("@TaskId", taskId);
+                return await cmd.ExecuteNonQueryAsync(ct) > 0;
+            }, ct);
+        }
+
         // ---------- Waiters (runtime) ----------
 
         public Task<TaskWaiter> InsertWaiterAsync(TaskWaiter w, CancellationToken ct = default)

--- a/Data/Tasks/TaskStore.cs
+++ b/Data/Tasks/TaskStore.cs
@@ -180,6 +180,7 @@ namespace Saturn.Data.Tasks
             {
                 var sourceRepo = RepoFor(originalScope);
                 var deps = await sourceRepo.GetDependenciesAsync(task.Id);
+                var runs = await sourceRepo.GetRunsAsync(task.Id, limit: int.MaxValue);
 
                 // DeleteTaskAsync also wipes edges where this task is the blocker;
                 // snapshot the dependents' edge lists so they can be restored.
@@ -190,9 +191,14 @@ namespace Saturn.Data.Tasks
                 }
 
                 await sourceRepo.DeleteTaskAsync(task.Id);
+                await sourceRepo.DeleteRunsForTaskAsync(task.Id);
                 task.Scope = spec.Scope;
                 await RepoOf(task).InsertTaskAsync(task);
                 await RepoOf(task).SetDependenciesAsync(task.Id, deps);
+                foreach (var run in runs)
+                {
+                    await RepoOf(task).InsertRunAsync(run);
+                }
 
                 foreach (var (dependentId, edges) in dependentEdges)
                 {

--- a/Saturn.Tests/Tasks/TaskStoreTests.cs
+++ b/Saturn.Tests/Tasks/TaskStoreTests.cs
@@ -215,6 +215,32 @@ namespace Saturn.Tests.Tasks
         }
 
         [Fact]
+        public async Task UpdateAsync_ScopeChange_MigratesRunHistorySoRecurringDependentsStayUnblocked()
+        {
+            var recurring = await CreateTaskAsync("nightly job", s =>
+            {
+                s.RecurrenceKind = RecurrenceKinds.Interval;
+                s.RecurrenceIntervalSeconds = 3600;
+            });
+            var dependent = await CreateTaskAsync("after nightly", s => s.BlockedBy = new List<string> { recurring.Id });
+
+            // Simulate one fired occurrence completing while the task is still project-scoped.
+            await _store.Project.InsertRunAsync(new TaskRun { TaskId = recurring.Id, ScheduledFor = DateTime.UtcNow });
+            await _store.CompleteAsync(recurring.Id, success: true);
+
+            (await _store.IsBlockedAsync(dependent.Id)).Should().BeFalse();
+
+            await _store.UpdateAsync(recurring.Id, new TaskUpdateSpec { Scope = TaskScopes.Global });
+
+            // The completed run must have moved with the task, or the dependent
+            // becomes re-blocked because its history is now invisible.
+            (await _store.Project.GetRunsAsync(recurring.Id)).Should().BeEmpty();
+            var migratedRuns = await _store.Global.GetRunsAsync(recurring.Id);
+            migratedRuns.Should().ContainSingle().Which.Outcome.Should().NotBeNull();
+            (await _store.IsBlockedAsync(dependent.Id)).Should().BeFalse();
+        }
+
+        [Fact]
         public async Task TryEnqueueWakeAsync_DeduplicatesByKey()
         {
             var first = await _store.Project.TryEnqueueWakeAsync(new WakeItem { Kind = "test", Prompt = "p", DedupeKey = "dup:1" });


### PR DESCRIPTION
Moving a recurring task between project and global scope only migrated the task row and dependency edges, leaving its TaskRuns behind in the source database. Since HasCompletedRunAsync checks the task's current database, dependents that were already unblocked would flip back to blocked as soon as the task changed scope. This copies the run history to the destination database and clears it from the source during the move.

Generated by The Saturn Pipeline