### PR TITLE
Read property attributes when extracting page metadata

### DIFF
--- a/Tools/WebFetchTool.cs
+++ b/Tools/WebFetchTool.cs
@@ -534,7 +534,11 @@ Limits:
             var metaTags = doc.DocumentNode.SelectNodes("//meta[@name or @property]") ?? Enumerable.Empty<HtmlNode>();
             foreach (var meta in metaTags)
             {
-                var name = meta.GetAttributeValue("name", "") ?? meta.GetAttributeValue("property", "");
+                var name = meta.GetAttributeValue("name", "");
+                if (string.IsNullOrEmpty(name))
+                {
+                    name = meta.GetAttributeValue("property", "");
+                }
                 var content = meta.GetAttributeValue("content", "");
                 
                 if (!string.IsNullOrEmpty(name) && !string.IsNullOrEmpty(content))


### PR DESCRIPTION
The WebFetchTool was not extracting OpenGraph and Twitter metadata because the null coalescing operator on a string that never returns null was dead code. This fix properly checks if the name attribute is empty before falling back to the property attribute.

Generated by The Saturn Pipeline