### PR TITLE
Guard task updates with optimistic concurrency

### DIFF
--- a/Core/Tasks/TaskCoordinator.cs
+++ b/Core/Tasks/TaskCoordinator.cs
@@ -577,18 +577,30 @@ namespace Saturn.Core.Tasks
         public async Task ResolveClaimAsync(string taskId, bool approved)
         {
             var applied = false;
-            var task = await UpdateTaskWithRetryAsync(taskId, t =>
+            SaturnTask? task;
+            try
             {
-                if (t.ClaimStatus != ClaimStatuses.PendingApproval)
+                task = await UpdateTaskWithRetryAsync(taskId, t =>
                 {
-                    applied = false;
-                    return false;
-                }
-                t.ClaimStatus = approved ? ClaimStatuses.Approved : ClaimStatuses.Denied;
-                t.ClaimedBy = approved ? "orchestrator" : null;
-                applied = true;
-                return true;
-            });
+                    if (t.ClaimStatus != ClaimStatuses.PendingApproval)
+                    {
+                        applied = false;
+                        return false;
+                    }
+                    t.ClaimStatus = approved ? ClaimStatuses.Approved : ClaimStatuses.Denied;
+                    t.ClaimedBy = approved ? "orchestrator" : null;
+                    applied = true;
+                    return true;
+                });
+            }
+            catch (InvalidOperationException ex)
+            {
+                // Called fire-and-forget from the web approval callback, so a
+                // conflict that outlasts the retry budget has nowhere else to
+                // surface; log it instead of losing it as an unobserved fault.
+                Console.Error.WriteLine($"Resolve claim for task {taskId} failed: {ex.Message}");
+                return;
+            }
             if (task == null || !applied)
             {
                 return;

--- a/Core/Tasks/TaskCoordinator.cs
+++ b/Core/Tasks/TaskCoordinator.cs
@@ -343,6 +343,31 @@ namespace Saturn.Core.Tasks
             return (false, null, false);
         }
 
+        // Reload-mutate-write loop over the optimistic concurrency guard in
+        // UpdateTaskAsync. mutate returns false to skip the write when its
+        // precondition no longer holds on the freshly loaded row; the freshest
+        // row is returned either way, or null when the task no longer exists.
+        private async Task<SaturnTask?> UpdateTaskWithRetryAsync(string taskId, Func<SaturnTask, bool> mutate)
+        {
+            for (var attempt = 0; attempt < 3; attempt++)
+            {
+                var task = await _store.FindAsync(taskId);
+                if (task == null)
+                {
+                    return null;
+                }
+                if (!mutate(task))
+                {
+                    return task;
+                }
+                if (await _store.RepoOf(task).UpdateTaskAsync(task))
+                {
+                    return task;
+                }
+            }
+            throw new InvalidOperationException("concurrent update, try again");
+        }
+
         // ---------- Dispatch lifecycle ----------
 
         public async Task<(bool ok, string message, string? dispatchId)> DispatchTaskAsync(string taskId, string agentId, string agentName, bool userInitiated = false)
@@ -411,9 +436,12 @@ namespace Saturn.Core.Tasks
                 mgrTaskId = await AgentManager.Instance.HandOffTask(agentId, taskPrompt, onBeforeStart: async id =>
                 {
                     await _store.Project.SetDispatchManagerTaskIdAsync(dispatch.Id, id);
-                    task.Status = TaskStatuses.InProgress;
-                    task.ClaimedBy = agentName;
-                    await _store.RepoOf(task).UpdateTaskAsync(task);
+                    await UpdateTaskWithRetryAsync(task.Id, t =>
+                    {
+                        t.Status = TaskStatuses.InProgress;
+                        t.ClaimedBy = agentName;
+                        return true;
+                    });
                 });
             }
             catch (InvalidOperationException ex)
