### PR TITLE
Escape quotes in the HTML escape helper

### DIFF
--- a/Web/wwwroot/app.js
+++ b/Web/wwwroot/app.js
@@ -49,9 +49,12 @@ const api = {
 };
 
 function esc(value) {
-  const div = document.createElement("div");
-  div.textContent = value ?? "";
-  return div.innerHTML;
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
 }
 
 function fmtDuration(totalSeconds) {


### PR DESCRIPTION
The esc() helper was only escaping &, <, and > via div.textContent/div.innerHTML, leaving double and single quotes unescaped. This allows attribute injection in HTML attributes like value="..." and data-*="..." when esc() is used, resulting in truncated edit fields and silent data loss. The fix implements proper HTML entity escaping for all dangerous characters including quotes.

Generated by The Saturn Pipeline