### PR TITLE
Reset the turn tool log when a new run starts

### DIFF
--- a/Web/wwwroot/app.js
+++ b/Web/wwwroot/app.js
@@ -1816,6 +1816,10 @@ function connectEvents() {
 
   es.addEventListener("orchestrator.state", (e) => {
     const d = JSON.parse(e.data);
+    if (d.busy && !state.orchestratorBusy) {
+      currentTurnTools = [];
+      renderToolLog();
+    }
     setOrchestratorBusy(d.busy);
   });
 


### PR DESCRIPTION
Fixes a bug where the tool call log for a run could carry stale entries into the next run when the previous run ended without an assistant message, such as a cancellation or error. The orchestrator.state SSE handler now clears the tool log whenever a run transitions into a busy state, so a scheduler-initiated run always starts clean.

Generated by The Saturn Pipeline