@@ -513,8 +541,15 @@ namespace Saturn.Core.Tasks
 
             if (task.RequiresApproval)
             {
-                task.ClaimStatus = ClaimStatuses.PendingApproval;
-                await _store.RepoOf(task).UpdateTaskAsync(task);
+                task = await UpdateTaskWithRetryAsync(task.Id, t =>
+                {
+                    t.ClaimStatus = ClaimStatuses.PendingApproval;
+                    return true;
+                });
+                if (task == null)
+                {
+                    return ("error", $"Task {taskId} not found");
+                }
                 _hub.Publish("tasks.changed", new { taskId = task.Id, scope = task.Scope, board = task.Board, change = "claim_pending" });
                 if (OnClaimApprovalNeeded != null)
                 {
@@ -525,24 +560,39 @@ namespace Saturn.Core.Tasks
                     "you will receive a scheduler message when it is approved or denied. Do not start work on it yet.");
             }
 
-            task.ClaimStatus = ClaimStatuses.Approved;
-            task.ClaimedBy = "orchestrator";
-            await _store.RepoOf(task).UpdateTaskAsync(task);
+            task = await UpdateTaskWithRetryAsync(task.Id, t =>
+            {
+                t.ClaimStatus = ClaimStatuses.Approved;
+                t.ClaimedBy = "orchestrator";
+                return true;
+            });
+            if (task == null)
+            {
+                return ("error", $"Task {taskId} not found");
+            }
             _hub.Publish("tasks.changed", new { taskId = task.Id, scope = task.Scope, board = task.Board, change = "claimed" });
             return ("claimed", $"Task {taskId} claimed. Work on it yourself or dispatch_task it to a sub-agent.");
         }
 
         public async Task ResolveClaimAsync(string taskId, bool approved)
         {
-            var task = await _store.FindAsync(taskId);
-            if (task == null || task.ClaimStatus != ClaimStatuses.PendingApproval)
+            var applied = false;
+            var task = await UpdateTaskWithRetryAsync(taskId, t =>
+            {
+                if (t.ClaimStatus != ClaimStatuses.PendingApproval)
+                {
+                    applied = false;
+                    return false;
+                }
+                t.ClaimStatus = approved ? ClaimStatuses.Approved : ClaimStatuses.Denied;
+                t.ClaimedBy = approved ? "orchestrator" : null;
+                applied = true;
+                return true;
+            });
+            if (task == null || !applied)
             {
                 return;
             }
-
-            task.ClaimStatus = approved ? ClaimStatuses.Approved : ClaimStatuses.Denied;
-            task.ClaimedBy = approved ? "orchestrator" : null;
-            await _store.RepoOf(task).UpdateTaskAsync(task);
             _hub.Publish("tasks.changed", new { taskId = task.Id, scope = task.Scope, board = task.Board, change = approved ? "claim_approved" : "claim_denied" });
 
             await EnqueueWakeAsync(
@@ -568,11 +618,25 @@ namespace Saturn.Core.Tasks
                 }
 
                 await _store.Project.MarkDispatchOrphanedAsync(dispatch.Id);
-                var task = await _store.FindAsync(dispatch.TaskId);
-                if (task != null && task.Status == TaskStatuses.InProgress)
+                SaturnTask? task = null;
+                try
                 {
-                    task.Status = TaskStatuses.Pending;
-                    await _store.RepoOf(task).UpdateTaskAsync(task);
+                    task = await UpdateTaskWithRetryAsync(dispatch.TaskId, t =>
+                    {
+                        if (t.Status != TaskStatuses.InProgress)
+                        {
+                            return false;
+                        }
+                        t.Status = TaskStatuses.Pending;
+                        return true;
+                    });
+                }
+                catch (InvalidOperationException ex)
+                {
+                    // Keep recovering the remaining dispatches; the wake below still
+                    // tells the orchestrator this dispatch was interrupted.
+                    Console.Error.WriteLine($"Recovery update for task {dispatch.TaskId} failed: {ex.Message}");
+                    task = await _store.FindAsync(dispatch.TaskId);
                 }
 
                 await EnqueueWakeAsync(

--- a/Data/Tasks/TaskRepository.cs
+++ b/Data/Tasks/TaskRepository.cs
@@ -169,9 +169,23 @@ namespace Saturn.Data.Tasks
             }, ct);
         }
 
