### PR TITLE
Return a validation error when saving user rules fails

### DIFF
--- a/Web/WebServer.cs
+++ b/Web/WebServer.cs
@@ -917,12 +917,15 @@ namespace Saturn.Web
 
             api.MapPut("/user-rules", async (UserRulesUpdateRequest request) =>
             {
-                var saved = await Saturn.Core.UserRulesManager.SaveRulesAsync(request.Content ?? "");
-                if (!saved)
+                try
                 {
-                    return Results.Problem("Failed to save rules file");
+                    await Saturn.Core.UserRulesManager.SaveRulesAsync(request.Content ?? "");
+                    return Results.Ok(new { saved = true });
                 }
-                return Results.Ok(new { saved = true });
+                catch (InvalidOperationException ex)
+                {
+                    return Results.BadRequest(new { error = ex.Message });
+                }
             });
 
             // ---------- modes ----------


### PR DESCRIPTION
The PUT /user-rules endpoint now catches InvalidOperationException from SaveRulesAsync and returns a BadRequest response with the validation error message. This fixes the issue where oversized content (>50k characters) would surface as an unhandled 500 error instead of a proper validation response.

Generated by The Saturn Pipeline