### PR TITLE
Return unfiltered output when the filter regex times out

### DIFF
--- a/Tools/GetCommandOutputTool.cs
+++ b/Tools/GetCommandOutputTool.cs
@@ -80,10 +80,18 @@ Notes:
 
             var (stdout, stderr) = bg.ReadNew();
 
+            var filterTimedOut = false;
             if (filterRegex != null)
             {
-                stdout = FilterLines(stdout, filterRegex);
-                stderr = FilterLines(stderr, filterRegex);
+                try
+                {
+                    stdout = FilterLines(stdout, filterRegex);
+                    stderr = FilterLines(stderr, filterRegex);
+                }
+                catch (RegexMatchTimeoutException)
+                {
+                    filterTimedOut = true;
+                }
             }
 
             var status = bg.Status.ToString().ToLowerInvariant();
@@ -94,6 +102,10 @@ Notes:
             if (bg.Status != BackgroundCommandStatus.Running && bg.ExitCode.HasValue)
             {
                 output.AppendLine($"Exit Code: {bg.ExitCode.Value}");
+            }
+            if (filterTimedOut)
+            {
+                output.AppendLine("Filter regex timed out; showing unfiltered output.");
             }
             output.AppendLine();
 

--- a/Tools/GetCommandOutputTool.cs
+++ b/Tools/GetCommandOutputTool.cs
@@ -83,6 +83,8 @@ Notes:
             var filterTimedOut = false;
             if (filterRegex != null)
             {
+                var unfilteredStdout = stdout;
+                var unfilteredStderr = stderr;
                 try
                 {
                     stdout = FilterLines(stdout, filterRegex);
@@ -90,6 +92,11 @@ Notes:
                 }
                 catch (RegexMatchTimeoutException)
                 {
+                    // A timeout partway through (e.g. stdout filtered fine, stderr
+                    // timed out) must not leave one stream filtered and the other
+                    // not — revert both so the message below is accurate.
+                    stdout = unfilteredStdout;
+                    stderr = unfilteredStderr;
                     filterTimedOut = true;
                 }
             }


### PR DESCRIPTION
When a filter regex times out during output filtering, the tool now preserves the unfiltered output instead of losing it. A notification line is prepended to indicate that filtering timed out.

This prevents data loss when complex regex patterns exceed the 2-second match timeout on large output buffers.

Generated by The Saturn Pipeline