+        // Optimistic concurrency: the write only lands if the row still carries the
+        // UpdatedAt the caller loaded. Returns false when a concurrent writer got
+        // there first (or the row is gone); callers reload, reapply and retry.
         public Task<bool> UpdateTaskAsync(SaturnTask t, CancellationToken ct = default)
         {
-            t.UpdatedAt = DateTime.UtcNow;
+            // UpdatedAt is stored via ToString("O") and read back with
+            // RoundtripKind, so the "O" string of the loaded value matches the
+            // stored text exactly; compare on that form rather than on ticks.
+            var expectedUpdatedAt = t.UpdatedAt.ToString("O");
+            var now = DateTime.UtcNow;
+            if (now <= t.UpdatedAt)
+            {
+                // Clock granularity can make back-to-back updates share a timestamp,
+                // which would let a stale writer still match; always move forward.
+                now = t.UpdatedAt.AddTicks(1);
+            }
+            t.UpdatedAt = now;
             return WithWriteLockAsync(async () =>
             {
                 using var connection = CreateConnection();
@@ -183,9 +197,10 @@ namespace Saturn.Data.Tasks
                         RecurrenceIntervalSeconds=@RecurrenceIntervalSeconds, RecurrenceCron=@RecurrenceCron,
                         CatchUpPolicy=@CatchUpPolicy, NextRunAt=@NextRunAt, LastRunAt=@LastRunAt,
                         UpdatedAt=@UpdatedAt, CompletedAt=@CompletedAt
-                    WHERE Id=@Id", connection);
+                    WHERE Id=@Id AND UpdatedAt=@ExpectedUpdatedAt", connection);
                 BindTask(cmd, t);
                 cmd.Parameters.AddWithValue("@SortOrder", t.SortOrder);
+                cmd.Parameters.AddWithValue("@ExpectedUpdatedAt", expectedUpdatedAt);
                 return await cmd.ExecuteNonQueryAsync(ct) > 0;
             }, ct);
         }

--- a/Data/Tasks/TaskRepository.cs
+++ b/Data/Tasks/TaskRepository.cs
@@ -217,15 +217,26 @@ namespace Saturn.Data.Tasks
             }, ct);
         }
 
-        public Task<bool> DeleteTaskAsync(string id, CancellationToken ct = default)
+        // expectedUpdatedAt, when given, guards the delete with the same
+        // optimistic-concurrency token as UpdateTaskAsync so a scope-move's
+        // delete+insert can't discard a write that landed after it loaded the row.
+        public Task<bool> DeleteTaskAsync(string id, DateTime? expectedUpdatedAt = null, CancellationToken ct = default)
         {
             return WithWriteLockAsync(async () =>
             {
                 using var connection = CreateConnection();
-                using var cmd = new SqliteCommand(
-                    "DELETE FROM Tasks WHERE Id = @Id; DELETE FROM TaskDependencies WHERE TaskId = @Id OR BlockedByTaskId = @Id;",
-                    connection);
+                var sql = "DELETE FROM Tasks WHERE Id = @Id";
+                if (expectedUpdatedAt.HasValue)
+                {
+                    sql += " AND UpdatedAt = @ExpectedUpdatedAt";
+                }
+                sql += "; DELETE FROM TaskDependencies WHERE TaskId = @Id OR BlockedByTaskId = @Id;";
+                using var cmd = new SqliteCommand(sql, connection);
                 cmd.Parameters.AddWithValue("@Id", id);
+                if (expectedUpdatedAt.HasValue)
+                {
+                    cmd.Parameters.AddWithValue("@ExpectedUpdatedAt", expectedUpdatedAt.Value.ToString("O"));
+                }
                 return await cmd.ExecuteNonQueryAsync(ct) > 0;
             }, ct);
         }

--- a/Data/Tasks/TaskStore.cs
+++ b/Data/Tasks/TaskStore.cs
@@ -194,7 +194,13 @@ namespace Saturn.Data.Tasks
                         dependentEdges[dependentId] = await sourceRepo.GetDependenciesAsync(dependentId);
                     }
 
