### PR TITLE
Keep the live stream when a send is rejected because the assistant is busy

### DIFF
--- a/Web/wwwroot/app.js
+++ b/Web/wwwroot/app.js
@@ -35,7 +35,9 @@ const api = {
         const data = await res.json();
         message = data.error || data.detail || message;
       } catch { /* not json */ }
-      throw new Error(message);
+      const err = new Error(message);
+      err.status = res.status;
+      throw err;
     }
     if (res.status === 204 || res.status === 202) return null;
     const text = await res.text();
@@ -774,9 +776,15 @@ $("#chat-form").addEventListener("submit", async (e) => {
   } catch (err) {
     state.transcript = state.transcript.filter((x) => x !== entry);
     renderTranscript();
-    setOrchestratorBusy(false);
     $("#chat-text").value = message;
-    toast(`<b>Error:</b> ${esc(err.message)}`);
+    if (err.status === 409) {
+      // A scheduler-initiated run is already in progress; the server's state
+      // events keep driving the busy UI, so don't tear down the live stream.
+      toast("The assistant is already busy with a run — try again shortly.");
+    } else {
+      setOrchestratorBusy(false);
+      toast(`<b>Error:</b> ${esc(err.message)}`);
+    }
   }
 });
 


### PR DESCRIPTION
When a scheduler-initiated run is already active, sending a message returns a 409 and the old catch block wiped the live stream panel and re-enabled Send, even though the server was still running the other job. The catch now only tears down the busy UI for non-409 failures, and shows a toast letting the user know the assistant is already busy.

Generated by The Saturn Pipeline