### PR TITLE
Add spawn_agent one-call delegation tool

### DIFF
--- a/Agents/MultiAgent/AgentManager.cs
+++ b/Agents/MultiAgent/AgentManager.cs
@@ -31,7 +31,7 @@ namespace Saturn.Agents.MultiAgent
         // (recursive create_agent, terminating siblings, or waiting on their own task).
         private static readonly HashSet<string> SubAgentExcludedTools = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
-            "create_agent", "hand_off_to_agent", "terminate_agent",
+            "spawn_agent", "create_agent", "hand_off_to_agent", "terminate_agent",
             "wait_for_agent", "get_agent_status", "get_task_result",
             "claim_task", "dispatch_task", "list_due_tasks"
         };
@@ -88,7 +88,8 @@ namespace Saturn.Agents.MultiAgent
             int? maxTokens = null,
             double? topP = null,
             string? systemPromptOverride = null,
-            bool? includeUserRules = null)
+            bool? includeUserRules = null,
+            bool disposeOnTaskCompletion = false)
         {
             var agentId = $"agent_{Guid.NewGuid():N}".Substring(0, 12);
 
@@ -99,7 +100,8 @@ namespace Saturn.Agents.MultiAgent
                 Purpose = purpose,
                 Status = AgentStatus.Idle,
                 CreatedAt = DateTime.Now,
-                CurrentTask = null
+                CurrentTask = null,
+                DisposeOnTaskCompletion = disposeOnTaskCompletion
             };
 
             // Reserve the slot atomically so a burst of concurrent creates can't exceed the cap.
@@ -637,8 +639,14 @@ Your decision:";
 
             // Publish the idle transition before completion handlers run: a handler
             // may immediately hand off another task, and its "Working" event must
-            // not be followed by a stale "Idle".
-            if (becameIdle)
+            // not be followed by a stale "Idle". One-shot agents (spawn_agent) are
+            // terminated instead, after their result is recorded, so they release
+            // their concurrency slot without orchestrator cleanup.
+            if (becameIdle && agentContext.DisposeOnTaskCompletion)
+            {
+                TerminateAgent(agentId);
+            }
+            else if (becameIdle)
             {
                 OnAgentStatusChanged?.Invoke(agentId, agentContext.Name, "Idle");
             }

--- a/Agents/MultiAgent/Objects/SubAgentContext.cs
+++ b/Agents/MultiAgent/Objects/SubAgentContext.cs
@@ -18,5 +18,6 @@ namespace Saturn.Agents.MultiAgent.Objects
         public AgentTask? CurrentTask { get; set; }
         public int RevisionCount { get; set; } = 0;
         public CancellationTokenSource? Cancellation { get; set; }
+        public bool DisposeOnTaskCompletion { get; set; }
     }
 }

--- a/Config/SubAgentPreferences.cs
+++ b/Config/SubAgentPreferences.cs
@@ -31,7 +31,8 @@ namespace Saturn.Config
         public int DefaultMaxTokens { get; set; } = 4096;
         public double DefaultTopP { get; set; } = 0.95;
         public bool DefaultEnableTools { get; set; } = true;
-        
+        public int SpawnAgentTimeoutSeconds { get; set; } = 600;
+
         public bool EnableReviewStage { get; set; } = false;
         public string ReviewerModel { get; set; } = "anthropic/claude-3.5-sonnet";
         public int ReviewTimeoutSeconds { get; set; } = 300;

--- a/Program.cs
+++ b/Program.cs
@@ -229,7 +229,7 @@ namespace Saturn
             {
                 "apply_diff", "grep", "glob", "read_file", "list_files",
                 "write_file", "search_and_replace", "delete_file",
-                "create_agent", "hand_off_to_agent", "get_agent_status",
+                "spawn_agent", "get_agent_status",
                 "wait_for_agent", "get_task_result", "terminate_agent", "execute_command",
                 "get_command_output", "kill_command", "web_fetch", "web_search",
                 "update_todos"
@@ -294,12 +294,11 @@ Prime Directive
    - Documentation Agent: Create for updating docs, comments, and READMEs
 
 3) Effective delegation:
