### PR TITLE
Dispose reviewer and terminated agents and cancel timed out reviews

### DIFF
--- a/Agents/MultiAgent/AgentManager.cs
+++ b/Agents/MultiAgent/AgentManager.cs
@@ -243,7 +243,7 @@ Your report is consumed by an orchestrator agent, so keep it factual and free of
                 }
             }
 
-            _ = Task.Run(async () =>
+            var executionTask = Task.Run(async () =>
             {
                 try
                 {
@@ -326,6 +326,8 @@ Your report is consumed by an orchestrator agent, so keep it factual and free of
                     CompleteTask(taskId, agentId, agentContext, false, $"Error: {ex.Message}");
                 }
             });
+            agentContext.ExecutionTask = executionTask;
+            _ = executionTask;
 
             return taskId;
         }
@@ -670,10 +672,12 @@ Your decision:";
             if (_runningAgents.TryRemove(agentId, out var context))
             {
                 CancellationTokenSource? cancellation;
+                Task? executionTask;
                 lock (_agentRegistrationLock)
                 {
                     context.Status = AgentStatus.Terminated;
                     cancellation = context.Cancellation;
+                    executionTask = context.ExecutionTask;
                 }
 
                 try
@@ -686,12 +690,22 @@ Your decision:";
 
                 if (context.Agent != null)
                 {
-                    try
+                    var agentToDispose = context.Agent;
+                    if (executionTask != null && !executionTask.IsCompleted)
                     {
-                        context.Agent.Dispose();
+                        // The handoff's execution loop may still be mid-flight (e.g.
+                        // blocked on a provider response); disposing here could tear
+                        // down state it is still touching, so defer disposal until
+                        // the task actually unwinds — same reasoning as the reviewer
+                        // timeout path above.
+                        _ = executionTask.ContinueWith(_ =>
+                        {
+                            try { agentToDispose.Dispose(); } catch { }
+                        }, TaskScheduler.Default);
                     }
-                    catch
+                    else
                     {
+                        try { agentToDispose.Dispose(); } catch { }
                     }
                 }
 

--- a/Agents/MultiAgent/AgentManager.cs
+++ b/Agents/MultiAgent/AgentManager.cs
@@ -524,7 +524,7 @@ Your decision:";
                 };
                 
                 var reviewerAgent = new Agent(reviewerConfig);
-                
+
                 var reviewerContext = new ReviewerContext
                 {
                     Id = reviewerId,
@@ -533,60 +533,80 @@ Your decision:";
                     TaskId = taskId,
                     StartedAt = DateTime.Now
                 };
-                
+
                 _reviewers[reviewerId] = reviewerContext;
-                
-                var reviewTask = reviewerAgent.Execute<Message>(reviewPrompt);
+
+                var reviewCts = new CancellationTokenSource();
+                var reviewTask = reviewerAgent.Execute<Message>(reviewPrompt, reviewCts.Token);
                 var timeoutTask = Task.Delay(prefs.ReviewTimeoutSeconds * 1000);
-                
+
                 var completedTask = await Task.WhenAny(reviewTask, timeoutTask);
-                
+
                 if (completedTask == timeoutTask)
                 {
                     _reviewers.TryRemove(reviewerId, out _);
+                    reviewCts.Cancel();
+                    // The review call may still be mid-flight (e.g. blocked on a
+                    // provider response); disposing the agent here could tear down
+                    // state it is still touching, so defer disposal until the task
+                    // actually unwinds.
+                    _ = reviewTask.ContinueWith(_ =>
+                    {
+                        reviewerAgent.Dispose();
+                        reviewCts.Dispose();
+                    }, TaskScheduler.Default);
+
                     return new ReviewDecision
                     {
                         Status = ReviewStatus.Approved,
                         Feedback = "Review timed out - auto-approved"
                     };
                 }
-                
-                var reviewResult = await reviewTask;
-                var reviewText = reviewResult.Content.ToString().Trim();
-                
-                _reviewers.TryRemove(reviewerId, out _);
 
