### PR TITLE
Add typed sub-agents and raise sub-agent capability limits

### DIFF
--- a/Agents/MultiAgent/AgentManager.cs
+++ b/Agents/MultiAgent/AgentManager.cs
@@ -89,7 +89,9 @@ namespace Saturn.Agents.MultiAgent
             double? topP = null,
             string? systemPromptOverride = null,
             bool? includeUserRules = null,
-            bool disposeOnTaskCompletion = false)
+            bool disposeOnTaskCompletion = false,
+            IReadOnlyList<string>? allowedTools = null,
+            string? systemPromptAddendum = null)
         {
             var agentId = $"agent_{Guid.NewGuid():N}".Substring(0, 12);
 
@@ -135,6 +137,19 @@ When the task is complete, report back concisely:
 - Anything you could not complete, and why
 Your report is consumed by an orchestrator agent, so keep it factual and free of filler.";
 
+                if (systemPromptOverride == null && !string.IsNullOrWhiteSpace(systemPromptAddendum))
+                {
+                    systemPrompt += $"\n\n{systemPromptAddendum}";
+                }
+
+                var subAgentTools = ToolRegistry.Instance.GetAllNames()
+                    .Where(toolName => !SubAgentExcludedTools.Contains(toolName));
+                if (allowedTools != null)
+                {
+                    subAgentTools = subAgentTools
+                        .Where(toolName => allowedTools.Contains(toolName, StringComparer.OrdinalIgnoreCase));
+                }
+
                 var config = new AgentConfiguration
                 {
                     Name = name,
@@ -145,11 +160,11 @@ Your report is consumed by an orchestrator agent, so keep it factual and free of
                     MaxTokens = maxTokens ?? 4096,
                     TopP = topP ?? 0.95,
                     EnableTools = enableTools,
-                    ToolNames = ToolRegistry.Instance.GetAllNames()
-                        .Where(name => !SubAgentExcludedTools.Contains(name))
-                        .ToList(),
+                    ToolNames = subAgentTools.ToList(),
                     MaintainHistory = true,
-                    MaxHistoryMessages = 20
+                    // A real coding task is routinely 25+ tool round-trips; a low cap
+                    // makes the agent forget its own task mid-way.
+                    MaxHistoryMessages = 200
                 };
 
                 var agent = new Agent(config);
@@ -608,7 +623,7 @@ Your decision:";
                     return new ReviewDecision
                     {
                         Status = ReviewStatus.Approved,
-                        Feedback = "Review timed out - auto-approved"
+                        Feedback = "Reviewer timed out - result is UNREVIEWED"
                     };
                 }
 

