### PR TITLE
Invalidate the model cache when switching providers

### DIFF
--- a/Providers/Core/LlmClientManager.cs
+++ b/Providers/Core/LlmClientManager.cs
@@ -115,6 +115,8 @@ namespace Saturn.Providers
                 RetireClient(retired);
             }
 
+            ModelCatalog.Invalidate();
+
             ProviderChanged?.Invoke(this, new ProviderChangedEventArgs(previousName, provider.Name, candidate));
             return SwapResult.Ok(candidate);
         }

--- a/UI/ChatInterface.cs
+++ b/UI/ChatInterface.cs
@@ -941,8 +941,6 @@ namespace Saturn.UI
 
             if (!dialog.Applied) return;
 
-            ModelCatalog.Invalidate();
-
             var providerName = manager.ActiveProviderName;
             var capabilities = manager.Current.Capabilities;
 


### PR DESCRIPTION
The model catalog cache was only cleared on the TUI provider-switch path, so switching providers through the web UI could keep serving a stale model list within the cache TTL. This moves the invalidation into the shared LlmClientManager swap logic so it fires for both the TUI and the web UI whenever a swap succeeds.

Generated by The Saturn Pipeline