-   - Create agents with clear, focused purposes
-   - Provide sufficient context in the task description
-   - Use hand_off_to_agent for fire-and-forget tasks
-   - Use wait_for_agent when you need results before proceeding
-   - Check agent status periodically for long-running tasks
-   - Aggregate results from multiple agents when working in parallel
+   - Spawn agents with spawn_agent: give each a clear, self-contained task including file paths and expected output - sub-agents start fresh and cannot see this conversation
+   - By default spawn_agent blocks and returns the agent's report directly; set background=true for work that should run while you continue
+   - For parallel work, spawn several background agents in one message, then collect them all with a single wait_for_agent call
+   - Sub-agent reports are returned to you, not shown to the user - relay what matters in your response
+   - Once you delegate a task, do not do it yourself as well - wait for the result and integrate it
    
 4) CRITICAL: Integrating sub-agent work:
    - DO NOT recreate or redo work completed by sub-agents

--- a/Saturn.Tests/Tools/SpawnAgentToolTests.cs
+++ b/Saturn.Tests/Tools/SpawnAgentToolTests.cs
@@ -1,0 +1,197 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Saturn.Agents.MultiAgent;
+using Saturn.OpenRouter.Models.Api.Chat;
+using Saturn.Providers;
+using Saturn.Tests.Approvals;
+using Saturn.Tests.Providers;
+using Saturn.Tools.MultiAgent;
+using Xunit;
+
+namespace Saturn.Tests.Tools
+{
+    public class SpawnAgentToolTests : IDisposable
+    {
+        public SpawnAgentToolTests()
+        {
+            AgentManager.Instance.SetParentSessionId(null);
+            AgentManager.Instance.SetParentModel(null);
+        }
+
+        public void Dispose()
+        {
+            AgentManager.Instance.TerminateAllAgents();
+        }
+
+        private static Dictionary<string, object> Params(string name, string task, params (string key, object value)[] extra)
+        {
+            var parameters = new Dictionary<string, object>
+            {
+                ["name"] = name,
+                ["task"] = task
+            };
+            foreach (var (key, value) in extra)
+            {
+                parameters[key] = value;
+            }
+            return parameters;
+        }
+
+        private static async Task WaitForAgentCountAsync(int expected, int timeoutMs = 2000)
+        {
+            var start = DateTime.Now;
+            while ((DateTime.Now - start).TotalMilliseconds < timeoutMs)
+            {
+                if (AgentManager.Instance.GetCurrentAgentCount() == expected)
+                {
+                    return;
+                }
+                await Task.Delay(50);
+            }
+            AgentManager.Instance.GetCurrentAgentCount().Should().Be(expected);
+        }
+
+        [Fact]
+        public void Schema_RequiresNameAndTask_BackgroundDefaultsFalse()
+        {
+            var tool = new SpawnAgentTool();
+            var schema = tool.GetParameters();
+
+            var required = (string[])schema["required"];
+            required.Should().BeEquivalentTo(new[] { "name", "task" });
+
+            var properties = (Dictionary<string, object>)schema["properties"];
+            properties.Keys.Should().Contain(new[] { "name", "task", "purpose", "background", "timeout_seconds" });
+
+            var background = (Dictionary<string, object>)properties["background"];
+            background["default"].Should().Be(false);
+        }
+
+        [Fact]
+        public async Task Execute_SyncSpawn_ReturnsReportAndReleasesAgent()
+        {
+            var client = new FakeLlmClient { ResponseContent = "report: all files reviewed" };
+            AgentManager.Instance.Initialize(new StaticClientSource(client, "fake"));
+            var baseline = AgentManager.Instance.GetCurrentAgentCount();
+
+            var tool = new SpawnAgentTool();
+            var result = await tool.ExecuteAsync(Params("explorer", "Review the files and report back."));
+
+            result.Success.Should().BeTrue();
+            result.FormattedOutput.Should().Contain("report: all files reviewed");
+            result.FormattedOutput.Should().Contain("explorer completed");
+
+            await WaitForAgentCountAsync(baseline);
+        }
+
+        [Fact]
+        public async Task Execute_BackgroundSpawn_ReturnsTaskIdAndCleansUpOnCompletion()
+        {
+            var client = new FakeLlmClient { ResponseContent = "done" };
+            AgentManager.Instance.Initialize(new StaticClientSource(client, "fake"));
+            var baseline = AgentManager.Instance.GetCurrentAgentCount();
+
+            var tool = new SpawnAgentTool();
+            var result = await tool.ExecuteAsync(Params("worker", "Do the thing.", ("background", true)));
+
+            result.Success.Should().BeTrue();
+            var data = (Dictionary<string, object>)result.RawData!;
+            data["status"].Should().Be("running");
+            var taskId = (string)data["task_id"];
+
+            var completed = await AgentManager.Instance.WaitForAllTasks(new List<string> { taskId }, 5000);
+            completed.Should().ContainSingle(r => r.TaskId == taskId && r.Success && r.Result.Contains("done"));
+
+            await WaitForAgentCountAsync(baseline);
+        }
+
+        [Fact]
+        public async Task Execute_SyncSpawnTimeout_ReturnsTaskIdAndAgentKeepsRunning()
+        {
+            var client = new BlockingLlmClient();
+            AgentManager.Instance.Initialize(new StaticClientSource(client, "fake"));
+            var baseline = AgentManager.Instance.GetCurrentAgentCount();
+
+            var tool = new SpawnAgentTool();
+            var result = await tool.ExecuteAsync(Params("slow-worker", "Long task.", ("timeout_seconds", 1)));
+
+            result.Success.Should().BeTrue();
+            var data = (Dictionary<string, object>)result.RawData!;
+            data["status"].Should().Be("running");
+            var taskId = (string)data["task_id"];
+            AgentManager.Instance.GetTaskResult(taskId).Should().BeNull();
+
+            client.Unblock();
+
+            var completed = await AgentManager.Instance.WaitForAllTasks(new List<string> { taskId }, 5000);
+            completed.Should().ContainSingle(r => r.TaskId == taskId && r.Success);
+
+            await WaitForAgentCountAsync(baseline);
+        }
+
+        [Fact]
+        public async Task Execute_SubAgentError_SurfacesAsToolFailureAndReleasesAgent()
+        {
+            var client = new FakeLlmClient();
+            client.ChatExceptionQueue.Enqueue(new InvalidOperationException("boom"));
+            AgentManager.Instance.Initialize(new StaticClientSource(client, "fake"));
+            var baseline = AgentManager.Instance.GetCurrentAgentCount();
+
+            var tool = new SpawnAgentTool();
+            var result = await tool.ExecuteAsync(Params("failing-worker", "Fail please."));
+
+            result.Success.Should().BeFalse();
+            result.Error.Should().Contain("boom");
+
+            await WaitForAgentCountAsync(baseline);
+        }
+
+        private sealed class BlockingLlmClient : ILlmClient
+        {
+            private readonly TaskCompletionSource _gate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public LlmClientCapabilities Capabilities { get; } = new();
+
+            public void Unblock() => _gate.TrySetResult();
+
+            public async Task<ChatCompletionResponse?> ChatAsync(ChatCompletionRequest request, CancellationToken cancellationToken = default)
+            {
+                await _gate.Task.WaitAsync(cancellationToken);
+                return new ChatCompletionResponse
+                {
+                    Choices = new[]
+                    {
+                        new Choice
+                        {
+                            Message = new AssistantMessageResponse { Role = "assistant", Content = "finished late" },
+                            FinishReason = "stop"
+                        }
+                    }
+                };
+            }
+
+            public async IAsyncEnumerable<ChatCompletionChunk> StreamChatAsync(
+                ChatCompletionRequest request,
+                [EnumeratorCancellation] CancellationToken cancellationToken = default)
+            {
+                await _gate.Task.WaitAsync(cancellationToken);
+                yield break;
+            }
+
+            public Task<List<ModelInfo>> ListModelsAsync(CancellationToken cancellationToken = default)
+                => Task.FromResult(new List<ModelInfo>());
+
+            public Task<bool> ValidateConnectionAsync(CancellationToken cancellationToken = default)
+                => Task.FromResult(true);
+
+            public void Dispose()
+            {
+            }
+        }
+    }
+}