-                    await sourceRepo.DeleteTaskAsync(task.Id);
+                    // Guard the delete with the row's loaded UpdatedAt so a writer
+                    // that committed since we read it isn't silently discarded by
+                    // the move; reload and reapply the whole spec on conflict.
+                    if (!await sourceRepo.DeleteTaskAsync(task.Id, task.UpdatedAt))
+                    {
+                        continue;
+                    }
                     task.Scope = spec.Scope;
                     await RepoOf(task).InsertTaskAsync(task);
                     await RepoOf(task).SetDependenciesAsync(task.Id, deps);

--- a/Data/Tasks/TaskStore.cs
+++ b/Data/Tasks/TaskStore.cs
@@ -128,89 +128,98 @@ namespace Saturn.Data.Tasks
 
         public async Task<SaturnTask?> UpdateAsync(string id, TaskUpdateSpec spec)
         {
-            var task = await FindAsync(id);
-            if (task == null)
+            // Read-modify-write under optimistic concurrency: when the guarded
+            // update loses a race, reload the row and reapply the spec so the
+            // concurrent writer's committed columns survive.
+            for (var attempt = 0; attempt < 3; attempt++)
             {
-                return null;
-            }
-
-            var originalScope = task.Scope;
-
-            if (spec.Title != null && !string.IsNullOrWhiteSpace(spec.Title)) task.Title = spec.Title.Trim();
-            if (spec.Notes != null) task.Notes = string.IsNullOrWhiteSpace(spec.Notes) ? null : spec.Notes.Trim();
-            if (spec.Priority != null) task.Priority = spec.Priority;
-            if (spec.Board != null && !string.IsNullOrWhiteSpace(spec.Board)) task.Board = spec.Board.Trim();
-            if (spec.SortOrder.HasValue) task.SortOrder = spec.SortOrder.Value;
-            if (spec.AgentAvailable.HasValue) task.AgentAvailable = spec.AgentAvailable.Value;
-            if (spec.RequiresApproval.HasValue) task.RequiresApproval = spec.RequiresApproval.Value;
-            if (spec.UserHandoffOnly.HasValue) task.UserHandoffOnly = spec.UserHandoffOnly.Value;
-
-            if (spec.Status != null && TaskStatuses.All.Contains(spec.Status))
-            {
-                task.Status = spec.Status;
-                task.CompletedAt = TaskStatuses.IsTerminal(spec.Status) ? DateTime.UtcNow : null;
-            }
-
-            if (spec.RecurrenceKind != null)
-            {
-                var kind = spec.RecurrenceKind;
-                var interval = spec.RecurrenceIntervalSeconds ?? task.RecurrenceIntervalSeconds;
-                var cron = spec.RecurrenceCron ?? task.RecurrenceCron;
-                var error = RecurrenceCalculator.Validate(kind, interval, cron);
-                if (error != null)
+                var task = await FindAsync(id);
+                if (task == null)
                 {
-                    throw new ArgumentException(error);
-                }
-                task.RecurrenceKind = kind;
-                task.RecurrenceIntervalSeconds = kind == RecurrenceKinds.Interval ? interval : null;
-                task.RecurrenceCron = kind == RecurrenceKinds.Cron ? cron : null;
-                task.NextRunAt = task.IsRecurring
-                    ? RecurrenceCalculator.GetNextOccurrenceUtc(task.RecurrenceKind, task.RecurrenceIntervalSeconds, task.RecurrenceCron, DateTime.UtcNow)
-                    : null;
-            }
-            if (spec.CatchUpPolicy != null) task.CatchUpPolicy = spec.CatchUpPolicy;
-
-            if (spec.BlockedBy != null)
-            {
-                await ValidateDependenciesAsync(task.Id, spec.BlockedBy);
-            }
-
-            // Scope moves migrate the row between databases.
-            if (spec.Scope != null && TaskScopes.All.Contains(spec.Scope) && spec.Scope != originalScope)
-            {
-                var sourceRepo = RepoFor(originalScope);
-                var deps = await sourceRepo.GetDependenciesAsync(task.Id);
-
-                // DeleteTaskAsync also wipes edges where this task is the blocker;
-                // snapshot the dependents' edge lists so they can be restored.
-                var dependentEdges = new Dictionary<string, List<string>>();
-                foreach (var dependentId in await sourceRepo.GetDependentsAsync(task.Id))
-                {
-                    dependentEdges[dependentId] = await sourceRepo.GetDependenciesAsync(dependentId);
+                    return null;
                 }
 
-                await sourceRepo.DeleteTaskAsync(task.Id);
-                task.Scope = spec.Scope;
-                await RepoOf(task).InsertTaskAsync(task);
-                await RepoOf(task).SetDependenciesAsync(task.Id, deps);
+                var originalScope = task.Scope;
 
-                foreach (var (dependentId, edges) in dependentEdges)
+                if (spec.Title != null && !string.IsNullOrWhiteSpace(spec.Title)) task.Title = spec.Title.Trim();
+                if (spec.Notes != null) task.Notes = string.IsNullOrWhiteSpace(spec.Notes) ? null : spec.Notes.Trim();
+                if (spec.Priority != null) task.Priority = spec.Priority;
+                if (spec.Board != null && !string.IsNullOrWhiteSpace(spec.Board)) task.Board = spec.Board.Trim();
+                if (spec.SortOrder.HasValue) task.SortOrder = spec.SortOrder.Value;
+                if (spec.AgentAvailable.HasValue) task.AgentAvailable = spec.AgentAvailable.Value;
+                if (spec.RequiresApproval.HasValue) task.RequiresApproval = spec.RequiresApproval.Value;
+                if (spec.UserHandoffOnly.HasValue) task.UserHandoffOnly = spec.UserHandoffOnly.Value;
+
+                if (spec.Status != null && TaskStatuses.All.Contains(spec.Status))
                 {
-                    await sourceRepo.SetDependenciesAsync(dependentId, edges);
+                    task.Status = spec.Status;
+                    task.CompletedAt = TaskStatuses.IsTerminal(spec.Status) ? DateTime.UtcNow : null;
                 }
-            }
-            else
-            {
-                await RepoOf(task).UpdateTaskAsync(task);
+
+                if (spec.RecurrenceKind != null)
+                {
+                    var kind = spec.RecurrenceKind;
+                    var interval = spec.RecurrenceIntervalSeconds ?? task.RecurrenceIntervalSeconds;
+                    var cron = spec.RecurrenceCron ?? task.RecurrenceCron;
+                    var error = RecurrenceCalculator.Validate(kind, interval, cron);
+                    if (error != null)
+                    {
+                        throw new ArgumentException(error);
+                    }
+                    task.RecurrenceKind = kind;
+                    task.RecurrenceIntervalSeconds = kind == RecurrenceKinds.Interval ? interval : null;
+                    task.RecurrenceCron = kind == RecurrenceKinds.Cron ? cron : null;
+                    task.NextRunAt = task.IsRecurring
+                        ? RecurrenceCalculator.GetNextOccurrenceUtc(task.RecurrenceKind, task.RecurrenceIntervalSeconds, task.RecurrenceCron, DateTime.UtcNow)
+                        : null;
+                }
+                if (spec.CatchUpPolicy != null) task.CatchUpPolicy = spec.CatchUpPolicy;
+
+                if (spec.BlockedBy != null)
+                {
+                    await ValidateDependenciesAsync(task.Id, spec.BlockedBy);
+                }
+
+                // Scope moves migrate the row between databases.
+                if (spec.Scope != null && TaskScopes.All.Contains(spec.Scope) && spec.Scope != originalScope)
+                {
+                    var sourceRepo = RepoFor(originalScope);
+                    var deps = await sourceRepo.GetDependenciesAsync(task.Id);
+
+                    // DeleteTaskAsync also wipes edges where this task is the blocker;
+                    // snapshot the dependents' edge lists so they can be restored.
+                    var dependentEdges = new Dictionary<string, List<string>>();
+                    foreach (var dependentId in await sourceRepo.GetDependentsAsync(task.Id))
+                    {
+                        dependentEdges[dependentId] = await sourceRepo.GetDependenciesAsync(dependentId);
+                    }
+
+                    await sourceRepo.DeleteTaskAsync(task.Id);
+                    task.Scope = spec.Scope;
+                    await RepoOf(task).InsertTaskAsync(task);
+                    await RepoOf(task).SetDependenciesAsync(task.Id, deps);
+
+                    foreach (var (dependentId, edges) in dependentEdges)
+                    {
+                        await sourceRepo.SetDependenciesAsync(dependentId, edges);
+                    }
+                }
+                else if (!await RepoOf(task).UpdateTaskAsync(task))
+                {
+                    // Lost the race (or the task was deleted): reload and reapply.
+                    continue;
+                }
+
+                if (spec.BlockedBy != null)
+                {
+                    await RepoOf(task).SetDependenciesAsync(task.Id, spec.BlockedBy.Distinct().ToList());
+                }
+
+                OnTaskChanged?.Invoke("updated", task);
+                return task;
             }
 
-            if (spec.BlockedBy != null)
-            {
-                await RepoOf(task).SetDependenciesAsync(task.Id, spec.BlockedBy.Distinct().ToList());
-            }
-
-            OnTaskChanged?.Invoke("updated", task);
-            return task;
+            throw new InvalidOperationException("concurrent update, try again");
         }
 
         public async Task<bool> DeleteAsync(string id)