--- a/Agents/MultiAgent/AgentManager.cs
+++ b/Agents/MultiAgent/AgentManager.cs
@@ -126,6 +126,15 @@ namespace Saturn.Agents.MultiAgent
             {
                 model = await ModelCatalog.ResolveModelAsync(_clientSource, model, _parentModel);
 
+                // Clamp to the model's advertised output limit so a generous default
+                // cannot turn into a 400 on models with smaller completion caps.
+                var effectiveMaxTokens = maxTokens ?? SubAgentPreferences.Instance.DefaultMaxTokens;
+                var modelMaxCompletion = await ModelCatalog.GetMaxCompletionTokensAsync(_clientSource, model);
+                if (modelMaxCompletion.HasValue && modelMaxCompletion.Value > 0)
+                {
+                    effectiveMaxTokens = Math.Min(effectiveMaxTokens, modelMaxCompletion.Value);
+                }
+
                 var systemPrompt = systemPromptOverride ?? $@"You are a specialized sub-agent named {name}.
 Your purpose: {purpose}
 
@@ -157,7 +166,7 @@ Your report is consumed by an orchestrator agent, so keep it factual and free of
                     ClientSource = _clientSource,
                     Model = model,
                     Temperature = temperature ?? 0.3,
-                    MaxTokens = maxTokens ?? 4096,
+                    MaxTokens = effectiveMaxTokens,
                     TopP = topP ?? 0.95,
                     EnableTools = enableTools,
                     ToolNames = subAgentTools.ToList(),

--- a/Agents/MultiAgent/AgentTypeRegistry.cs
+++ b/Agents/MultiAgent/AgentTypeRegistry.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Saturn.Agents.MultiAgent
+{
+    public sealed class AgentTypeDefinition
+    {
+        public string Name { get; init; } = "";
+        public string Description { get; init; } = "";
+
+        /// <summary>
+        /// Tools this type may use; null grants every tool available to sub-agents.
+        /// Orchestration tools are excluded for all types regardless of this list.
+        /// </summary>
+        public IReadOnlyList<string>? ToolNames { get; init; }
+
+        /// <summary>Appended to the standard sub-agent system prompt.</summary>
+        public string? SystemPromptAddendum { get; init; }
+    }
+
+    /// <summary>
+    /// Built-in sub-agent types. The spawn_agent tool schema and the orchestrator
+    /// system prompt are both rendered from this registry so they cannot drift.
+    /// </summary>
+    public static class AgentTypeRegistry
+    {
+        public const string DefaultTypeName = "general";
+
+        public static readonly IReadOnlyList<AgentTypeDefinition> All = new[]
+        {
+            new AgentTypeDefinition
+            {
+                Name = "general",
+                Description = "Full capabilities. Use when the task mixes reading and modifying, or does not fit a more specific type.",
+            },
+            new AgentTypeDefinition
+            {
+                Name = "explorer",
+                Description = "Read-only exploration: locate code, trace behavior, summarize findings across many files. Cannot modify files or run commands.",
+                ToolNames = new[] { "grep", "glob", "read_file", "list_files", "web_fetch", "web_search" },
+                SystemPromptAddendum = "You are read-only: report findings, never attempt to change anything. Cite file paths and line numbers in your report so the orchestrator can act on them directly.",
+            },
+            new AgentTypeDefinition
+            {
+                Name = "coder",
+                Description = "Implementation work: write or modify code, run builds and tests to verify.",
+                SystemPromptAddendum = "Match the project's existing style, naming, and comment density. Verify your changes by building or running tests when possible, and state in your report exactly what you verified and how.",
+            },
+            new AgentTypeDefinition
+            {
+                Name = "reviewer",
+                Description = "Code review and verification: read code, run tests and checks, report issues. Does not modify files.",
+                ToolNames = new[] { "grep", "glob", "read_file", "list_files", "execute_command", "get_command_output", "kill_command", "web_fetch", "web_search" },
+                SystemPromptAddendum = "Do not modify any files. Review the code or changes you are pointed at, running tests where useful. Report concrete findings with file paths and line numbers, ordered by severity, and say explicitly if you found no issues.",
+            },
+        };
+
+        public static bool TryGet(string? name, out AgentTypeDefinition definition)
+        {
+            definition = All.FirstOrDefault(t =>
+                t.Name.Equals(name, StringComparison.OrdinalIgnoreCase))!;
+            return definition != null;
+        }
+
+        public static AgentTypeDefinition Default =>
+            All.First(t => t.Name == DefaultTypeName);
+
+        public static string[] Names => All.Select(t => t.Name).ToArray();
+
+        /// <summary>One line per type, for embedding in prompts and tool schemas.</summary>
+        public static string DescribeAll(string indent = "")
+        {
+            var builder = new StringBuilder();
+            foreach (var type in All)
+            {
+                builder.AppendLine($"{indent}- {type.Name}: {type.Description}");
+            }
+            return builder.ToString().TrimEnd();
+        }
+    }
+}

--- a/Config/Objects/SubAgentConfiguration.cs
+++ b/Config/Objects/SubAgentConfiguration.cs
@@ -10,7 +10,7 @@ namespace Saturn.Config.Objects
     {
         public string Model { get; set; } = "anthropic/claude-3.5-sonnet";
         public double Temperature { get; set; } = 0.3;
-        public int MaxTokens { get; set; } = 4096;
+        public int MaxTokens { get; set; } = 32768;
         public double TopP { get; set; } = 0.95;
         public bool EnableTools { get; set; } = true;
         public string? SystemPromptOverride { get; set; }

--- a/Config/SubAgentPreferences.cs
+++ b/Config/SubAgentPreferences.cs
@@ -28,7 +28,7 @@ namespace Saturn.Config
         
         public string DefaultModel { get; set; } = "anthropic/claude-3.5-sonnet";
         public double DefaultTemperature { get; set; } = 0.3;
-        public int DefaultMaxTokens { get; set; } = 8192;
+        public int DefaultMaxTokens { get; set; } = 32768;
         public double DefaultTopP { get; set; } = 0.95;
         public bool DefaultEnableTools { get; set; } = true;
         public int SpawnAgentTimeoutSeconds { get; set; } = 600;

--- a/Config/SubAgentPreferences.cs
+++ b/Config/SubAgentPreferences.cs
@@ -28,7 +28,7 @@ namespace Saturn.Config
         
         public string DefaultModel { get; set; } = "anthropic/claude-3.5-sonnet";
         public double DefaultTemperature { get; set; } = 0.3;
-        public int DefaultMaxTokens { get; set; } = 4096;
+        public int DefaultMaxTokens { get; set; } = 8192;
         public double DefaultTopP { get; set; } = 0.95;
         public bool DefaultEnableTools { get; set; } = true;
         public int SpawnAgentTimeoutSeconds { get; set; } = 600;

--- a/Program.cs
+++ b/Program.cs
@@ -285,12 +285,8 @@ Prime Directive
    - Large refactors: Breaking down big changes into smaller, manageable pieces
    - Exploration: Searching/analysing while you continue with other work
 
-2) Sub-agent patterns:
-   - Research Agent: Create for gathering information, searching docs, analyzing code patterns
-   - Test Agent: Create for writing/running tests while you implement features
-   - Refactor Agent: Create for systematic code improvements
-   - Analysis Agent: Create for code review, performance analysis, security checks
-   - Documentation Agent: Create for updating docs, comments, and READMEs
+2) Agent types (pass as agent_type to spawn_agent; pick the narrowest that fits):
+" + AgentTypeRegistry.DescribeAll("   ") + @"
 
 3) Effective delegation:
    - Spawn agents with spawn_agent: give each a clear, self-contained task including file paths and expected output - sub-agents start fresh and cannot see this conversation