-                if (reviewText.StartsWith("APPROVED:", StringComparison.OrdinalIgnoreCase))
+                try
                 {
-                    return new ReviewDecision
+                    var reviewResult = await reviewTask;
+                    var reviewText = reviewResult.Content.ToString().Trim();
+
+                    _reviewers.TryRemove(reviewerId, out _);
+
+                    if (reviewText.StartsWith("APPROVED:", StringComparison.OrdinalIgnoreCase))
                     {
-                        Status = ReviewStatus.Approved,
-                        Feedback = reviewText.Substring(9).Trim()
-                    };
+                        return new ReviewDecision
+                        {
+                            Status = ReviewStatus.Approved,
+                            Feedback = reviewText.Substring(9).Trim()
+                        };
+                    }
+                    else if (reviewText.StartsWith("REVISION:", StringComparison.OrdinalIgnoreCase))
+                    {
+                        return new ReviewDecision
+                        {
+                            Status = ReviewStatus.RevisionRequested,
+                            Feedback = reviewText.Substring(9).Trim()
+                        };
+                    }
+                    else if (reviewText.StartsWith("REJECTED:", StringComparison.OrdinalIgnoreCase))
+                    {
+                        return new ReviewDecision
+                        {
+                            Status = ReviewStatus.Rejected,
+                            Feedback = reviewText.Substring(9).Trim()
+                        };
+                    }
+                    else
+                    {
+                        return new ReviewDecision
+                        {
+                            Status = ReviewStatus.Approved,
+                            Feedback = "Review response unclear - defaulting to approved"
+                        };
+                    }
                 }
-                else if (reviewText.StartsWith("REVISION:", StringComparison.OrdinalIgnoreCase))
+                finally
                 {
-                    return new ReviewDecision
-                    {
-                        Status = ReviewStatus.RevisionRequested,
-                        Feedback = reviewText.Substring(9).Trim()
-                    };
-                }
-                else if (reviewText.StartsWith("REJECTED:", StringComparison.OrdinalIgnoreCase))
-                {
-                    return new ReviewDecision
-                    {
-                        Status = ReviewStatus.Rejected,
-                        Feedback = reviewText.Substring(9).Trim()
-                    };
-                }
-                else
-                {
-                    return new ReviewDecision
-                    {
-                        Status = ReviewStatus.Approved,
-                        Feedback = "Review response unclear - defaulting to approved"
-                    };
+                    reviewerAgent.Dispose();
+                    reviewCts.Dispose();
                 }
             }
             finally
@@ -662,6 +682,17 @@ Your decision:";
                 }
                 catch (ObjectDisposedException)
                 {
+                }
+
+                if (context.Agent != null)
+                {
+                    try
+                    {
+                        context.Agent.Dispose();
+                    }
+                    catch
+                    {
+                    }
                 }
 
                 OnAgentStatusChanged?.Invoke(agentId, context.Name, "Terminated");

--- a/Agents/MultiAgent/Objects/SubAgentContext.cs
+++ b/Agents/MultiAgent/Objects/SubAgentContext.cs
@@ -18,5 +18,6 @@ namespace Saturn.Agents.MultiAgent.Objects
         public AgentTask? CurrentTask { get; set; }
         public int RevisionCount { get; set; } = 0;
         public CancellationTokenSource? Cancellation { get; set; }
+        public Task? ExecutionTask { get; set; }
     }
 }


### PR DESCRIPTION
Reviewer agents created in StartReviewProcess were never disposed, leaking their SQLite chat history repository and semaphores on every review cycle. When a review timed out, the in-flight LLM call was also left running unbounded in the background instead of being cancelled. TerminateAgent had the same gap, removing an agent's context without ever disposing the underlying agent.

This adds a cancellation token to the reviewer's execute call so a timeout actually cancels the request, defers disposal until that call unwinds, and disposes the agent on the normal completion path and in TerminateAgent.

Generated by The Saturn Pipeline

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation and cleanup when terminating running sub-agents.
  * Prevented resources from being disposed while handoff or review tasks are still in progress.
  * Added reliable timeout handling for reviewer operations.
  * Ensured reviewer results are finalized consistently, including unclear responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->