--- a/Tools/MultiAgent/CreateAgentTool.cs
+++ b/Tools/MultiAgent/CreateAgentTool.cs
@@ -11,7 +11,7 @@ namespace Saturn.Tools.MultiAgent
     {
         public override string Name => "create_agent";
         
-        public override string Description => "Create a new sub-agent with specific capabilities and purpose";
+        public override string Description => "Create a persistent sub-agent that can be given multiple tasks over its lifetime via hand_off_to_agent. Prefer spawn_agent, the one-call alternative, unless you need to reuse the same agent across several tasks.";
         
         protected override Dictionary<string, object> GetParameterProperties()
         {

--- a/Tools/MultiAgent/HandOffToAgentTool.cs
+++ b/Tools/MultiAgent/HandOffToAgentTool.cs
@@ -10,7 +10,7 @@ namespace Saturn.Tools.MultiAgent
     {
         public override string Name => "hand_off_to_agent";
         
-        public override string Description => "Hand off a task to a sub-agent for parallel execution. Returns a task ID to track progress.";
+        public override string Description => "Hand off a task to an existing sub-agent created with create_agent. Returns a task ID to track with wait_for_agent. Prefer spawn_agent, the one-call alternative, unless you are reusing an agent across several tasks.";
         
         protected override Dictionary<string, object> GetParameterProperties()
         {

--- a/Tools/MultiAgent/SpawnAgentTool.cs
+++ b/Tools/MultiAgent/SpawnAgentTool.cs
@@ -1,0 +1,194 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Saturn.Tools.Core;
+using Saturn.Agents.MultiAgent;
+using Saturn.Config;
+
+namespace Saturn.Tools.MultiAgent
+{
+    public class SpawnAgentTool : ToolBase
+    {
+        public override string Name => "spawn_agent";
+
+        public override string Description => @"Spawn a sub-agent to complete a task and return its report. This is your primary tool for delegation.
+
+When to use:
+- Independent work that can run in parallel with yours
+- Tasks that mean reading across many files when you only need the conclusion, not the file contents
+- Large self-contained subtasks (refactoring one module, writing a test suite, researching a library)
+
+When NOT to use:
+- Small changes you can make directly yourself
+- Single-fact lookups where you already know the file to check
+
+How to use:
+- The agent starts fresh with no memory of this conversation. Include everything it needs in 'task': the goal, relevant file paths, constraints, and what its report should contain.
+- By default this call blocks until the agent finishes and returns its report as the tool result. The report is returned to you, not shown to the user, so relay what matters.
+- Set background=true to get a task_id back immediately instead; collect the result later with wait_for_agent. Spawn several background agents in one message to run them in parallel.
+- The agent is single-use: it is cleaned up automatically after its task completes.
+
+Rules:
+- Once you delegate a task, do not do it yourself as well - wait for the result and integrate it.
+- Work completed by a sub-agent is done. Review its report and integrate; never redo it.";
+
+        protected override Dictionary<string, object> GetParameterProperties()
+        {
+            return new Dictionary<string, object>
+            {
+                ["name"] = new Dictionary<string, object>
+                {
+                    ["type"] = "string",
+                    ["description"] = "Short display name for the agent, e.g. 'code-explorer' or 'test-writer'"
+                },
+                ["task"] = new Dictionary<string, object>
+                {
+                    ["type"] = "string",
+                    ["description"] = "Self-contained instructions: the goal, relevant file paths, constraints, and what the report should contain. The agent cannot see this conversation."
+                },
+                ["purpose"] = new Dictionary<string, object>
+                {
+                    ["type"] = "string",
+                    ["description"] = "Optional one-line role statement for the agent's system prompt, e.g. 'Explore code and report findings without modifying anything'"
+                },
+                ["background"] = new Dictionary<string, object>
+                {
+                    ["type"] = "boolean",
+                    ["default"] = false,
+                    ["description"] = "If true, return a task_id immediately instead of waiting; collect the result with wait_for_agent"
+                },
+                ["timeout_seconds"] = new Dictionary<string, object>
+                {
+                    ["type"] = "number",
+                    ["description"] = "How long to wait for the agent before returning control (default: 600). Only used when background is false; on timeout the agent keeps running and you get a task_id to wait on."
+                }
+            };
+        }
+
+        protected override string[] GetRequiredParameters()
+        {
+            return new[] { "name", "task" };
+        }
+
+        public override string GetDisplaySummary(Dictionary<string, object> parameters)
+        {
+            var name = GetParameter<string>(parameters, "name", "agent");
+            var task = GetParameter<string>(parameters, "task", "");
+            var background = GetParameter<bool>(parameters, "background", false);
+            var suffix = background ? " (background)" : "";
+            return $"Spawning {name}{suffix}: {TruncateString(task, 40)}";
+        }
+
+        public override async Task<ToolResult> ExecuteAsync(Dictionary<string, object> parameters)
+        {
+            try
+            {
+                var name = parameters["name"].ToString()!;
+                var task = parameters["task"].ToString()!;
+                var purpose = GetParameter<string?>(parameters, "purpose", null);
+                if (string.IsNullOrWhiteSpace(purpose))
+                {
+                    purpose = "Complete the assigned task accurately and report the results";
+                }
+                var background = GetParameter<bool>(parameters, "background", false);
+
+                var prefs = SubAgentPreferences.Instance;
+                var config = prefs.GetConfigurationForPurpose(purpose);
+                var timeoutSeconds = parameters.ContainsKey("timeout_seconds")
+                    ? Convert.ToInt32(parameters["timeout_seconds"])
+                    : prefs.SpawnAgentTimeoutSeconds;
+
+                var created = await AgentManager.Instance.TryCreateSubAgent(
+                    name,
+                    purpose,
+                    config.Model,
+                    config.EnableTools,
+                    config.Temperature,
+                    config.MaxTokens,
+                    config.TopP,
+                    config.SystemPromptOverride,
+                    disposeOnTaskCompletion: true
+                );
+
+                if (!created.success)
+                {
+                    var errorMessage = $"Cannot spawn agent '{name}': {created.result}\n";
+                    errorMessage += $"Current agents: {AgentManager.Instance.GetCurrentAgentCount()}/{AgentManager.Instance.GetMaxConcurrentAgents()}\n";
+                    if (created.runningTaskIds != null && created.runningTaskIds.Count > 0)
+                    {
+                        errorMessage += "Running tasks you can wait for with wait_for_agent:\n";
+                        errorMessage += string.Join("\n", created.runningTaskIds.Select(id => $"  - {id}"));
+                    }
+                    return CreateErrorResult(errorMessage);
+                }
+
+                var agentId = created.result;
+                string taskId;
+                try
+                {
+                    taskId = await AgentManager.Instance.HandOffTask(agentId, task);
+                }
+                catch (Exception)
+                {
+                    AgentManager.Instance.TerminateAgent(agentId);
+                    throw;
+                }
+
+                if (background)
+                {
+                    return CreateSuccessResult(
+                        new Dictionary<string, object>
+                        {
+                            ["task_id"] = taskId,
+                            ["agent_id"] = agentId,
+                            ["agent_name"] = name,
+                            ["status"] = "running"
+                        },
+                        $"Spawned {name} in the background. Task ID: {taskId}. Collect the result with wait_for_agent when you need it."
+                    );
+                }
+
+                var results = await AgentManager.Instance.WaitForAllTasks(
+                    new List<string> { taskId }, timeoutSeconds * 1000);
+                var result = results.FirstOrDefault();
+
+                if (result == null)
+                {
+                    return CreateSuccessResult(
+                        new Dictionary<string, object>
+                        {
+                            ["task_id"] = taskId,
+                            ["agent_id"] = agentId,
+                            ["agent_name"] = name,
+                            ["status"] = "running"
+                        },
+                        $"{name} is still working after {timeoutSeconds}s. It keeps running; retrieve its report with wait_for_agent on task ID {taskId}."
+                    );
+                }
+
+                if (!result.Success)
+                {
+                    return CreateErrorResult($"Sub-agent {name} failed after {result.Duration.TotalSeconds:F1}s: {result.Result}");
+                }
+
+                return CreateSuccessResult(
+                    new Dictionary<string, object>
+                    {
+                        ["task_id"] = taskId,
+                        ["agent_id"] = agentId,
+                        ["agent_name"] = name,
+                        ["status"] = "completed",
+                        ["duration_seconds"] = result.Duration.TotalSeconds,
+                        ["result"] = result.Result
+                    },
+                    $"{name} completed in {result.Duration.TotalSeconds:F1}s.\n\nReport:\n{result.Result}"
+                );
+            }
+            catch (Exception ex)
+            {
+                return CreateErrorResult($"Failed to spawn agent: {ex.Message}");
+            }
+        }
+    }
+}

--- a/Tools/MultiAgent/WaitForAgentTool.cs
+++ b/Tools/MultiAgent/WaitForAgentTool.cs
@@ -11,7 +11,7 @@ namespace Saturn.Tools.MultiAgent
     {
         public override string Name => "wait_for_agent";
         
-        public override string Description => "Wait for one or more agent tasks to complete and retrieve their results";
+        public override string Description => "Wait for one or more agent tasks to complete and retrieve their results. Coding tasks routinely take minutes; prefer one long wait over repeated short ones. Pass all outstanding task IDs in a single call rather than waiting for them one at a time.";
         
         protected override Dictionary<string, object> GetParameterProperties()
         {
@@ -26,8 +26,8 @@ namespace Saturn.Tools.MultiAgent
                 ["timeout_seconds"] = new Dictionary<string, object>
                 {
                     ["type"] = "number",
-                    ["default"] = 30,
-                    ["description"] = "Maximum time to wait in seconds (default: 30)"
+                    ["default"] = 600,
+                    ["description"] = "Maximum time to wait in seconds (default: 600). A timeout is not a failure: tasks keep running and can be waited on again."
                 }
             };
         }
@@ -40,7 +40,7 @@ namespace Saturn.Tools.MultiAgent
         public override string GetDisplaySummary(Dictionary<string, object> parameters)
         {
             var taskIdsObj = GetParameter<object?>(parameters, "task_ids", null);
-            var timeout = GetParameter<int>(parameters, "timeout_seconds", 30);
+            var timeout = GetParameter<int>(parameters, "timeout_seconds", 600);
             
             string agentInfo = "agents";
             if (taskIdsObj is List<object> objList && objList.Count > 0)
@@ -71,8 +71,8 @@ namespace Saturn.Tools.MultiAgent
                     taskIds = new List<string>();
                 }
                 
-                var timeoutSeconds = parameters.ContainsKey("timeout_seconds") ? 
-                    Convert.ToInt32(parameters["timeout_seconds"]) : 30;
+                var timeoutSeconds = parameters.ContainsKey("timeout_seconds") ?
+                    Convert.ToInt32(parameters["timeout_seconds"]) : 600;
                 var timeoutMs = timeoutSeconds * 1000;
                 
                 var startTime = DateTime.Now;


### PR DESCRIPTION
Adds a spawn_agent tool that creates a sub-agent, hands off the task, waits, and returns the report in one call. Agents spawned this way are single-use and release their slot automatically when the task completes.

Raises the wait_for_agent default timeout from 30s to 600s, points create_agent and hand_off_to_agent descriptions at the new tool, and updates the default tool list and delegation guidance in the system prompt. Includes end-to-end tests over AgentManager with a fake LLM client.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a one-shot agent delegation option that automatically cleans up agents after completing their tasks.
  * Added `spawn_agent` support for synchronous and background work, including task tracking and configurable timeouts.
  * Added guidance for monitoring delegated tasks and integrating their results.
  * Prevented delegated agents from spawning additional agents.

* **Improvements**
  * Increased the default agent-task wait timeout to 600 seconds.
  * Clarified when to use persistent agents versus one-shot delegation.

* **Tests**
  * Added coverage for successful, background, timed-out, and failed delegated tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->