### PR TITLE
Do not restore sessions the user has closed

### DIFF
--- a/Data/ChatHistoryRepository.cs
+++ b/Data/ChatHistoryRepository.cs
@@ -500,15 +500,20 @@ public class ChatHistoryRepository : IDisposable
         });
     }
 
-    public async Task<List<ChatSession>> GetSessionsAsync(string? chatType = null, int limit = 100)
+    public async Task<List<ChatSession>> GetSessionsAsync(string? chatType = null, int limit = 100, bool activeOnly = false)
     {
         return await WithReadLockAsync(async () =>
         {
             using var connection = CreateConnection();
 
-            var sql = chatType != null
-                ? "SELECT * FROM ChatSessions WHERE ChatType = @ChatType ORDER BY UpdatedAt DESC LIMIT @Limit"
-                : "SELECT * FROM ChatSessions ORDER BY UpdatedAt DESC LIMIT @Limit";
+            var conditions = new List<string>();
+            if (chatType != null)
+                conditions.Add("ChatType = @ChatType");
+            if (activeOnly)
+                conditions.Add("IsActive = 1");
+
+            var whereClause = conditions.Count > 0 ? " WHERE " + string.Join(" AND ", conditions) : "";
+            var sql = $"SELECT * FROM ChatSessions{whereClause} ORDER BY UpdatedAt DESC LIMIT @Limit";
 
             using var cmd = new SqliteCommand(sql, connection);
             if (chatType != null)

--- a/Web/OrchestratorService.cs
+++ b/Web/OrchestratorService.cs
@@ -58,7 +58,7 @@ namespace Saturn.Web
         {
             try
             {
-                var sessions = await history.GetSessionsAsync("main", 1);
+                var sessions = await history.GetSessionsAsync("main", 1, activeOnly: true);
                 if (sessions.Count == 0)
                 {
                     return;


### PR DESCRIPTION
Closing a chat in the web UI marks the session inactive in the database, but a restart still picked the most recently updated main session regardless of that flag and resumed appending to it. GetSessionsAsync now accepts an activeOnly flag that filters to IsActive sessions, and the web restore path passes it so a restart no longer resurrects a closed chat.

Generated by The Saturn Pipeline