@@ -307,10 +303,10 @@ Prime Directive
    - Integrate results from parallel agents into a coherent whole - integrate, never duplicate
 
 5) Example workflows:
-   - Complex feature: Create analysis agent to study existing code while you plan implementation
-   - Bug fix: Create test agent to reproduce issue while you develop the fix
-   - Refactoring: Create multiple agents to handle different modules in parallel
-   - Code review: Create review agent to check your changes while you document them
+   - Complex feature: spawn an explorer to map the existing code while you plan the implementation
+   - Bug fix: spawn a reviewer to reproduce the issue while you develop the fix
+   - Refactoring: spawn several background coder agents to handle independent modules in parallel
+   - Code review: spawn a reviewer to check your changes while you document them
 
 Operating Principles
 1) Tool usage

--- a/Providers/Core/ModelCatalog.cs
+++ b/Providers/Core/ModelCatalog.cs
@@ -117,6 +117,45 @@ namespace Saturn.Providers
             }
         }
 
+        /// <summary>
+        /// Returns the model's advertised completion-token limit, or null when the
+        /// provider does not report one (callers should not clamp in that case).
+        /// </summary>
+        public static async Task<int?> GetMaxCompletionTokensAsync(ILlmClientSource clientSource, string modelId)
+        {
+            try
+            {
+                if (clientSource == null || !clientSource.IsConnected || string.IsNullOrWhiteSpace(modelId))
+                {
+                    return null;
+                }
+
+                var (providerKey, client) = clientSource.Snapshot();
+                var models = await GetAsync(providerKey, client, CancellationToken.None);
+
+                var match = models.FirstOrDefault(m => string.Equals(m.Id, modelId, StringComparison.OrdinalIgnoreCase));
+                if (match == null)
+                {
+                    var variantSeparator = modelId.LastIndexOf(':');
+                    if (variantSeparator > 0)
+                    {
+                        var baseModel = modelId.Substring(0, variantSeparator);
+                        match = models.FirstOrDefault(m => string.Equals(m.Id, baseModel, StringComparison.OrdinalIgnoreCase));
+                    }
+                }
+
+                return match?.MaxCompletionTokens;
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
         public static void Invalidate()
         {
             lock (_lock)

--- a/Providers/Core/ModelInfo.cs
+++ b/Providers/Core/ModelInfo.cs
@@ -12,6 +12,8 @@ namespace Saturn.Providers
 
         public int? ContextLength { get; set; }
 
+        public int? MaxCompletionTokens { get; set; }
+
         public string? PromptPrice { get; set; }
 
         public string? CompletionPrice { get; set; }

--- a/Providers/OpenRouter/OpenRouterLlmClient.cs
+++ b/Providers/OpenRouter/OpenRouterLlmClient.cs
@@ -68,6 +68,7 @@ namespace Saturn.Providers
                     DisplayName = m.Name,
                     Description = m.Description,
                     ContextLength = m.ContextLength,
+                    MaxCompletionTokens = m.TopProvider?.MaxCompletionTokens,
                     PromptPrice = m.Pricing?.Prompt,
                     CompletionPrice = m.Pricing?.Completion
                 })

--- a/Saturn.Tests/Agents/AgentTypeRegistryTests.cs
+++ b/Saturn.Tests/Agents/AgentTypeRegistryTests.cs
@@ -1,0 +1,61 @@
+using System.Linq;
+using FluentAssertions;
+using Saturn.Agents.MultiAgent;
+using Xunit;
+
+namespace Saturn.Tests.Agents
+{
+    public class AgentTypeRegistryTests
+    {
+        [Fact]
+        public void TryGet_IsCaseInsensitive()
+        {
+            AgentTypeRegistry.TryGet("Explorer", out var type).Should().BeTrue();
+            type.Name.Should().Be("explorer");
+        }
+
+        [Fact]
+        public void TryGet_UnknownType_ReturnsFalse()
+        {
+            AgentTypeRegistry.TryGet("warlock", out _).Should().BeFalse();
+        }
+
+        [Fact]
+        public void Default_IsGeneralWithFullToolAccess()
+        {
+            AgentTypeRegistry.Default.Name.Should().Be("general");
+            AgentTypeRegistry.Default.ToolNames.Should().BeNull();
+        }
+
+        [Fact]
+        public void ReadOnlyTypes_DoNotIncludeWriteTools()
+        {
+            var writeTools = new[] { "apply_diff", "write_file", "search_and_replace", "delete_file" };
+
+            foreach (var typeName in new[] { "explorer", "reviewer" })
+            {
+                AgentTypeRegistry.TryGet(typeName, out var type).Should().BeTrue();
+                type.ToolNames.Should().NotBeNull();
+                type.ToolNames.Should().NotContain(writeTools);
+            }
+        }
+
+        [Fact]
+        public void DescribeAll_ListsEveryType()
+        {
+            var described = AgentTypeRegistry.DescribeAll("   ");
+
+            foreach (var type in AgentTypeRegistry.All)
+            {
+                described.Should().Contain($"   - {type.Name}: ");
+            }
+        }
+
+        [Fact]
+        public void Names_MatchRegistry()
+        {
+            AgentTypeRegistry.Names.Should().BeEquivalentTo(
+                AgentTypeRegistry.All.Select(t => t.Name));
+        }
+    }
+}

--- a/Saturn.Tests/Tools/SpawnAgentToolTests.cs
+++ b/Saturn.Tests/Tools/SpawnAgentToolTests.cs
@@ -140,6 +140,53 @@ namespace Saturn.Tests.Tools
         }
 
         [Fact]
