### PR TITLE
Match command output filters against lines without trailing carriage returns

### DIFF
--- a/Tools/GetCommandOutputTool.cs
+++ b/Tools/GetCommandOutputTool.cs
@@ -133,7 +133,7 @@ Notes:
 
             var matched = text
                 .Split('\n')
-                .Where(line => regex.IsMatch(line));
+                .Where(line => regex.IsMatch(line.TrimEnd('\r')));
 
             return string.Join("\n", matched);
         }


### PR DESCRIPTION
FilterLines was matching regex patterns directly against lines from the split output, which retain trailing carriage returns on Windows. This prevented filters using $ anchors from matching properly. The fix trims the trailing CR before regex matching while preserving the original line content in the output.

Generated by The Saturn Pipeline