### PR TITLE
Open the browser only after the web server is listening

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -45,8 +45,7 @@ namespace Saturn
                     var server = new Saturn.Web.WebServer(agent, client, port);
                     Console.WriteLine($"Saturn web UI running at {server.Url}");
                     Console.WriteLine("Press Ctrl+C to stop.");
-                    TryOpenBrowser(server.Url);
-                    await server.RunAsync();
+                    await server.RunAsync(onReady: () => TryOpenBrowser(server.Url));
                     return;
                 }
 

--- a/Web/WebServer.cs
+++ b/Web/WebServer.cs
@@ -70,7 +70,7 @@ namespace Saturn.Web
 
         public string Url => $"http://localhost:{_port}";
 
-        public async Task RunAsync(CancellationToken cancellationToken = default)
+        public async Task RunAsync(CancellationToken cancellationToken = default, Action? onReady = null)
         {
             CommandApprovalService.GlobalOverride = _approvalCoordinator;
             TaskSystem.Store = _tasks;
@@ -142,6 +142,11 @@ namespace Saturn.Web
 
             MapStaticAssets(app);
             MapApi(app);
+
+            if (onReady != null)
+            {
+                app.Lifetime.ApplicationStarted.Register(onReady);
+            }
 
             await app.RunAsync(cancellationToken);
         }


### PR DESCRIPTION
The web UI opened a browser tab before Kestrel finished binding, so a slow startup showed a connection-refused page. RunAsync now accepts an onReady callback fired from the host's ApplicationStarted event, and Program.cs uses it to open the browser only once the server is actually listening.

Generated by The Saturn Pipeline