+        public async Task Execute_ExplorerType_GetsReadOnlyToolsAndAddendum()
+        {
+            var client = new BlockingLlmClient();
+            AgentManager.Instance.Initialize(new StaticClientSource(client, "fake"));
+
+            var tool = new SpawnAgentTool();
+            var result = await tool.ExecuteAsync(Params("scout", "Map the codebase.",
+                ("agent_type", "explorer"), ("background", true)));
+
+            result.Success.Should().BeTrue();
+            var context = AgentManager.Instance.GetAgentContexts().Single(c => c.Name == "scout");
+            context.Agent.Configuration.ToolNames.Should().Contain("grep");
+            context.Agent.Configuration.ToolNames.Should().NotContain(new[] { "apply_diff", "write_file", "execute_command" });
+            context.Agent.Configuration.SystemPrompt.ToString().Should().Contain("read-only");
+
+            client.Unblock();
+            var taskId = (string)((Dictionary<string, object>)result.RawData!)["task_id"];
+            await AgentManager.Instance.WaitForAllTasks(new List<string> { taskId }, 5000);
+            await WaitForAgentCountAsync(0);
+        }
+
+        [Fact]
+        public async Task Execute_UnknownAgentType_ReturnsErrorListingValidTypes()
+        {
+            var client = new FakeLlmClient();
+            AgentManager.Instance.Initialize(new StaticClientSource(client, "fake"));
+
+            var tool = new SpawnAgentTool();
+            var result = await tool.ExecuteAsync(Params("x", "y", ("agent_type", "warlock")));
+
+            result.Success.Should().BeFalse();
+            result.Error.Should().Contain("warlock").And.Contain("general").And.Contain("explorer");
+            AgentManager.Instance.GetCurrentAgentCount().Should().Be(0);
+        }
+
+        [Fact]
+        public void Schema_AgentTypeEnum_MatchesRegistry()
+        {
+            var tool = new SpawnAgentTool();
+            var properties = (Dictionary<string, object>)tool.GetParameters()["properties"];
+            var agentType = (Dictionary<string, object>)properties["agent_type"];
+
+            ((string[])agentType["enum"]).Should().BeEquivalentTo(AgentTypeRegistry.Names);
+            agentType["default"].Should().Be("general");
+        }
+
+        [Fact]
         public async Task Execute_AtAgentLimit_ReturnsErrorWithoutLeakingSlot()
         {
             var client = new BlockingLlmClient();

--- a/Saturn.Tests/Tools/SpawnAgentToolTests.cs
+++ b/Saturn.Tests/Tools/SpawnAgentToolTests.cs
@@ -25,12 +25,14 @@ namespace Saturn.Tests.Tools
             AgentManager.Instance.SetParentSessionId(null);
             AgentManager.Instance.SetParentModel(null);
             _originalMaxAgents = AgentManager.Instance.GetMaxConcurrentAgents();
+            ModelCatalog.Invalidate();
         }
 
         public void Dispose()
         {
             AgentManager.Instance.TerminateAllAgents();
             AgentManager.Instance.SetMaxConcurrentAgents(_originalMaxAgents);
+            ModelCatalog.Invalidate();
         }
 
         private static Dictionary<string, object> Params(string name, string task, params (string key, object value)[] extra)
