### PR TITLE
Fix duplicated newline check in non-streaming rendering

### DIFF
--- a/UI/ChatInterface.cs
+++ b/UI/ChatInterface.cs
@@ -719,11 +719,11 @@ namespace Saturn.UI
                             Application.MainLoop.Invoke(() =>
                             {
                                 var currentText = chatView.Text;
-                                
+
                                 chatView.Text += renderedResponse;
-                                
+
                                 var updatedText = chatView.Text;
-                                bool endsWithNewline = updatedText.EndsWith("\n\n");
+                                bool endsWithNewline = updatedText.EndsWith("\n");
                                 bool endsWithDoubleNewline = updatedText.EndsWith("\n\n");
                                 
                                 var trimmedResponse = renderedResponse.TrimEnd();


### PR DESCRIPTION
The non-streaming response rendering block had a copy-paste error where the first boolean check was testing for double newline instead of a single newline. This caused responses to get extra blank lines or stray trailing spaces before the next prompt. The fix changes the first EndsWith check to match the correct streaming-path implementation.

Generated by The Saturn Pipeline