@@ -313,30 +322,42 @@ namespace Saturn.Data.Tasks
 
         public async Task<SaturnTask?> CompleteAsync(string id, bool success = true, string? note = null)
         {
-            var task = await FindAsync(id);
-            if (task == null)
+            // Reload-and-reapply on conflict: for a recurring task the reloaded row
+            // carries a NextRunAt the recurrence sweep may have advanced while we
+            // were writing, so this loop never stomps a concurrently claimed
+            // occurrence back to its pre-claim schedule.
+            for (var attempt = 0; attempt < 3; attempt++)
             {
-                return null;
+                var task = await FindAsync(id);
+                if (task == null)
+                {
+                    return null;
+                }
+
+                if (task.IsRecurring)
+                {
+                    await RepoOf(task).SetLatestRunOutcomeAsync(task.Id,
+                        note ?? (success ? TaskStatuses.Done : TaskStatuses.Failed));
+                    task.Status = TaskStatuses.Pending;
+                    task.ClaimStatus = ClaimStatuses.None;
+                    task.ClaimedBy = null;
+                    task.CompletedAt = null;
+                }
+                else
+                {
+                    task.Status = success ? TaskStatuses.Done : TaskStatuses.Failed;
+                    task.CompletedAt = DateTime.UtcNow;
+                }
+
+                if (!await RepoOf(task).UpdateTaskAsync(task))
+                {
+                    continue;
+                }
+                OnTaskChanged?.Invoke("completed", task);
+                return task;
             }
 
-            if (task.IsRecurring)
-            {
-                await RepoOf(task).SetLatestRunOutcomeAsync(task.Id,
-                    note ?? (success ? TaskStatuses.Done : TaskStatuses.Failed));
-                task.Status = TaskStatuses.Pending;
-                task.ClaimStatus = ClaimStatuses.None;
-                task.ClaimedBy = null;
-                task.CompletedAt = null;
-            }
-            else
-            {
-                task.Status = success ? TaskStatuses.Done : TaskStatuses.Failed;
-                task.CompletedAt = DateTime.UtcNow;
-            }
-
-            await RepoOf(task).UpdateTaskAsync(task);
-            OnTaskChanged?.Invoke("completed", task);
-            return task;
+            throw new InvalidOperationException("concurrent update, try again");
         }
 
         public async Task<List<SaturnTask>> GetNewlyUnblockedAsync(string completedId)