@@ -159,6 +161,22 @@ namespace Saturn.Tests.Tools
             var taskId = (string)((Dictionary<string, object>)result.RawData!)["task_id"];
             await AgentManager.Instance.WaitForAllTasks(new List<string> { taskId }, 5000);
             await WaitForAgentCountAsync(0);
+        }
+
+        [Fact]
+        public async Task TryCreateSubAgent_ClampsMaxTokensToModelLimit()
+        {
+            var client = new FakeLlmClient();
+            client.Models.Add(new ModelInfo { Id = "small-model", MaxCompletionTokens = 9000, IsLoaded = true });
+            AgentManager.Instance.Initialize(new StaticClientSource(client, "fake"));
+            ModelCatalog.Invalidate();
+
+            var created = await AgentManager.Instance.TryCreateSubAgent(
+                "clamped", "test clamp", "small-model", maxTokens: 32768);
+
+            created.success.Should().BeTrue();
+            var context = AgentManager.Instance.GetAgentContexts().Single(c => c.Name == "clamped");
+            context.Agent.Configuration.MaxTokens.Should().Be(9000);
         }
 
         [Fact]

--- a/Tools/MultiAgent/SpawnAgentTool.cs
+++ b/Tools/MultiAgent/SpawnAgentTool.cs
@@ -24,6 +24,7 @@ When NOT to use:
 - Single-fact lookups where you already know the file to check
 
 How to use:
