### PR TITLE
Enforce a single open dispatch per task

### DIFF
--- a/Core/Tasks/TaskCoordinator.cs
+++ b/Core/Tasks/TaskCoordinator.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
 using Saturn.Agents.MultiAgent;
 using Saturn.Agents.MultiAgent.Objects;
 using Saturn.Config;
@@ -390,12 +391,25 @@ namespace Saturn.Core.Tasks
                 return (false, $"Task {taskId} is already dispatched to {openDispatches[0].AgentName}", null);
             }
 
-            var dispatch = await _store.Project.InsertDispatchAsync(new TaskDispatch
+            TaskDispatch dispatch;
+            try
             {
-                TaskId = taskId,
-                AgentId = agentId,
-                AgentName = agentName
-            });
+                dispatch = await _store.Project.InsertDispatchAsync(new TaskDispatch
+                {
+                    TaskId = taskId,
+                    AgentId = agentId,
+                    AgentName = agentName
+                });
+            }
+            catch (SqliteException ex) when (ex.SqliteErrorCode == 19 && ex.SqliteExtendedErrorCode == 2067)
+            {
+                // The partial unique index (idx_dispatch_open_unique) rejected a second
+                // concurrent open dispatch for this task; the pre-check above raced with
+                // another dispatcher and lost. Report the same "already dispatched" shape.
+                var current = (await _store.Project.GetDispatchesForTaskAsync(taskId)).Where(d => d.CompletedAt == null && !d.Orphaned).ToList();
+                var agentLabel = current.Count > 0 ? current[0].AgentName : "another agent";
+                return (false, $"Task {taskId} is already dispatched to {agentLabel}", null);
+            }
 
             var taskPrompt =
                 $"You have been dispatched Saturn task '{task.Title}' ({task.Id}).\n" +

--- a/Data/Tasks/TaskRepository.cs
+++ b/Data/Tasks/TaskRepository.cs
@@ -106,7 +106,16 @@ namespace Saturn.Data.Tasks
                         Orphaned INTEGER NOT NULL DEFAULT 0
                     );
                     CREATE INDEX IF NOT EXISTS idx_dispatch_mgr ON TaskDispatches(AgentManagerTaskId);
-                    CREATE INDEX IF NOT EXISTS idx_dispatch_open ON TaskDispatches(TaskId) WHERE CompletedAt IS NULL;
+
+                    UPDATE TaskDispatches SET Orphaned = 1
+                    WHERE CompletedAt IS NULL AND Orphaned = 0 AND Id NOT IN (
+                        SELECT d2.Id FROM TaskDispatches d2
+                        WHERE d2.CompletedAt IS NULL AND d2.Orphaned = 0 AND d2.TaskId = TaskDispatches.TaskId
+                        ORDER BY d2.StartedAt DESC LIMIT 1
+                    );
+
+                    DROP INDEX IF EXISTS idx_dispatch_open;
+                    CREATE UNIQUE INDEX IF NOT EXISTS idx_dispatch_open_unique ON TaskDispatches(TaskId) WHERE CompletedAt IS NULL AND Orphaned = 0;
 
                     CREATE TABLE IF NOT EXISTS WakeQueue (
                         Id TEXT PRIMARY KEY,


### PR DESCRIPTION
Task dispatch had a race where the web UI and the orchestrator could both dispatch the same task before either dispatch row was written, causing two agents to work the same task. The open-dispatch index is now a partial unique index on TaskId so only one active dispatch per task can exist at the database level, and existing duplicate open dispatches are cleaned up on startup by orphaning all but the most recent. DispatchTaskAsync now catches the resulting unique-constraint violation and returns the same already-dispatched error as the existing pre-check.

Generated by The Saturn Pipeline