--- a/Saturn.Tests/Tasks/TaskStoreTests.cs
+++ b/Saturn.Tests/Tasks/TaskStoreTests.cs
@@ -215,6 +215,40 @@ namespace Saturn.Tests.Tasks
         }
 
         [Fact]
+        public async Task UpdateTaskAsync_RejectsStaleWrites()
+        {
+            var task = await CreateTaskAsync("contended");
+
+            var copyA = await _store.Project.GetTaskAsync(task.Id);
+            var copyB = await _store.Project.GetTaskAsync(task.Id);
+
+            copyA!.Notes = "first writer";
+            (await _store.Project.UpdateTaskAsync(copyA)).Should().BeTrue();
+
+            // copyB still carries the pre-update UpdatedAt, so its write must lose.
+            copyB!.Status = TaskStatuses.InProgress;
+            (await _store.Project.UpdateTaskAsync(copyB)).Should().BeFalse();
+
+            var current = await _store.Project.GetTaskAsync(task.Id);
+            current!.Notes.Should().Be("first writer");
+            current.Status.Should().Be(TaskStatuses.Pending);
+        }
+
+        [Fact]
+        public async Task UpdateAsync_ReappliesOnConflict_InsteadOfClobbering()
+        {
+            var task = await CreateTaskAsync("racy");
+
+            // A stale in-memory copy commits between our load and write paths;
+            // the store-level update must still land without reverting it.
+            await _store.CompleteAsync(task.Id);
+            var updated = await _store.UpdateAsync(task.Id, new TaskUpdateSpec { Notes = "late edit" });
+
+            updated!.Notes.Should().Be("late edit");
+            updated.Status.Should().Be(TaskStatuses.Done);
+        }
+
+        [Fact]
         public async Task TryEnqueueWakeAsync_DeduplicatesByKey()
         {
             var first = await _store.Project.TryEnqueueWakeAsync(new WakeItem { Kind = "test", Prompt = "p", DedupeKey = "dup:1" });

--- a/Web/WebServer.cs
+++ b/Web/WebServer.cs
@@ -632,14 +632,25 @@ namespace Saturn.Web
                 {
                     return Results.BadRequest(new { error = ex.Message });
                 }
+                catch (InvalidOperationException ex)
+                {
+                    return Results.Conflict(new { error = ex.Message });
+                }
             });
 
             api.MapPost("/todos/{id}/complete", async (string id, TaskCompleteRequest request) =>
             {
-                var task = await _tasks.CompleteAsync(id, request.Success ?? true, request.Note);
-                return task == null
-                    ? Results.NotFound(new { error = $"Task {id} not found" })
-                    : Results.Ok(ProjectTaskView(await _tasks.BuildViewAsync(task)));
+                try
+                {
+                    var task = await _tasks.CompleteAsync(id, request.Success ?? true, request.Note);
+                    return task == null
+                        ? Results.NotFound(new { error = $"Task {id} not found" })
+                        : Results.Ok(ProjectTaskView(await _tasks.BuildViewAsync(task)));
+                }
+                catch (InvalidOperationException ex)
+                {
+                    return Results.Conflict(new { error = ex.Message });
+                }
             });
 
             api.MapPost("/todos/{id}/dispatch", async (string id, TaskDispatchRequest request) =>


### PR DESCRIPTION
TaskRepository.UpdateTaskAsync wrote every column with a bare WHERE Id, so concurrent read-modify-write callers silently clobbered each other's committed columns. A web UI notes edit racing an agent completion could revert a done task back to in_progress, and a stale write could restore a pre-claim NextRunAt and make the recurrence sweep fire the same occurrence twice. The update now only lands when the row still carries the UpdatedAt the caller loaded, and returns false otherwise. TaskStore.UpdateAsync, CompleteAsync and the TaskCoordinator call sites reload the task, reapply their mutation and retry up to three times, so a reloaded recurring task keeps a concurrently advanced NextRunAt. Web endpoints surface an exhausted retry as 409, and new tests cover the stale write rejection and the reapply path.

Generated by The Saturn Pipeline

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task updates and state transitions when multiple operations occur simultaneously.
  * Prevented newer task changes from being overwritten by stale updates.
  * Added automatic retries for conflicting task edits and completions.
  * Improved recovery of interrupted or orphaned tasks.

* **API**
  * Task update conflicts now return a clear HTTP 409 Conflict response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->