### PR TITLE
Handle trailing slashes in list_files paths

### DIFF
--- a/Tools/ListFilesTool.cs
+++ b/Tools/ListFilesTool.cs
@@ -156,6 +156,11 @@ Examples
                 
                 ValidatePathSecurity(path);
                 var fullPath = Path.GetFullPath(path);
+                var root = Path.GetPathRoot(fullPath) ?? string.Empty;
+                if (fullPath.Length > root.Length)
+                {
+                    fullPath = fullPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+                }
                 
                 if (!Directory.Exists(fullPath))
                 {


### PR DESCRIPTION
Normalize the base path by stripping trailing separators after calling Path.GetFullPath. This fixes the tree rendering bug where paths with trailing slashes would cause nodeMap lookups to fail during BuildTreeStructure.

The fix preserves root paths like C:\ to avoid breaking path validation.

Generated by The Saturn Pipeline