### PR TITLE
Raise default max history messages to 200

### DIFF
--- a/Agents/Core/AgentConfiguration.cs
+++ b/Agents/Core/AgentConfiguration.cs
@@ -16,7 +16,7 @@ namespace Saturn.Agents.Core
         public double? FrequencyPenalty { get; set; }
         public double? PresencePenalty { get; set; }
         public string[]? StopSequences { get; set; }
-        public int? MaxHistoryMessages { get; set; } = 20;
+        public int? MaxHistoryMessages { get; set; } = 200;
         public bool MaintainHistory { get; set; } = true;
         public List<string> ToolNames { get; set; } = new List<string>();
         public bool EnableTools { get; set; } = false;

--- a/Program.cs
+++ b/Program.cs
@@ -40,8 +40,6 @@ namespace Saturn
                 if (isWebMode)
                 {
                     agent.IsOrchestrator = true;
-                    // Long-horizon web sessions benefit from a deeper context window.
-                    agent.Configuration.MaxHistoryMessages = 50;
                     var server = new Saturn.Web.WebServer(agent, client, port);
                     Console.WriteLine($"Saturn web UI running at {server.Url}");
                     Console.WriteLine("Press Ctrl+C to stop.");
@@ -164,7 +162,7 @@ namespace Saturn
                 MaxTokens = 4096,
                 TopP = 0.25,
                 MaintainHistory = true,
-                MaxHistoryMessages = 10,
+                MaxHistoryMessages = 200,
                 EnableTools = true,
                 EnableStreaming = true,
                 RequireCommandApproval = true,

--- a/Saturn.Tests/Tools/ReadFileToolTests.cs
+++ b/Saturn.Tests/Tools/ReadFileToolTests.cs
@@ -14,14 +14,12 @@ namespace Saturn.Tests.Tools
     public class ReadFileToolTests : IDisposable
     {
         private readonly string _testDirectory;
-        private readonly List<string> _createdFiles;
         private readonly string _originalDirectory;
 
         public ReadFileToolTests()
         {
             var testDirectory = Path.Combine(Path.GetTempPath(), $"SaturnTests_{Guid.NewGuid()}");
             Directory.CreateDirectory(testDirectory);
-            _createdFiles = new List<string>();
             _originalDirectory = Directory.GetCurrentDirectory();
             Directory.SetCurrentDirectory(testDirectory);
             // Use the canonical form so absolute test paths match the working directory
@@ -205,7 +203,6 @@ namespace Saturn.Tests.Tools
         {
             var filePath = Path.Combine(_testDirectory, fileName);
             File.WriteAllText(filePath, content, Encoding.UTF8);
-            _createdFiles.Add(filePath);
             return filePath;
         }
 
@@ -213,17 +210,26 @@ namespace Saturn.Tests.Tools
         {
             Directory.SetCurrentDirectory(_originalDirectory);
 
-            foreach (var file in _createdFiles)
+            // Windows can hold transient locks on freshly written files (e.g. AV
+            // scanners); cleanup is best-effort, so retry briefly and never throw.
+            for (var attempt = 0; attempt < 3; attempt++)
             {
-                if (File.Exists(file))
+                try
                 {
-                    File.Delete(file);
+                    if (Directory.Exists(_testDirectory))
+                    {
+                        Directory.Delete(_testDirectory, true);
+                    }
+                    return;
                 }
-            }
+                catch (IOException)
+                {
+                }
+                catch (UnauthorizedAccessException)
+                {
+                }
 
-            if (Directory.Exists(_testDirectory))
-            {
-                Directory.Delete(_testDirectory, true);
+                System.Threading.Thread.Sleep(100);
             }
         }
     }

--- a/UI/AgentConfiguration.cs
+++ b/UI/AgentConfiguration.cs
@@ -14,7 +14,7 @@ namespace Saturn.UI
         public double TopP { get; set; } = 0.25;
         public bool EnableStreaming { get; set; } = true;
         public bool MaintainHistory { get; set; } = true;
-        public int MaxHistoryMessages { get; set; } = 10;
+        public int MaxHistoryMessages { get; set; } = 200;
         public string SystemPrompt { get; set; }
         public bool EnableTools { get; set; } = false;
         public List<string> ToolNames { get; set; } = new List<string>();

--- a/UI/ChatInterface.cs
+++ b/UI/ChatInterface.cs
@@ -55,7 +55,7 @@ namespace Saturn.UI
                 TopP = agent.Configuration.TopP ?? 0.25,
                 EnableStreaming = agent.Configuration.EnableStreaming,
                 MaintainHistory = agent.Configuration.MaintainHistory,
-                MaxHistoryMessages = agent.Configuration.MaxHistoryMessages ?? 10,
+                MaxHistoryMessages = agent.Configuration.MaxHistoryMessages ?? 200,
                 SystemPrompt = agent.Configuration.SystemPrompt?.ToString() ?? "",
                 EnableTools = agent.Configuration.EnableTools,
                 ToolNames = agent.Configuration.ToolNames ?? new List<string>(),
@@ -1180,7 +1180,7 @@ namespace Saturn.UI
             var dialog = new Dialog("Set Max History Messages", 50, 10);
             dialog.ColorScheme = Colors.Dialog;
 
-            var label = new Label($"Max History Messages (0-100): Current = {currentConfig.MaxHistoryMessages}")
+            var label = new Label($"Max History Messages (0-1000): Current = {currentConfig.MaxHistoryMessages}")
             {
                 X = 1,
                 Y = 1,
@@ -1202,7 +1202,7 @@ namespace Saturn.UI
 
             okButton.Clicked += async () =>
             {
-                if (int.TryParse(textField.Text.ToString(), out int maxHistory) && maxHistory >= 0 && maxHistory <= 100)
+                if (int.TryParse(textField.Text.ToString(), out int maxHistory) && maxHistory >= 0 && maxHistory <= 1000)
                 {
                     currentConfig.MaxHistoryMessages = maxHistory;
                     await UpdateConfiguration();
@@ -1210,7 +1210,7 @@ namespace Saturn.UI
                 }
                 else
                 {
-                    MessageBox.ErrorQuery("Invalid Input", "Please enter a value between 0 and 100", "OK");
+                    MessageBox.ErrorQuery("Invalid Input", "Please enter a value between 0 and 1000", "OK");
                 }
             };
 


### PR DESCRIPTION
Default max history was 10/20 and web mode overwrote the persisted value down to 50 on startup.

- Raise all MaxHistoryMessages defaults to 200
- Remove the web mode override so the saved config value wins
- Lift the TUI dialog input cap from 100 to 1000