+- Pick the narrowest agent_type that fits the task; types with fewer tools stay focused and cannot cause side effects.
 - The agent starts fresh with no memory of this conversation. Include everything it needs in 'task': the goal, relevant file paths, constraints, and what its report should contain.
 - By default this call blocks until the agent finishes and returns its report as the tool result. The report is returned to you, not shown to the user, so relay what matters.
 - Set background=true to get a task_id back immediately instead; collect the result later with wait_for_agent. Spawn several background agents in one message to run them in parallel.
@@ -47,10 +48,17 @@ Rules:
                     ["type"] = "string",
                     ["description"] = "Self-contained instructions: the goal, relevant file paths, constraints, and what the report should contain. The agent cannot see this conversation."
                 },
+                ["agent_type"] = new Dictionary<string, object>
+                {
+                    ["type"] = "string",
+                    ["enum"] = AgentTypeRegistry.Names,
+                    ["default"] = AgentTypeRegistry.DefaultTypeName,
+                    ["description"] = "The kind of agent to spawn:\n" + AgentTypeRegistry.DescribeAll()
+                },
                 ["purpose"] = new Dictionary<string, object>
                 {
                     ["type"] = "string",
-                    ["description"] = "Optional one-line role statement for the agent's system prompt, e.g. 'Explore code and report findings without modifying anything'"
+                    ["description"] = "Optional one-line role statement for the agent's system prompt, e.g. 'Explore code and report findings without modifying anything'. Defaults to the agent_type's standard role."
                 },
                 ["background"] = new Dictionary<string, object>
                 {
@@ -87,15 +95,28 @@ Rules:
             {
                 var name = parameters["name"].ToString()!;
                 var task = parameters["task"].ToString()!;
+
+                var agentTypeName = GetParameter<string?>(parameters, "agent_type", null);
+                AgentTypeDefinition agentType;
+                if (string.IsNullOrWhiteSpace(agentTypeName))
+                {
+                    agentType = AgentTypeRegistry.Default;
+                }
+                else if (!AgentTypeRegistry.TryGet(agentTypeName, out agentType))
+                {
+                    return CreateErrorResult(
+                        $"Unknown agent_type '{agentTypeName}'. Valid types: {string.Join(", ", AgentTypeRegistry.Names)}");
+                }
+
                 var purpose = GetParameter<string?>(parameters, "purpose", null);
                 if (string.IsNullOrWhiteSpace(purpose))
                 {
-                    purpose = "Complete the assigned task accurately and report the results";
+                    purpose = agentType.Description;
                 }
                 var background = GetParameter<bool>(parameters, "background", false);
 
                 var prefs = SubAgentPreferences.Instance;
-                var config = prefs.GetConfigurationForPurpose(purpose);
+                var config = prefs.GetConfigurationForPurpose(agentType.Name);
                 var timeoutSeconds = parameters.ContainsKey("timeout_seconds")
                     ? Convert.ToInt32(parameters["timeout_seconds"])
                     : prefs.SpawnAgentTimeoutSeconds;
@@ -109,7 +130,9 @@ Rules:
                     config.MaxTokens,
                     config.TopP,
                     config.SystemPromptOverride,
-                    disposeOnTaskCompletion: true
+                    disposeOnTaskCompletion: true,
+                    allowedTools: agentType.ToolNames,
+                    systemPromptAddendum: agentType.SystemPromptAddendum
                 );
 
                 if (!created.success)


### PR DESCRIPTION
Adds an agent type registry (general, explorer, coder, reviewer) with per-type tool restrictions and prompt addenda. The spawn_agent schema enum and the orchestrator system prompt both render from the registry so they cannot drift.

Also raises sub-agent MaxHistoryMessages from 20 to 200 and default max tokens from 4096 to 8192, since coding tasks routinely exceed both, and marks reviewer-timeout results as UNREVIEWED instead of auto-approved.