### PR TITLE
Web panel UX rework: orchestrator command center, unified Work view, actionable approvals

### DIFF
--- a/Agents/MultiAgent/AgentManager.cs
+++ b/Agents/MultiAgent/AgentManager.cs
@@ -300,7 +300,7 @@ Your report is consumed by an orchestrator agent, so keep it factual and free of
 
                         if (terminated)
                         {
-                            CompleteTask(taskId, agentId, agentContext, false, "Task terminated before completion");
+                            CompleteTask(taskId, agentId, agentContext, task, false, "Task terminated before completion");
                             return;
                         }
 
@@ -364,38 +364,38 @@ Your report is consumed by an orchestrator agent, so keep it factual and free of
 
                         if (terminated)
                         {
-                            CompleteTask(taskId, agentId, agentContext, false, "Task terminated before completion");
+                            CompleteTask(taskId, agentId, agentContext, task, false, "Task terminated before completion");
                         }
                         else if (reviewDecision.Status == ReviewStatus.Approved)
                         {
                             var approvalMessage = agentContext.RevisionCount > 0 
                                 ? $"{currentResult}\n\n[Review: Approved after {agentContext.RevisionCount} revision(s) - {reviewDecision.Feedback}]"
                                 : $"{currentResult}\n\n[Review: Approved - {reviewDecision.Feedback}]";
-                            CompleteTask(taskId, agentId, agentContext, true, approvalMessage);
+                            CompleteTask(taskId, agentId, agentContext, task, true, approvalMessage);
                         }
                         else if (reviewDecision.Status == ReviewStatus.Rejected)
                         {
-                            CompleteTask(taskId, agentId, agentContext, false, 
+                            CompleteTask(taskId, agentId, agentContext, task, false,
                                 $"Task rejected by reviewer: {reviewDecision.Feedback}");
                         }
                         else
                         {
-                            CompleteTask(taskId, agentId, agentContext, false, 
+                            CompleteTask(taskId, agentId, agentContext, task, false,
                                 $"Task failed review after {agentContext.RevisionCount} revision(s). Final feedback: {reviewDecision.Feedback}");
                         }
                     }
                     else
                     {
-                        CompleteTask(taskId, agentId, agentContext, true, result.Content.ToString());
+                        CompleteTask(taskId, agentId, agentContext, task, true, result.Content.ToString());
                     }
                 }
                 catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
                 {
-                    CompleteTask(taskId, agentId, agentContext, false, "Task terminated before completion");
+                    CompleteTask(taskId, agentId, agentContext, task, false, "Task terminated before completion");
                 }
                 catch (Exception ex)
                 {
-                    CompleteTask(taskId, agentId, agentContext, false, $"Error: {ex.Message}");
+                    CompleteTask(taskId, agentId, agentContext, task, false, $"Error: {ex.Message}");
                 }
             });
             agentContext.ExecutionTask = executionTask;
@@ -689,7 +689,7 @@ Your decision:";
             }
         }
         
-        private void CompleteTask(string taskId, string agentId, SubAgentContext agentContext, bool success, string result)
+        private void CompleteTask(string taskId, string agentId, SubAgentContext agentContext, string description, bool success, string result)
         {
             DateTime? startedAt = null;
             var becameIdle = false;
@@ -719,6 +719,7 @@ Your decision:";
                 TaskId = taskId,
                 AgentId = agentId,
                 AgentName = agentContext.Name,
+                Description = description,
                 Success = success,
                 Result = result,
                 CompletedAt = DateTime.Now,

--- a/Agents/MultiAgent/Objects/AgentTaskResult.cs
+++ b/Agents/MultiAgent/Objects/AgentTaskResult.cs
@@ -11,6 +11,7 @@ namespace Saturn.Agents.MultiAgent.Objects
         public string TaskId { get; set; } = "";
         public string AgentId { get; set; } = "";
         public string AgentName { get; set; } = "";
+        public string Description { get; set; } = "";
         public bool Success { get; set; }
         public string Result { get; set; } = "";
         public DateTime CompletedAt { get; set; }

--- a/Web/WebServer.cs
+++ b/Web/WebServer.cs
@@ -184,6 +184,7 @@ namespace Saturn.Web
                     taskId,
                     result.AgentId,
                     result.AgentName,
+                    result.Description,
                     result.Success,
                     result.CompletedAt,
                     durationSeconds = result.Duration.TotalSeconds
@@ -323,6 +324,7 @@ namespace Saturn.Web
                         taskId = t.TaskId,
                         agentId = t.AgentId,
                         agentName = t.AgentName,
+                        description = t.Description,
                         success = t.Success,
                         result = t.Result,
                         completedAt = t.CompletedAt,

--- a/Web/wwwroot/app.js
+++ b/Web/wwwroot/app.js
@@ -158,6 +158,38 @@ function toast(html, ms = 3500) {
   }, ms);
 }
 
+// Approval toasts persist until the request is resolved (here, in the
+// Approvals view, from another client, or by timeout) — never auto-dismiss.
+function approvalToast(a) {
+  removeApprovalToast(a.id);
+  const el = document.createElement("div");
+  el.className = "toast approval-toast";
+  el.dataset.approvalId = a.id;
+  el.innerHTML = `
+    <div class="toast-title">⚑ Approval needed${a.agentName ? ` · ${esc(a.agentName)}` : ""}</div>
+    <div class="toast-body">${esc(a.title)}</div>
+    ${a.command ? `<div class="toast-command">${esc(a.command.slice(0, 160))}</div>` : ""}
+    <div class="toast-actions">
+      <button class="btn sm primary" data-act="approve">Approve</button>
+      <button class="btn sm danger" data-act="deny">Deny</button>
+      <button class="btn ghost sm" data-act="view">View</button>
+    </div>`;
+  el.querySelector('[data-act="approve"]').addEventListener("click", () => resolveApproval(a.id, true));
+  el.querySelector('[data-act="deny"]').addEventListener("click", () => resolveApproval(a.id, false));
+  el.querySelector('[data-act="view"]').addEventListener("click", () => {
+    removeApprovalToast(a.id);
+    showView("approvals");
+  });
+  $("#toasts").appendChild(el);
+}
+
+function removeApprovalToast(id) {
+  $$(`.approval-toast[data-approval-id="${CSS.escape(id)}"]`).forEach((el) => {
+    el.classList.add("out");
+    setTimeout(() => el.remove(), 350);
+  });
+}
+
 /* ---------- state ---------- */
 
 const state = {
@@ -1379,6 +1411,9 @@ function renderApprovals() {
 }
 
 async function resolveApproval(id, approved) {
+  // Drop the toast either way: on success the resolved event confirms it,
+  // and a failure means the request is already gone (timeout, other client).
+  removeApprovalToast(id);
   try {
     await api.post(`/approvals/${id}`, { approved });
     await Promise.all([loadApprovals(), loadOverview()]);
@@ -1831,12 +1866,13 @@ function connectEvents() {
     const d = JSON.parse(e.data);
     const what = d.command || d.title || "decision";
     logActivity(`approval requested: <b>${esc(what.slice(0, 60))}</b>`);
-    toast(`<b>Approval needed:</b> ${esc(what.slice(0, 80))}`, 6000);
+    if (state.view !== "approvals") approvalToast(d);
     refreshIf(["approvals"], [loadApprovals]);
   });
 
   es.addEventListener("approval.resolved", (e) => {
     const d = JSON.parse(e.data);
+    removeApprovalToast(d.id);
     logDecision(`${d.approved ? "approved" : "denied"} by <b>${esc(d.resolvedBy || "user")}</b>${d.command ? `: ${esc(d.command.slice(0, 70))}` : ""}${d.reason ? ` — ${esc(d.reason.slice(0, 80))}` : ""}`);
     refreshIf(["approvals"], [loadApprovals]);
   });

--- a/Web/wwwroot/app.js
+++ b/Web/wwwroot/app.js
@@ -257,7 +257,8 @@ async function refreshView(name) {
 // so refresh keeps your place and views are linkable.
 function currentRoute() {
   const parts = location.hash.replace(/^#\/?/, "").split("/");
-  const view = VIEW_TITLES[parts[0]] ? parts[0] : "orchestrator";
+  // hasOwnProperty, not truthiness: "#/constructor" must not pass the check.
+  const view = Object.prototype.hasOwnProperty.call(VIEW_TITLES, parts[0]) ? parts[0] : "orchestrator";
   const sub = view === "work" && WORK_TABS.includes(parts[1]) ? parts[1] : null;
   return { view, sub };
 }

--- a/Web/wwwroot/app.js
+++ b/Web/wwwroot/app.js
@@ -701,7 +701,7 @@ function renderTasks() {
       (t) => `
       <div class="task-row clickable" data-task="${esc(t.taskId)}">
         <span class="task-status ${t.success ? "done" : "failed"}">${t.success ? "done" : "failed"}</span>
-        <span class="task-desc">${esc(t.result.slice(0, 160))}</span>
+        <span class="task-desc" title="${esc(t.description || "")}">${esc(t.description || t.result.slice(0, 160))}</span>
         <span class="task-agent">${esc(t.agentName)}</span>
         <span class="task-time">${fmtDuration(t.durationSeconds)}</span>
       </div>`
@@ -718,6 +718,7 @@ function renderTasks() {
         <div class="kv"><span>Agent</span><span>${esc(t.agentName)} (${esc(t.agentId)})</span></div>
         <div class="kv"><span>Duration</span><span>${fmtDuration(t.durationSeconds)}</span></div>
         <div class="kv"><span>Finished</span><span>${new Date(t.completedAt).toLocaleString()}</span></div>
+        ${t.description ? `<div class="hint" style="margin-top:10px;white-space:pre-wrap">${esc(t.description)}</div>` : ""}
         <div class="result-pre md" id="task-result-md" style="margin-top:14px"></div>`
       );
       renderMarkdown($("#task-result-md"), t.result);
@@ -1916,8 +1917,9 @@ function connectEvents() {
 
   es.addEventListener("task.completed", (e) => {
     const d = JSON.parse(e.data);
-    logActivity(`task <b>${esc(d.taskId)}</b> ${d.success ? "completed" : "failed"} (${esc(d.agentName)})`);
-    toast(`Task <b>${esc(d.taskId)}</b> ${d.success ? "completed" : "<b>failed</b>"} — ${esc(d.agentName)}`);
+    const desc = d.description ? `: ${esc(d.description.slice(0, 60))}` : "";
+    logActivity(`task <b>${esc(d.taskId)}</b> ${d.success ? "completed" : "failed"} (${esc(d.agentName)})${desc}`);
+    toast(`Task ${d.success ? "completed" : "<b>failed</b>"} — ${esc(d.agentName)}${desc}`);
     refreshIf(["work", "agents"], [loadTasks, loadAgents]);
   });
 

--- a/Web/wwwroot/app.js
+++ b/Web/wwwroot/app.js
@@ -466,7 +466,12 @@ $("#agent-search").addEventListener("input", (e) => {
 });
 
 async function terminateAll() {
-  if (!confirm("Terminate all agents and clear completed tasks?")) return;
+  const ok = await confirmModal(
+    "Terminate all agents",
+    "Terminates every agent and clears completed tasks. Anything still running is lost.",
+    "Terminate all"
+  );
+  if (!ok) return;
   try {
     const r = await api.post("/agents/terminate-all");
     toast(`Terminated <b>${r.terminated}</b> agents`);
@@ -487,9 +492,35 @@ function openModal(title, bodyHtml) {
   $("#modal-backdrop").hidden = false;
 }
 
+// Set by confirmModal so dismissing any way (✕, backdrop, Escape) counts as "no".
+let onModalDismiss = null;
+
 function closeModal() {
   $("#modal-backdrop").hidden = true;
   $("#modal-body").innerHTML = "";
+  const cb = onModalDismiss;
+  onModalDismiss = null;
+  if (cb) cb();
+}
+
+function confirmModal(title, body, confirmLabel = "Confirm", danger = true) {
+  return new Promise((resolve) => {
+    openModal(
+      title,
+      `
+      <p style="font-size:13px;color:var(--muted);margin:0">${body}</p>
+      <div class="modal-actions">
+        <button class="btn" id="cf-cancel">Cancel</button>
+        <button class="btn ${danger ? "danger" : "primary"}" id="cf-ok">${esc(confirmLabel)}</button>
+      </div>`
+    );
+    onModalDismiss = () => resolve(false);
+    $("#cf-cancel").addEventListener("click", closeModal);
+    $("#cf-ok").addEventListener("click", () => {
+      resolve(true);
+      closeModal();
+    });
+  });
 }
 
 $("#modal-close").addEventListener("click", closeModal);
@@ -895,7 +926,13 @@ $("#chat-text").addEventListener("keydown", (e) => {
 $("#chat-cancel").addEventListener("click", () => api.post("/orchestrator/cancel").catch(() => {}));
 
 $("#chat-new").addEventListener("click", async () => {
-  if (!confirm("Start a fresh conversation? The current chat context is closed (history stays in Sessions).")) return;
+  const ok = await confirmModal(
+    "Start a fresh conversation?",
+    "The current chat context is closed. History stays available in Sessions.",
+    "New chat",
+    false
+  );
+  if (!ok) return;
   try {
     await api.post("/orchestrator/new-session");
   } catch (err) {
@@ -1787,9 +1824,16 @@ $("#setting-approval").addEventListener("change", (e) =>
 );
 
 $("#setting-trust").addEventListener("change", async (e) => {
-  if (e.target.checked && !confirm("Trust mode auto-approves EVERY shell command from every agent. Enable?")) {
-    e.target.checked = false;
-    return;
+  if (e.target.checked) {
+    const ok = await confirmModal(
+      "Enable trust mode",
+      "Trust mode auto-approves EVERY shell command from every agent, with no review.",
+      "Enable trust mode"
+    );
+    if (!ok) {
+      e.target.checked = false;
+      return;
+    }
   }
   await putSetting({ trustMode: e.target.checked },
     e.target.checked ? "<b>Trust mode ON</b> — all commands auto-approve" : "Trust mode off");

--- a/Web/wwwroot/app.js
+++ b/Web/wwwroot/app.js
@@ -202,9 +202,9 @@ function showView(name) {
 
 async function refreshView(name) {
   try {
-    if (name === "overview") { await loadOverview(); await loadWakes(); }
+    if (name === "overview") await loadOverview();
     else if (name === "agents") await loadAgents();
-    else if (name === "work") await Promise.all([loadTodos(), loadTasks()]);
+    else if (name === "work") await Promise.all([loadTodos(), loadTasks(), loadWakes()]);
     else if (name === "orchestrator") await loadTranscript();
     else if (name === "sessions") await loadSessions();
     else if (name === "approvals") await loadApprovals();
@@ -633,10 +633,11 @@ $("#btn-clear-tasks").addEventListener("click", async () => {
 function showWorkTab(tab) {
   state.workTab = tab;
   $$("#work-tabs .seg-item").forEach((b) => b.classList.toggle("active", b.dataset.worktab === tab));
-  ["queue", "running", "history"].forEach((t) => {
+  ["queue", "running", "history", "schedule"].forEach((t) => {
     $(`#work-pane-${t}`).hidden = t !== tab;
   });
-  (tab === "queue" ? loadTodos() : loadTasks()).catch(() => {});
+  const load = tab === "queue" ? loadTodos : tab === "schedule" ? loadWakes : loadTasks;
+  load().catch(() => {});
 }
 
 $("#work-tabs").addEventListener("click", (e) => {
@@ -1803,14 +1804,14 @@ function connectEvents() {
   es.addEventListener("agents.cleared", () => refreshIf(["agents", "work"], [loadAgents, loadTasks]));
   es.addEventListener("tasks.cleared", () => refreshIf(["work"], [loadTasks]));
   es.addEventListener("todos.changed", () => refreshIf(["work"], [loadTodos]));
-  es.addEventListener("tasks.changed", () => refreshIf(["work", "overview"], [loadTodos, loadWakes]));
+  es.addEventListener("tasks.changed", () => refreshIf(["work"], [loadTodos, loadWakes]));
   es.addEventListener("settings.changed", () => refreshIf(["settings"], [loadSettings]));
   es.addEventListener("wake.enqueued", (e) => {
     const d = JSON.parse(e.data);
     logActivity(`wake queued: <b>${esc(d.kind)}</b>${d.taskId ? ` (${esc(d.taskId)})` : ""}`);
-    refreshIf(["overview"], [loadWakes]);
+    refreshIf(["work"], [loadWakes]);
   });
-  es.addEventListener("wake.delivered", () => refreshIf(["overview"], [loadWakes]));
+  es.addEventListener("wake.delivered", () => refreshIf(["work"], [loadWakes]));
   es.addEventListener("task.due", (e) => {
     const d = JSON.parse(e.data);
     logActivity(`recurring task due: <b>${esc(d.title)}</b>${d.skipped ? " (skipped)" : ""}`);

--- a/Web/wwwroot/app.js
+++ b/Web/wwwroot/app.js
@@ -195,6 +195,7 @@ function removeApprovalToast(id) {
 const state = {
   view: "orchestrator",
   workTab: "queue",
+  chatWindow: 20,
   overview: null,
   agents: [],
   tasks: { running: [], completed: [] },
@@ -934,12 +935,29 @@ function buildToolStrip(tools) {
   return details;
 }
 
+/* Only a window of recent messages lives in the DOM. While following the
+   bottom the window trims back to CHAT_WINDOW (older nodes are disposed);
+   scrolling toward the top restores CHAT_WINDOW_STEP more at a time, starting
+   CHAT_LOAD_MARGIN px before the rendered history runs out. */
+const CHAT_WINDOW = 20;
+const CHAT_WINDOW_STEP = 20;
+const CHAT_LOAD_MARGIN = 800;
+
 function renderTranscript(opts = {}) {
   // Compute stickiness before wiping the log — the wipe changes scrollHeight.
   const stick = opts.stick ?? isNearBottom();
+  if (stick) state.chatWindow = CHAT_WINDOW;
   const log = $("#chat-log");
   log.innerHTML = "";
-  for (const e of state.transcript) {
+  const hidden = Math.max(0, state.transcript.length - state.chatWindow);
+  if (hidden > 0) {
+    const older = document.createElement("button");
+    older.className = "chat-older";
+    older.textContent = `↑ ${hidden} earlier message${hidden === 1 ? "" : "s"}`;
+    older.addEventListener("click", growChatWindow);
+    log.appendChild(older);
+  }
+  for (const e of state.transcript.slice(-state.chatWindow)) {
     if (e.role === "task") {
       const card = document.createElement("details");
       card.className = `chat-task${e.success === false ? " failed" : ""}`;
@@ -972,6 +990,25 @@ function renderTranscript(opts = {}) {
   }
   if (stick) scrollChatToBottom();
 }
+
+function growChatWindow() {
+  if (state.chatWindow >= state.transcript.length) return;
+  const scroll = $("#chat-scroll");
+  const prevHeight = scroll.scrollHeight;
+  const prevTop = scroll.scrollTop;
+  state.chatWindow = Math.min(state.transcript.length, state.chatWindow + CHAT_WINDOW_STEP);
+  renderTranscript({ stick: false });
+  // Older content was prepended; offset by the height it added so the
+  // message the user was looking at stays put.
+  scroll.scrollTop = prevTop + (scroll.scrollHeight - prevHeight);
+}
+
+$("#chat-scroll").addEventListener("scroll", () => {
+  const scroll = $("#chat-scroll");
+  if (scroll.scrollTop < CHAT_LOAD_MARGIN && state.chatWindow < state.transcript.length) {
+    growChatWindow();
+  }
+});
 
 let workingSince = null;
 let workingTimer = null;

--- a/Web/wwwroot/app.js
+++ b/Web/wwwroot/app.js
@@ -873,10 +873,14 @@ function scheduleStreamRender() {
   streamRenderPending = true;
   setTimeout(() => {
     streamRenderPending = false;
+    // Capture stickiness before the render grows the scroll height. The
+    // stream bubble can grow up to its 300px inner cap between renders, so
+    // the follow margin must exceed that or following silently stops.
+    const stick = isNearBottom(340);
     const el = $("#chat-stream-text");
     renderMarkdown(el, streamBuffer);
     el.scrollTop = el.scrollHeight;
-    scrollChatToBottom();
+    if (stick) scrollChatToBottom();
   }, 80);
 }
 
@@ -885,11 +889,18 @@ function scrollChatToBottom() {
   scroll.scrollTop = scroll.scrollHeight;
 }
 
+// "Following" the conversation means the user is within `margin` px of the
+// bottom; anyone who scrolled up to read history is left alone.
+function isNearBottom(margin = 160) {
+  const scroll = $("#chat-scroll");
+  return scroll.scrollHeight - scroll.scrollTop - scroll.clientHeight < margin;
+}
+
 async function loadTranscript() {
   const t = await api.get("/orchestrator/transcript");
   state.transcript = t.entries;
   setOrchestratorBusy(t.busy);
-  renderTranscript();
+  renderTranscript({ stick: true });
 }
 
 function summarizeToolArgs(argsJson) {
@@ -923,7 +934,9 @@ function buildToolStrip(tools) {
   return details;
 }
 
-function renderTranscript() {
+function renderTranscript(opts = {}) {
+  // Compute stickiness before wiping the log — the wipe changes scrollHeight.
+  const stick = opts.stick ?? isNearBottom();
   const log = $("#chat-log");
   log.innerHTML = "";
   for (const e of state.transcript) {
@@ -957,7 +970,7 @@ function renderTranscript() {
     }
     log.appendChild(div);
   }
-  scrollChatToBottom();
+  if (stick) scrollChatToBottom();
 }
 
 let workingSince = null;
@@ -976,7 +989,7 @@ function setOrchestratorBusy(busy) {
   if (busy) {
     if (!workingSince) workingSince = Date.now();
     $("#chat-stream").hidden = false;
-    scrollChatToBottom();
+    if (isNearBottom(340)) scrollChatToBottom();
     updateWorkingLabel();
     if (!workingTimer) workingTimer = setInterval(updateWorkingLabel, 1000);
   } else {
@@ -993,7 +1006,8 @@ function setOrchestratorBusy(busy) {
 let currentTurnTools = [];
 
 function renderToolLog() {
-  $("#tool-log").innerHTML = currentTurnTools
+  const el = $("#tool-log");
+  el.innerHTML = currentTurnTools
     .map(
       (t, i) => `
       <div class="tool-row ${i === currentTurnTools.length - 1 ? "latest" : ""}">
@@ -1002,6 +1016,7 @@ function renderToolLog() {
       </div>`
     )
     .join("");
+  el.scrollTop = el.scrollHeight;
 }
 
 $("#chat-form").addEventListener("submit", async (e) => {
@@ -1013,7 +1028,7 @@ $("#chat-form").addEventListener("submit", async (e) => {
   // server round-trip; the SSE echo confirms it (or the catch rolls it back).
   const entry = { role: "user", content: message, optimistic: true };
   state.transcript.push(entry);
-  renderTranscript();
+  renderTranscript({ stick: true });
   currentTurnTools = [];
   setOrchestratorBusy(true);
   $("#chat-text").value = "";
@@ -2176,7 +2191,7 @@ function connectEvents() {
     state.transcript = [];
     currentTurnTools = [];
     setOrchestratorBusy(false);
-    if (state.view === "orchestrator") renderTranscript();
+    if (state.view === "orchestrator") renderTranscript({ stick: true });
     toast("Started a <b>new conversation</b>");
   });
 

--- a/Web/wwwroot/app.js
+++ b/Web/wwwroot/app.js
@@ -272,6 +272,37 @@ window.addEventListener("hashchange", () => {
   if (sub && sub !== state.workTab) showWorkTab(sub);
 });
 
+/* ---------- keyboard shortcuts ---------- */
+
+// 1-7 jump between views (nav order); "/" focuses the view's main input.
+// Disabled while typing or while a modal/drawer is open.
+const VIEW_ORDER = ["orchestrator", "overview", "agents", "work", "sessions", "approvals", "settings"];
+
+document.addEventListener("keydown", (e) => {
+  if (e.ctrlKey || e.metaKey || e.altKey) return;
+  const t = e.target;
+  if (t.matches?.("input, textarea, select") || t.isContentEditable) return;
+  if (!$("#modal-backdrop").hidden || !$("#drawer-backdrop").hidden) return;
+
+  const idx = Number(e.key) - 1;
+  if (e.key >= "1" && e.key <= "7" && VIEW_ORDER[idx]) {
+    showView(VIEW_ORDER[idx]);
+    return;
+  }
+  if (e.key === "/") {
+    const target =
+      state.view === "orchestrator" ? $("#chat-text")
+      : state.view === "agents" ? $("#agent-search")
+      : state.view === "work" ? $("#todo-title")
+      : null;
+    // offsetParent is null for inputs inside a hidden work pane.
+    if (target && target.offsetParent !== null) {
+      e.preventDefault();
+      target.focus();
+    }
+  }
+});
+
 $$(".nav-item").forEach((b) => b.addEventListener("click", () => showView(b.dataset.view)));
 $$("[data-goto]").forEach((el) =>
   el.addEventListener("click", () => {

--- a/Web/wwwroot/app.js
+++ b/Web/wwwroot/app.js
@@ -528,7 +528,29 @@ $("#modal-backdrop").addEventListener("mousedown", (e) => {
   if (e.target === $("#modal-backdrop")) closeModal();
 });
 document.addEventListener("keydown", (e) => {
-  if (e.key === "Escape" && !$("#modal-backdrop").hidden) closeModal();
+  if (e.key !== "Escape") return;
+  if (!$("#modal-backdrop").hidden) closeModal();
+  else if (!$("#drawer-backdrop").hidden) closeDrawer();
+});
+
+/* ---------- drawer (transcripts and other long reads) ---------- */
+
+function openDrawer(title, sub) {
+  $("#drawer-title").textContent = title;
+  $("#drawer-sub").textContent = sub || "";
+  $("#drawer-body").innerHTML = "";
+  $("#drawer-backdrop").hidden = false;
+  return $("#drawer-body");
+}
+
+function closeDrawer() {
+  $("#drawer-backdrop").hidden = true;
+  $("#drawer-body").innerHTML = "";
+}
+
+$("#drawer-close").addEventListener("click", closeDrawer);
+$("#drawer-backdrop").addEventListener("mousedown", (e) => {
+  if (e.target === $("#drawer-backdrop")) closeDrawer();
 });
 
 async function ensureModels() {
@@ -1422,35 +1444,40 @@ function renderSessions() {
     .join("");
 
   $$("[data-session]").forEach((row) =>
-    row.addEventListener("click", async () => {
-      const id = row.dataset.session;
-      try {
-        const messages = await api.get(`/sessions/${id}/messages`);
-        openModal(
-          "Session transcript",
-          `<div class="msg-view">${messages
-            .map(
-              (m, i) => `
-              <div class="msg-row">
-                <div class="msg-role">${esc(m.role)}${m.agentName ? ` · ${esc(m.agentName)}` : ""}</div>
-                <div class="msg-content${m.role === "assistant" ? " md" : ""}" data-msg-index="${i}"></div>
-              </div>`
-            )
-            .join("") || '<div class="hint">No messages in this session.</div>'}</div>`
-        );
-        $$("#modal-body [data-msg-index]").forEach((el) => {
-          const m = messages[Number(el.dataset.msgIndex)];
-          if (m.role === "assistant" && m.content !== "null") {
-            renderMarkdown(el, m.content);
-          } else {
-            el.textContent = m.content;
-          }
-        });
-      } catch (err) {
-        toast(`<b>Error:</b> ${esc(err.message)}`);
-      }
+    row.addEventListener("click", () => {
+      const s = state.sessions.find((x) => x.id === row.dataset.session);
+      if (s) openSessionDrawer(s);
     })
   );
+}
+
+async function openSessionDrawer(session) {
+  try {
+    const messages = await api.get(`/sessions/${session.id}/messages`);
+    const body = openDrawer(
+      session.title || session.id,
+      `${session.chatType}${session.agentName ? ` · ${session.agentName}` : ""} · ${new Date(session.updatedAt).toLocaleString()}`
+    );
+    body.innerHTML = `<div class="msg-view drawer-msgs">${messages
+      .map(
+        (m, i) => `
+        <div class="msg-row">
+          <div class="msg-role">${esc(m.role)}${m.agentName ? ` · ${esc(m.agentName)}` : ""}</div>
+          <div class="msg-content${m.role === "assistant" ? " md" : ""}" data-msg-index="${i}"></div>
+        </div>`
+      )
+      .join("") || '<div class="hint">No messages in this session.</div>'}</div>`;
+    body.querySelectorAll("[data-msg-index]").forEach((el) => {
+      const m = messages[Number(el.dataset.msgIndex)];
+      if (m.role === "assistant" && m.content !== "null") {
+        renderMarkdown(el, m.content);
+      } else {
+        el.textContent = m.content;
+      }
+    });
+  } catch (err) {
+    toast(`<b>Error:</b> ${esc(err.message)}`);
+  }
 }
 
 $("#btn-refresh-sessions").addEventListener("click", loadSessions);

--- a/Web/wwwroot/app.js
+++ b/Web/wwwroot/app.js
@@ -876,7 +876,13 @@ function scheduleStreamRender() {
     const el = $("#chat-stream-text");
     renderMarkdown(el, streamBuffer);
     el.scrollTop = el.scrollHeight;
+    scrollChatToBottom();
   }, 80);
+}
+
+function scrollChatToBottom() {
+  const scroll = $("#chat-scroll");
+  scroll.scrollTop = scroll.scrollHeight;
 }
 
 async function loadTranscript() {
@@ -951,7 +957,7 @@ function renderTranscript() {
     }
     log.appendChild(div);
   }
-  log.scrollTop = log.scrollHeight;
+  scrollChatToBottom();
 }
 
 let workingSince = null;
@@ -970,6 +976,7 @@ function setOrchestratorBusy(busy) {
   if (busy) {
     if (!workingSince) workingSince = Date.now();
     $("#chat-stream").hidden = false;
+    scrollChatToBottom();
     updateWorkingLabel();
     if (!workingTimer) workingTimer = setInterval(updateWorkingLabel, 1000);
   } else {

--- a/Web/wwwroot/app.js
+++ b/Web/wwwroot/app.js
@@ -576,10 +576,37 @@ $("#qa-terminate-all").addEventListener("click", terminateAll);
 
 /* ---------- modals ---------- */
 
+/* Overlays move focus in on open, trap Tab inside, and hand focus back to
+   the element that opened them on close. */
+const FOCUSABLE = "button, [href], input, select, textarea, [tabindex]:not([tabindex='-1'])";
+let modalOpener = null;
+let drawerOpener = null;
+
+function trapTab(container, e) {
+  const items = [...container.querySelectorAll(FOCUSABLE)].filter((el) => el.offsetParent !== null);
+  if (!items.length) return;
+  const first = items[0];
+  const last = items[items.length - 1];
+  if (e.shiftKey && document.activeElement === first) {
+    e.preventDefault();
+    last.focus();
+  } else if (!e.shiftKey && document.activeElement === last) {
+    e.preventDefault();
+    first.focus();
+  }
+}
+
+function restoreFocus(opener) {
+  if (opener?.isConnected) opener.focus();
+}
+
 function openModal(title, bodyHtml) {
+  modalOpener = document.activeElement;
   $("#modal-title").textContent = title;
   $("#modal-body").innerHTML = bodyHtml;
   $("#modal-backdrop").hidden = false;
+  // Callers that focus a specific field afterwards win — this is the default.
+  ($("#modal-body").querySelector(FOCUSABLE) || $("#modal-close")).focus();
 }
 
 // Set by confirmModal so dismissing any way (✕, backdrop, Escape) counts as "no".
@@ -588,6 +615,8 @@ let onModalDismiss = null;
 function closeModal() {
   $("#modal-backdrop").hidden = true;
   $("#modal-body").innerHTML = "";
+  restoreFocus(modalOpener);
+  modalOpener = null;
   const cb = onModalDismiss;
   onModalDismiss = null;
   if (cb) cb();
@@ -619,23 +648,35 @@ $("#modal-backdrop").addEventListener("mousedown", (e) => {
 });
 document.addEventListener("keydown", (e) => {
   if (e.key !== "Escape") return;
-  if (!$("#modal-backdrop").hidden) closeModal();
+  if ($("#todo-menu")) closeTodoMenu();
+  else if (!$("#modal-backdrop").hidden) closeModal();
   else if (!$("#drawer-backdrop").hidden) closeDrawer();
+});
+
+$("#modal-backdrop").addEventListener("keydown", (e) => {
+  if (e.key === "Tab") trapTab($("#modal"), e);
+});
+$("#drawer-backdrop").addEventListener("keydown", (e) => {
+  if (e.key === "Tab") trapTab($("#drawer"), e);
 });
 
 /* ---------- drawer (transcripts and other long reads) ---------- */
 
 function openDrawer(title, sub) {
+  drawerOpener = document.activeElement;
   $("#drawer-title").textContent = title;
   $("#drawer-sub").textContent = sub || "";
   $("#drawer-body").innerHTML = "";
   $("#drawer-backdrop").hidden = false;
+  $("#drawer-close").focus();
   return $("#drawer-body");
 }
 
 function closeDrawer() {
   $("#drawer-backdrop").hidden = true;
   $("#drawer-body").innerHTML = "";
+  restoreFocus(drawerOpener);
+  drawerOpener = null;
 }
 
 $("#drawer-close").addEventListener("click", closeDrawer);
@@ -1269,14 +1310,29 @@ function openTodoMenu(anchor, taskId) {
   menu.className = "popmenu";
   menu.id = "todo-menu";
   menu.dataset.taskId = taskId;
+  menu.setAttribute("role", "menu");
   menu.innerHTML = `
-    <button data-menu="detail">Details</button>
-    <button data-menu="edit">Edit</button>
-    <button data-menu="delete" class="danger">Delete</button>`;
+    <button role="menuitem" data-menu="detail">Details</button>
+    <button role="menuitem" data-menu="edit">Edit</button>
+    <button role="menuitem" data-menu="delete" class="danger">Delete</button>`;
+  menu.addEventListener("keydown", (e) => {
+    const items = [...menu.querySelectorAll("button")];
+    const idx = items.indexOf(document.activeElement);
+    if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+      e.preventDefault();
+      const dir = e.key === "ArrowDown" ? 1 : -1;
+      items[(idx + dir + items.length) % items.length].focus();
+    } else if (e.key === "Escape") {
+      e.stopPropagation();
+      closeTodoMenu();
+      anchor.focus();
+    }
+  });
   document.body.appendChild(menu);
   const r = anchor.getBoundingClientRect();
   menu.style.top = `${Math.min(r.bottom + 4, window.innerHeight - menu.offsetHeight - 8)}px`;
   menu.style.left = `${Math.min(r.right - menu.offsetWidth, window.innerWidth - menu.offsetWidth - 8)}px`;
+  menu.querySelector("button").focus();
   menu.querySelector('[data-menu="detail"]').addEventListener("click", () => { closeTodoMenu(); openTaskDetail(taskId); });
   menu.querySelector('[data-menu="edit"]').addEventListener("click", () => { closeTodoMenu(); openTaskModal(taskId); });
   menu.querySelector('[data-menu="delete"]').addEventListener("click", async () => {

--- a/Web/wwwroot/app.js
+++ b/Web/wwwroot/app.js
@@ -241,7 +241,7 @@ async function refreshView(name) {
     if (name === "overview") await loadOverview();
     else if (name === "agents") await loadAgents();
     else if (name === "work") await Promise.all([loadTodos(), loadTasks(), loadWakes()]);
-    else if (name === "orchestrator") await Promise.all([loadTranscript(), loadAgents(), loadTasks()]);
+    else if (name === "orchestrator") await Promise.all([loadTranscript(), loadAgents(), loadTasks(), loadTodos()]);
     else if (name === "sessions") await loadSessions();
     else if (name === "approvals") await loadApprovals();
     else if (name === "settings") await loadSettings();
@@ -402,6 +402,12 @@ function renderRail() {
     .slice(0, 6)
     .map((t) => `<li title="${esc(t.description)}"><span class="status-dot working"></span><span>${esc(t.description)}</span></li>`)
     .join("") || '<li class="rail-empty">idle</li>';
+  const openTodos = state.todos.filter((t) => !isTerminal(t.status));
+  $("#rail-queue").textContent = state.overview?.todos.open ?? openTodos.length;
+  $("#rail-queue-list").innerHTML = openTodos
+    .slice(0, 6)
+    .map((t) => `<li title="${esc(t.title)}"><span class="rail-pri ${esc(t.priority)}"></span><span>${esc(t.title)}</span></li>`)
+    .join("") || '<li class="rail-empty">nothing queued</li>';
   $("#rail-activity").innerHTML = state.activity
     .slice(0, 10)
     .map((a) => `<li>${a.html}</li>`)
@@ -1058,6 +1064,7 @@ async function loadTodos() {
   state.todos = await api.get(`/todos?${params}`);
   await loadBoards();
   renderTodos();
+  renderRail();
 }
 
 async function loadBoards() {
@@ -2069,8 +2076,8 @@ function connectEvents() {
 
   es.addEventListener("agents.cleared", () => refreshIf(["agents", "work", "orchestrator"], [loadAgents, loadTasks]));
   es.addEventListener("tasks.cleared", () => refreshIf(["work"], [loadTasks]));
-  es.addEventListener("todos.changed", () => refreshIf(["work"], [loadTodos]));
-  es.addEventListener("tasks.changed", () => refreshIf(["work"], [loadTodos, loadWakes]));
+  es.addEventListener("todos.changed", () => refreshIf(["work", "orchestrator"], [loadTodos]));
+  es.addEventListener("tasks.changed", () => refreshIf(["work", "orchestrator"], [loadTodos, loadWakes]));
   es.addEventListener("settings.changed", () => refreshIf(["settings"], [loadSettings]));
   es.addEventListener("wake.enqueued", (e) => {
     const d = JSON.parse(e.data);
@@ -2085,12 +2092,12 @@ function connectEvents() {
   es.addEventListener("task.unblocked", (e) => {
     const d = JSON.parse(e.data);
     logActivity(`task unblocked: <b>${esc(d.title)}</b>`);
-    refreshIf(["work"], [loadTodos]);
+    refreshIf(["work", "orchestrator"], [loadTodos]);
   });
   es.addEventListener("task.dispatched", (e) => {
     const d = JSON.parse(e.data);
     logActivity(`task <b>${esc(d.taskId)}</b> dispatched to <b>${esc(d.agentName)}</b>`);
-    refreshIf(["work", "agents"], [loadTodos, loadAgents]);
+    refreshIf(["work", "agents", "orchestrator"], [loadTodos, loadAgents]);
   });
 
   es.addEventListener("approval.requested", (e) => {

--- a/Web/wwwroot/app.js
+++ b/Web/wwwroot/app.js
@@ -1084,9 +1084,7 @@ function renderTodos() {
         ${state.todoScope === "all" ? `<span class="task-scope">${esc(t.scope)}${t.board !== "default" ? `/${esc(t.board)}` : ""}</span>` : ""}
         <button class="todo-pri ${esc(t.priority)}" data-id="${esc(t.id)}" data-pri="${esc(t.priority)}" title="cycle priority">${esc(t.priority)}</button>
         ${!isTerminal(t.status) && !t.dispatchedTo && !t.blocked ? `<button class="btn ghost sm" data-dispatch="${esc(t.id)}" title="hand off to an agent">▶</button>` : ""}
-        <button class="btn ghost sm" data-detail="${esc(t.id)}" title="details">ⓘ</button>
-        <button class="btn ghost sm" data-edit="${esc(t.id)}" title="edit">✎</button>
-        <button class="todo-del" data-del="${esc(t.id)}" title="delete">✕</button>
+        <button class="btn ghost sm" data-more="${esc(t.id)}" title="more actions">⋯</button>
       </li>`
     )
     .join("");
@@ -1147,17 +1145,53 @@ function renderTodos() {
     })
   );
 
-  $$("[data-edit]").forEach((b) => b.addEventListener("click", () => openTaskModal(b.dataset.edit)));
-  $$("[data-detail]").forEach((b) => b.addEventListener("click", () => openTaskDetail(b.dataset.detail)));
   $$("[data-dispatch]").forEach((b) => b.addEventListener("click", () => openDispatchModal(b.dataset.dispatch)));
-
-  $$("[data-del]").forEach((b) =>
-    b.addEventListener("click", async () => {
-      await api.del(`/todos/${b.dataset.del}`);
-      await Promise.all([loadTodos(), loadOverview()]);
-    })
-  );
+  $$("[data-more]").forEach((b) => b.addEventListener("click", (e) => {
+    e.stopPropagation();
+    openTodoMenu(b, b.dataset.more);
+  }));
 }
+
+/* ---------- todo overflow menu ---------- */
+
+function closeTodoMenu() {
+  $("#todo-menu")?.remove();
+}
+
+function openTodoMenu(anchor, taskId) {
+  if ($("#todo-menu")?.dataset.taskId === taskId) {
+    closeTodoMenu();
+    return;
+  }
+  closeTodoMenu();
+  const menu = document.createElement("div");
+  menu.className = "popmenu";
+  menu.id = "todo-menu";
+  menu.dataset.taskId = taskId;
+  menu.innerHTML = `
+    <button data-menu="detail">Details</button>
+    <button data-menu="edit">Edit</button>
+    <button data-menu="delete" class="danger">Delete</button>`;
+  document.body.appendChild(menu);
+  const r = anchor.getBoundingClientRect();
+  menu.style.top = `${Math.min(r.bottom + 4, window.innerHeight - menu.offsetHeight - 8)}px`;
+  menu.style.left = `${Math.min(r.right - menu.offsetWidth, window.innerWidth - menu.offsetWidth - 8)}px`;
+  menu.querySelector('[data-menu="detail"]').addEventListener("click", () => { closeTodoMenu(); openTaskDetail(taskId); });
+  menu.querySelector('[data-menu="edit"]').addEventListener("click", () => { closeTodoMenu(); openTaskModal(taskId); });
+  menu.querySelector('[data-menu="delete"]').addEventListener("click", async () => {
+    closeTodoMenu();
+    try {
+      await api.del(`/todos/${taskId}`);
+      await Promise.all([loadTodos(), loadOverview()]);
+    } catch (err) {
+      toast(`<b>Error:</b> ${esc(err.message)}`);
+    }
+  });
+}
+
+document.addEventListener("click", (e) => {
+  if (!e.target.closest("#todo-menu")) closeTodoMenu();
+});
 
 async function updateTodo(id, patch) {
   try {

--- a/Web/wwwroot/app.js
+++ b/Web/wwwroot/app.js
@@ -162,6 +162,7 @@ function toast(html, ms = 3500) {
 
 const state = {
   view: "overview",
+  workTab: "queue",
   overview: null,
   agents: [],
   tasks: { running: [], completed: [] },
@@ -184,9 +185,8 @@ const state = {
 const VIEW_TITLES = {
   overview: "Overview",
   agents: "Agents",
-  tasks: "Tasks",
+  work: "Work",
   orchestrator: "Orchestrator",
-  todos: "Todo List",
   sessions: "Sessions",
   approvals: "Approvals",
   settings: "Settings",
@@ -204,9 +204,8 @@ async function refreshView(name) {
   try {
     if (name === "overview") { await loadOverview(); await loadWakes(); }
     else if (name === "agents") await loadAgents();
-    else if (name === "tasks") await loadTasks();
+    else if (name === "work") await Promise.all([loadTodos(), loadTasks()]);
     else if (name === "orchestrator") await loadTranscript();
-    else if (name === "todos") await loadTodos();
     else if (name === "sessions") await loadSessions();
     else if (name === "approvals") await loadApprovals();
     else if (name === "settings") await loadSettings();
@@ -216,7 +215,12 @@ async function refreshView(name) {
 }
 
 $$(".nav-item").forEach((b) => b.addEventListener("click", () => showView(b.dataset.view)));
-$$("[data-goto]").forEach((el) => el.addEventListener("click", () => showView(el.dataset.goto)));
+$$("[data-goto]").forEach((el) =>
+  el.addEventListener("click", () => {
+    showView(el.dataset.goto);
+    if (el.dataset.gotoTab) showWorkTab(el.dataset.gotoTab);
+  })
+);
 
 /* ---------- activity feed ---------- */
 
@@ -280,9 +284,10 @@ function updateBadges() {
   const o = state.overview;
   if (!o) return;
   setBadge("#badge-agents", o.agents.total);
-  setBadge("#badge-tasks", o.tasks.running);
-  setBadge("#badge-todos", o.todos.open);
+  setBadge("#badge-work", o.todos.open);
   setBadge("#badge-approvals", o.pendingApprovals);
+  $("#workcount-queue").textContent = o.todos.open || "";
+  $("#workcount-running").textContent = o.tasks.running || "";
 }
 
 function setBadge(sel, value) {
@@ -575,7 +580,6 @@ async function loadTasks() {
 
 function renderTasks() {
   const { running, completed } = state.tasks;
-  $("#tasks-empty").classList.toggle("show", running.length === 0 && completed.length === 0);
 
   $("#task-running").innerHTML = running
     .map(
@@ -622,6 +626,22 @@ $("#btn-clear-tasks").addEventListener("click", async () => {
   await api.post("/tasks/clear-completed");
   await Promise.all([loadTasks(), loadOverview()]);
   toast("Completed tasks cleared");
+});
+
+/* ---------- work sub-tabs ---------- */
+
+function showWorkTab(tab) {
+  state.workTab = tab;
+  $$("#work-tabs .seg-item").forEach((b) => b.classList.toggle("active", b.dataset.worktab === tab));
+  ["queue", "running", "history"].forEach((t) => {
+    $(`#work-pane-${t}`).hidden = t !== tab;
+  });
+  (tab === "queue" ? loadTodos() : loadTasks()).catch(() => {});
+}
+
+$("#work-tabs").addEventListener("click", (e) => {
+  const btn = e.target.closest(".seg-item");
+  if (btn) showWorkTab(btn.dataset.worktab);
 });
 
 /* ---------- orchestrator ---------- */
@@ -1770,20 +1790,20 @@ function connectEvents() {
   es.addEventListener("agent.status", (e) => {
     const d = JSON.parse(e.data);
     logActivity(`<b>${esc(d.name)}</b> → ${esc(d.status)}`);
-    refreshIf(["agents", "tasks"], [loadAgents, loadTasks]);
+    refreshIf(["agents", "work"], [loadAgents, loadTasks]);
   });
 
   es.addEventListener("task.completed", (e) => {
     const d = JSON.parse(e.data);
     logActivity(`task <b>${esc(d.taskId)}</b> ${d.success ? "completed" : "failed"} (${esc(d.agentName)})`);
     toast(`Task <b>${esc(d.taskId)}</b> ${d.success ? "completed" : "<b>failed</b>"} — ${esc(d.agentName)}`);
-    refreshIf(["tasks", "agents"], [loadTasks, loadAgents]);
+    refreshIf(["work", "agents"], [loadTasks, loadAgents]);
   });
 
-  es.addEventListener("agents.cleared", () => refreshIf(["agents", "tasks"], [loadAgents, loadTasks]));
-  es.addEventListener("tasks.cleared", () => refreshIf(["tasks"], [loadTasks]));
-  es.addEventListener("todos.changed", () => refreshIf(["todos"], [loadTodos]));
-  es.addEventListener("tasks.changed", () => refreshIf(["todos", "overview"], [loadTodos, loadWakes]));
+  es.addEventListener("agents.cleared", () => refreshIf(["agents", "work"], [loadAgents, loadTasks]));
+  es.addEventListener("tasks.cleared", () => refreshIf(["work"], [loadTasks]));
+  es.addEventListener("todos.changed", () => refreshIf(["work"], [loadTodos]));
+  es.addEventListener("tasks.changed", () => refreshIf(["work", "overview"], [loadTodos, loadWakes]));
   es.addEventListener("settings.changed", () => refreshIf(["settings"], [loadSettings]));
   es.addEventListener("wake.enqueued", (e) => {
     const d = JSON.parse(e.data);
@@ -1798,12 +1818,12 @@ function connectEvents() {
   es.addEventListener("task.unblocked", (e) => {
     const d = JSON.parse(e.data);
     logActivity(`task unblocked: <b>${esc(d.title)}</b>`);
-    refreshIf(["todos"], [loadTodos]);
+    refreshIf(["work"], [loadTodos]);
   });
   es.addEventListener("task.dispatched", (e) => {
     const d = JSON.parse(e.data);
     logActivity(`task <b>${esc(d.taskId)}</b> dispatched to <b>${esc(d.agentName)}</b>`);
-    refreshIf(["todos", "agents"], [loadTodos, loadAgents]);
+    refreshIf(["work", "agents"], [loadTodos, loadAgents]);
   });
 
   es.addEventListener("approval.requested", (e) => {
@@ -1899,6 +1919,6 @@ function connectEvents() {
   setInterval(() => {
     loadOverview().catch(() => {});
     if (state.view === "agents") loadAgents().catch(() => {});
-    if (state.view === "tasks") loadTasks().catch(() => {});
+    if (state.view === "work") loadTasks().catch(() => {});
   }, 10000);
 })();

--- a/Web/wwwroot/app.js
+++ b/Web/wwwroot/app.js
@@ -229,6 +229,7 @@ function showView(name) {
   $$(".nav-item").forEach((b) => b.classList.toggle("active", b.dataset.view === name));
   $$(".view").forEach((v) => v.classList.toggle("active", v.id === `view-${name}`));
   $("#view-title").textContent = VIEW_TITLES[name] || name;
+  updateApprovalBanner();
   refreshView(name);
 }
 
@@ -320,7 +321,21 @@ function updateBadges() {
   setBadge("#badge-approvals", o.pendingApprovals);
   $("#workcount-queue").textContent = o.todos.open || "";
   $("#workcount-running").textContent = o.tasks.running || "";
+  updateApprovalBanner();
 }
+
+// Pending approvals block agents mid-run, so they get a persistent banner
+// on every view except Approvals itself (where the cards are already visible).
+function updateApprovalBanner() {
+  const n = state.overview?.pendingApprovals || 0;
+  const show = n > 0 && state.view !== "approvals";
+  $("#approval-banner").hidden = !show;
+  if (show) {
+    $("#approval-banner-text").textContent = `${n} ${n === 1 ? "request is" : "requests are"} waiting for your approval`;
+  }
+}
+
+$("#approval-banner-btn").addEventListener("click", () => showView("approvals"));
 
 function setBadge(sel, value) {
   const el = $(sel);

--- a/Web/wwwroot/app.js
+++ b/Web/wwwroot/app.js
@@ -193,7 +193,7 @@ function removeApprovalToast(id) {
 /* ---------- state ---------- */
 
 const state = {
-  view: "overview",
+  view: "orchestrator",
   workTab: "queue",
   overview: null,
   agents: [],
@@ -241,7 +241,7 @@ async function refreshView(name) {
     if (name === "overview") await loadOverview();
     else if (name === "agents") await loadAgents();
     else if (name === "work") await Promise.all([loadTodos(), loadTasks(), loadWakes()]);
-    else if (name === "orchestrator") await loadTranscript();
+    else if (name === "orchestrator") await Promise.all([loadTranscript(), loadAgents(), loadTasks()]);
     else if (name === "sessions") await loadSessions();
     else if (name === "approvals") await loadApprovals();
     else if (name === "settings") await loadSettings();
@@ -256,7 +256,7 @@ async function refreshView(name) {
 // so refresh keeps your place and views are linkable.
 function currentRoute() {
   const parts = location.hash.replace(/^#\/?/, "").split("/");
-  const view = VIEW_TITLES[parts[0]] ? parts[0] : "overview";
+  const view = VIEW_TITLES[parts[0]] ? parts[0] : "orchestrator";
   const sub = view === "work" && WORK_TABS.includes(parts[1]) ? parts[1] : null;
   return { view, sub };
 }
@@ -286,6 +286,7 @@ function logActivity(html) {
   state.activity.unshift({ time: new Date(), html });
   state.activity = state.activity.slice(0, 120);
   renderActivity();
+  renderRail();
 }
 
 function renderActivity() {
@@ -347,6 +348,33 @@ function updateBadges() {
   $("#workcount-queue").textContent = o.todos.open || "";
   $("#workcount-running").textContent = o.tasks.running || "";
   updateApprovalBanner();
+  renderRail();
+}
+
+// Live status rail beside the orchestrator chat: enough situational awareness
+// to command without tabbing away. Each section links to its full view.
+function renderRail() {
+  if (state.view !== "orchestrator") return;
+  const o = state.overview;
+  if (o) {
+    $("#rail-agents").textContent = o.agents.total;
+    $("#rail-running").textContent = o.tasks.running;
+    const approvals = $("#rail-approvals");
+    approvals.textContent = o.pendingApprovals;
+    approvals.classList.toggle("warn", o.pendingApprovals > 0);
+  }
+  $("#rail-agent-list").innerHTML = state.agents
+    .slice(0, 8)
+    .map((a) => `<li title="${esc(a.purpose)}"><span class="status-dot ${a.currentTask ? "working" : ""}"></span><span>${esc(a.name)}</span></li>`)
+    .join("") || '<li class="rail-empty">no agents</li>';
+  $("#rail-task-list").innerHTML = state.tasks.running
+    .slice(0, 6)
+    .map((t) => `<li title="${esc(t.description)}"><span class="status-dot working"></span><span>${esc(t.description)}</span></li>`)
+    .join("") || '<li class="rail-empty">idle</li>';
+  $("#rail-activity").innerHTML = state.activity
+    .slice(0, 10)
+    .map((a) => `<li>${a.html}</li>`)
+    .join("") || '<li class="rail-empty">quiet so far</li>';
 }
 
 // Pending approvals block agents mid-run, so they get a persistent banner
@@ -404,6 +432,7 @@ async function loadWakes() {
 async function loadAgents() {
   state.agents = await api.get("/agents");
   renderAgents();
+  renderRail();
 }
 
 function renderAgents() {
@@ -723,6 +752,7 @@ function openHandoffModal(agentId) {
 async function loadTasks() {
   state.tasks = await api.get("/tasks");
   renderTasks();
+  renderRail();
 }
 
 function renderTasks() {
@@ -1955,13 +1985,13 @@ function connectEvents() {
   es.addEventListener("agent.created", (e) => {
     const d = JSON.parse(e.data);
     logActivity(`agent <b>${esc(d.name)}</b> created`);
-    refreshIf(["agents"], [loadAgents]);
+    refreshIf(["agents", "orchestrator"], [loadAgents]);
   });
 
   es.addEventListener("agent.status", (e) => {
     const d = JSON.parse(e.data);
     logActivity(`<b>${esc(d.name)}</b> → ${esc(d.status)}`);
-    refreshIf(["agents", "work"], [loadAgents, loadTasks]);
+    refreshIf(["agents", "work", "orchestrator"], [loadAgents, loadTasks]);
   });
 
   es.addEventListener("task.completed", (e) => {
@@ -1969,10 +1999,10 @@ function connectEvents() {
     const desc = d.description ? `: ${esc(d.description.slice(0, 60))}` : "";
     logActivity(`task <b>${esc(d.taskId)}</b> ${d.success ? "completed" : "failed"} (${esc(d.agentName)})${desc}`);
     toast(`Task ${d.success ? "completed" : "<b>failed</b>"} — ${esc(d.agentName)}${desc}`);
-    refreshIf(["work", "agents"], [loadTasks, loadAgents]);
+    refreshIf(["work", "agents", "orchestrator"], [loadTasks, loadAgents]);
   });
 
-  es.addEventListener("agents.cleared", () => refreshIf(["agents", "work"], [loadAgents, loadTasks]));
+  es.addEventListener("agents.cleared", () => refreshIf(["agents", "work", "orchestrator"], [loadAgents, loadTasks]));
   es.addEventListener("tasks.cleared", () => refreshIf(["work"], [loadTasks]));
   es.addEventListener("todos.changed", () => refreshIf(["work"], [loadTodos]));
   es.addEventListener("tasks.changed", () => refreshIf(["work"], [loadTodos, loadWakes]));
@@ -2094,7 +2124,7 @@ function connectEvents() {
 
   setInterval(() => {
     loadOverview().catch(() => {});
-    if (state.view === "agents") loadAgents().catch(() => {});
-    if (state.view === "work") loadTasks().catch(() => {});
+    if (state.view === "agents" || state.view === "orchestrator") loadAgents().catch(() => {});
+    if (state.view === "work" || state.view === "orchestrator") loadTasks().catch(() => {});
   }, 10000);
 })();

--- a/Web/wwwroot/app.js
+++ b/Web/wwwroot/app.js
@@ -2139,7 +2139,7 @@ function connectEvents() {
   });
 
   es.addEventListener("agents.cleared", () => refreshIf(["agents", "work", "orchestrator"], [loadAgents, loadTasks]));
-  es.addEventListener("tasks.cleared", () => refreshIf(["work"], [loadTasks]));
+  es.addEventListener("tasks.cleared", () => refreshIf(["work", "orchestrator"], [loadTasks]));
   es.addEventListener("todos.changed", () => refreshIf(["work", "orchestrator"], [loadTodos]));
   es.addEventListener("tasks.changed", () => refreshIf(["work", "orchestrator"], [loadTodos, loadWakes]));
   es.addEventListener("settings.changed", () => refreshIf(["settings"], [loadSettings]));

--- a/Web/wwwroot/app.js
+++ b/Web/wwwroot/app.js
@@ -438,6 +438,7 @@ function renderAgents() {
         ${a.currentTask ? `<div class="agent-task" title="${esc(a.currentTask.description)}">${esc(a.currentTask.description)}</div>` : ""}
         <div class="agent-actions">
           <button class="btn sm" data-handoff="${esc(a.agentId)}" ${working ? "disabled" : ""}>Hand off</button>
+          <button class="btn sm" data-log="${esc(a.agentId)}" title="open this agent's transcript">Log</button>
           <button class="btn sm danger" data-terminate="${esc(a.agentId)}">Terminate</button>
         </div>
       </div>`;
@@ -446,6 +447,9 @@ function renderAgents() {
 
   $$("#agent-grid [data-handoff]").forEach((b) =>
     b.addEventListener("click", () => openHandoffModal(b.dataset.handoff))
+  );
+  $$("#agent-grid [data-log]").forEach((b) =>
+    b.addEventListener("click", () => openAgentTranscript(b.dataset.log))
   );
   $$("#agent-grid [data-terminate]").forEach((b) =>
     b.addEventListener("click", async () => {
@@ -464,6 +468,24 @@ $("#agent-search").addEventListener("input", (e) => {
   state.agentSearch = e.target.value;
   renderAgents();
 });
+
+// Sessions come back newest-first, so the first match is the agent's
+// latest conversation.
+async function openAgentTranscript(agentId) {
+  const agent = state.agents.find((a) => a.agentId === agentId);
+  if (!agent) return;
+  try {
+    const sessions = await api.get("/sessions?limit=100");
+    const session = sessions.find((s) => s.agentName === agent.name);
+    if (!session) {
+      toast(`No transcript for <b>${esc(agent.name)}</b> yet — it hasn't exchanged any messages`);
+      return;
+    }
+    await openSessionDrawer(session);
+  } catch (err) {
+    toast(`<b>Error:</b> ${esc(err.message)}`);
+  }
+}
 
 async function terminateAll() {
   const ok = await confirmModal(

--- a/Web/wwwroot/app.js
+++ b/Web/wwwroot/app.js
@@ -1704,13 +1704,14 @@ function renderApprovals() {
 }
 
 async function resolveApproval(id, approved) {
-  // Drop the toast either way: on success the resolved event confirms it,
-  // and a failure means the request is already gone (timeout, other client).
-  removeApprovalToast(id);
   try {
     await api.post(`/approvals/${id}`, { approved });
+    removeApprovalToast(id);
     await Promise.all([loadApprovals(), loadOverview()]);
   } catch (err) {
+    // 404 means it was already resolved elsewhere (or timed out) — stale
+    // either way. On transient failures keep the actions available.
+    if (err.status === 404) removeApprovalToast(id);
     toast(`<b>Error:</b> ${esc(err.message)}`);
   }
 }

--- a/Web/wwwroot/app.js
+++ b/Web/wwwroot/app.js
@@ -855,7 +855,7 @@ function showWorkTab(tab) {
   });
   syncHash();
   const load = tab === "queue" ? loadTodos : tab === "schedule" ? loadWakes : loadTasks;
-  load().catch(() => {});
+  load().catch((err) => toast(`<b>Error:</b> ${esc(err.message)}`));
 }
 
 $("#work-tabs").addEventListener("click", (e) => {

--- a/Web/wwwroot/app.js
+++ b/Web/wwwroot/app.js
@@ -1005,7 +1005,10 @@ function growChatWindow() {
 
 $("#chat-scroll").addEventListener("scroll", () => {
   const scroll = $("#chat-scroll");
-  if (scroll.scrollTop < CHAT_LOAD_MARGIN && state.chatWindow < state.transcript.length) {
+  // Both conditions matter: near the top AND away from the bottom. On a
+  // transcript shorter than the margin the two overlap, and without the
+  // second check sitting at the bottom would grow the window forever.
+  if (scroll.scrollTop < CHAT_LOAD_MARGIN && !isNearBottom(200) && state.chatWindow < state.transcript.length) {
     growChatWindow();
   }
 });

--- a/Web/wwwroot/app.js
+++ b/Web/wwwroot/app.js
@@ -224,12 +224,15 @@ const VIEW_TITLES = {
   settings: "Settings",
 };
 
+const WORK_TABS = ["queue", "running", "history", "schedule"];
+
 function showView(name) {
   state.view = name;
   $$(".nav-item").forEach((b) => b.classList.toggle("active", b.dataset.view === name));
   $$(".view").forEach((v) => v.classList.toggle("active", v.id === `view-${name}`));
   $("#view-title").textContent = VIEW_TITLES[name] || name;
   updateApprovalBanner();
+  syncHash();
   refreshView(name);
 }
 
@@ -246,6 +249,28 @@ async function refreshView(name) {
     toast(`<b>Error:</b> ${esc(err.message)}`);
   }
 }
+
+/* ---------- routing ---------- */
+
+// The view (and work sub-tab) live in the URL hash — #/agents, #/work/running —
+// so refresh keeps your place and views are linkable.
+function currentRoute() {
+  const parts = location.hash.replace(/^#\/?/, "").split("/");
+  const view = VIEW_TITLES[parts[0]] ? parts[0] : "overview";
+  const sub = view === "work" && WORK_TABS.includes(parts[1]) ? parts[1] : null;
+  return { view, sub };
+}
+
+function syncHash() {
+  const path = state.view === "work" ? `work/${state.workTab}` : state.view;
+  if (location.hash !== `#/${path}`) location.hash = `/${path}`;
+}
+
+window.addEventListener("hashchange", () => {
+  const { view, sub } = currentRoute();
+  if (view !== state.view) showView(view);
+  if (sub && sub !== state.workTab) showWorkTab(sub);
+});
 
 $$(".nav-item").forEach((b) => b.addEventListener("click", () => showView(b.dataset.view)));
 $$("[data-goto]").forEach((el) =>
@@ -680,9 +705,10 @@ $("#btn-clear-tasks").addEventListener("click", async () => {
 function showWorkTab(tab) {
   state.workTab = tab;
   $$("#work-tabs .seg-item").forEach((b) => b.classList.toggle("active", b.dataset.worktab === tab));
-  ["queue", "running", "history", "schedule"].forEach((t) => {
+  WORK_TABS.forEach((t) => {
     $(`#work-pane-${t}`).hidden = t !== tab;
   });
+  syncHash();
   const load = tab === "queue" ? loadTodos : tab === "schedule" ? loadWakes : loadTasks;
   load().catch(() => {});
 }
@@ -1965,7 +1991,10 @@ function connectEvents() {
 (async function boot() {
   connectEvents();
   await loadOverview().catch(() => {});
-  await refreshView(state.view);
+  const { view, sub } = currentRoute();
+  if (sub) state.workTab = sub;
+  showView(view);
+  if (view === "work") showWorkTab(state.workTab);
   ensureModels();
 
   setInterval(() => {

--- a/Web/wwwroot/index.html
+++ b/Web/wwwroot/index.html
@@ -64,6 +64,11 @@
         </div>
       </header>
 
+      <div class="approval-banner" id="approval-banner" hidden>
+        <span id="approval-banner-text">approvals waiting</span>
+        <button class="btn sm" id="approval-banner-btn">Review</button>
+      </div>
+
       <!-- OVERVIEW -->
       <section class="view active" id="view-overview">
         <div class="stat-grid">

--- a/Web/wwwroot/index.html
+++ b/Web/wwwroot/index.html
@@ -397,6 +397,19 @@
     </main>
   </div>
 
+  <div class="drawer-backdrop" id="drawer-backdrop" hidden>
+    <aside class="drawer">
+      <div class="drawer-head">
+        <div class="drawer-titles">
+          <h3 id="drawer-title">Transcript</h3>
+          <span class="drawer-sub" id="drawer-sub"></span>
+        </div>
+        <button class="btn ghost sm" id="drawer-close">✕</button>
+      </div>
+      <div class="drawer-body" id="drawer-body"></div>
+    </aside>
+  </div>
+
   <div class="modal-backdrop" id="modal-backdrop" hidden>
     <div class="modal" id="modal">
       <div class="modal-head">

--- a/Web/wwwroot/index.html
+++ b/Web/wwwroot/index.html
@@ -136,14 +136,16 @@
       <section class="view active" id="view-orchestrator">
         <div class="orch-layout">
         <div class="chat">
-          <div class="chat-log" id="chat-log"></div>
-          <div class="chat-stream" id="chat-stream" hidden>
-            <div class="chat-stream-head">
-              <span class="pulse-dot"></span>
-              <span id="working-label">assistant is working</span>
+          <div class="chat-scroll" id="chat-scroll">
+            <div class="chat-log" id="chat-log"></div>
+            <div class="chat-stream" id="chat-stream" hidden>
+              <div class="chat-stream-head">
+                <span class="pulse-dot"></span>
+                <span id="working-label">assistant is working</span>
+              </div>
+              <div class="tool-log" id="tool-log"></div>
+              <div class="md stream-md" id="chat-stream-text"></div>
             </div>
-            <div class="tool-log" id="tool-log"></div>
-            <div class="md stream-md" id="chat-stream-text"></div>
           </div>
           <form class="chat-input" id="chat-form">
             <textarea id="chat-text" rows="2" placeholder="Instruct the orchestrator… (Enter to send, Shift+Enter for newline)"></textarea>

--- a/Web/wwwroot/index.html
+++ b/Web/wwwroot/index.html
@@ -20,7 +20,10 @@
       </div>
 
       <nav class="nav">
-        <button class="nav-item active" data-view="overview">
+        <button class="nav-item active" data-view="orchestrator">
+          <span class="nav-icon">◈</span> Orchestrator
+        </button>
+        <button class="nav-item" data-view="overview">
           <span class="nav-icon">▣</span> Overview
         </button>
         <button class="nav-item" data-view="agents">
@@ -30,9 +33,6 @@
         <button class="nav-item" data-view="work">
           <span class="nav-icon">≡</span> Work
           <span class="nav-badge" id="badge-work">0</span>
-        </button>
-        <button class="nav-item" data-view="orchestrator">
-          <span class="nav-icon">◈</span> Orchestrator
         </button>
         <button class="nav-item" data-view="sessions">
           <span class="nav-icon">◷</span> Sessions
@@ -57,7 +57,7 @@
 
     <main class="main">
       <header class="topbar">
-        <h1 id="view-title">Overview</h1>
+        <h1 id="view-title">Orchestrator</h1>
         <div class="topbar-right">
           <span class="model-chip" id="model-chip">—</span>
           <span class="uptime" id="uptime-chip">up 0s</span>
@@ -70,7 +70,7 @@
       </div>
 
       <!-- OVERVIEW -->
-      <section class="view active" id="view-overview">
+      <section class="view" id="view-overview">
         <div class="stat-grid">
           <div class="stat-card" data-goto="agents">
             <div class="stat-value" id="stat-agents">0</div>
@@ -133,7 +133,8 @@
       </section>
 
       <!-- ORCHESTRATOR -->
-      <section class="view" id="view-orchestrator">
+      <section class="view active" id="view-orchestrator">
+        <div class="orch-layout">
         <div class="chat">
           <div class="chat-log" id="chat-log"></div>
           <div class="chat-stream" id="chat-stream" hidden>
@@ -152,6 +153,25 @@
               <button type="button" class="btn ghost sm" id="chat-new" title="start a fresh conversation">New chat</button>
             </div>
           </form>
+        </div>
+
+        <aside class="orch-rail">
+          <div class="rail-section" data-goto="agents">
+            <div class="rail-head"><span>Agents</span><span class="rail-count" id="rail-agents">0</span></div>
+            <ul class="rail-list" id="rail-agent-list"></ul>
+          </div>
+          <div class="rail-section" data-goto="work" data-goto-tab="running">
+            <div class="rail-head"><span>Running</span><span class="rail-count" id="rail-running">0</span></div>
+            <ul class="rail-list" id="rail-task-list"></ul>
+          </div>
+          <div class="rail-section" data-goto="approvals">
+            <div class="rail-head"><span>Approvals</span><span class="rail-count" id="rail-approvals">0</span></div>
+          </div>
+          <div class="rail-section rail-grow">
+            <div class="rail-head"><span>Activity</span></div>
+            <ul class="rail-list" id="rail-activity"></ul>
+          </div>
+        </aside>
         </div>
       </section>
 

--- a/Web/wwwroot/index.html
+++ b/Web/wwwroot/index.html
@@ -27,16 +27,12 @@
           <span class="nav-icon">⬡</span> Agents
           <span class="nav-badge" id="badge-agents">0</span>
         </button>
-        <button class="nav-item" data-view="tasks">
-          <span class="nav-icon">≡</span> Tasks
-          <span class="nav-badge" id="badge-tasks">0</span>
+        <button class="nav-item" data-view="work">
+          <span class="nav-icon">≡</span> Work
+          <span class="nav-badge" id="badge-work">0</span>
         </button>
         <button class="nav-item" data-view="orchestrator">
           <span class="nav-icon">◈</span> Orchestrator
-        </button>
-        <button class="nav-item" data-view="todos">
-          <span class="nav-icon">☑</span> Todo List
-          <span class="nav-badge" id="badge-todos">0</span>
         </button>
         <button class="nav-item" data-view="sessions">
           <span class="nav-icon">◷</span> Sessions
@@ -76,12 +72,12 @@
             <div class="stat-label">active agents</div>
             <div class="stat-sub" id="stat-agents-sub">0 working · max 0</div>
           </div>
-          <div class="stat-card" data-goto="tasks">
+          <div class="stat-card" data-goto="work" data-goto-tab="running">
             <div class="stat-value" id="stat-running">0</div>
             <div class="stat-label">tasks running</div>
             <div class="stat-sub" id="stat-tasks-sub">0 done · 0 failed</div>
           </div>
-          <div class="stat-card" data-goto="todos">
+          <div class="stat-card" data-goto="work">
             <div class="stat-value" id="stat-todos">0</div>
             <div class="stat-label">open todos</div>
             <div class="stat-sub" id="stat-todos-sub">0 completed</div>
@@ -135,21 +131,6 @@
         <div class="empty" id="agents-empty">No agents running. Spawn one to get started.</div>
       </section>
 
-      <!-- TASKS -->
-      <section class="view" id="view-tasks">
-        <div class="toolbar">
-          <span class="toolbar-title">Running</span>
-          <div class="toolbar-spacer"></div>
-          <button class="btn" id="btn-clear-tasks">Clear completed</button>
-        </div>
-        <div class="task-list" id="task-running"></div>
-        <div class="toolbar">
-          <span class="toolbar-title">Completed</span>
-        </div>
-        <div class="task-list" id="task-completed"></div>
-        <div class="empty" id="tasks-empty">No tasks yet. Hand work off to an agent.</div>
-      </section>
-
       <!-- ORCHESTRATOR -->
       <section class="view" id="view-orchestrator">
         <div class="chat">
@@ -173,8 +154,17 @@
         </div>
       </section>
 
-      <!-- TODOS / TASK MANAGER -->
-      <section class="view" id="view-todos">
+      <!-- WORK: queue (todos), running dispatches, history -->
+      <section class="view" id="view-work">
+        <div class="toolbar">
+          <div class="seg work-tabs" id="work-tabs">
+            <button class="seg-item active" data-worktab="queue">Queue <span class="seg-count" id="workcount-queue"></span></button>
+            <button class="seg-item" data-worktab="running">Running <span class="seg-count" id="workcount-running"></span></button>
+            <button class="seg-item" data-worktab="history">History</button>
+          </div>
+        </div>
+
+        <div class="work-pane" id="work-pane-queue">
         <div class="toolbar">
           <div class="seg" id="todo-scope">
             <button class="seg-item active" data-scope="all">all</button>
@@ -207,6 +197,19 @@
         </form>
         <ul class="todo-list" id="todo-list"></ul>
         <div class="empty" id="todos-empty">Nothing here. Add your first task above.</div>
+        </div>
+
+        <div class="work-pane" id="work-pane-running" hidden>
+          <div class="task-list" id="task-running"></div>
+        </div>
+
+        <div class="work-pane" id="work-pane-history" hidden>
+          <div class="toolbar">
+            <div class="toolbar-spacer"></div>
+            <button class="btn" id="btn-clear-tasks">Clear completed</button>
+          </div>
+          <div class="task-list" id="task-completed"></div>
+        </div>
       </section>
 
       <!-- SESSIONS -->

--- a/Web/wwwroot/index.html
+++ b/Web/wwwroot/index.html
@@ -164,6 +164,10 @@
             <div class="rail-head"><span>Running</span><span class="rail-count" id="rail-running">0</span></div>
             <ul class="rail-list" id="rail-task-list"></ul>
           </div>
+          <div class="rail-section" data-goto="work" data-goto-tab="queue">
+            <div class="rail-head"><span>Queue</span><span class="rail-count" id="rail-queue">0</span></div>
+            <ul class="rail-list" id="rail-queue-list"></ul>
+          </div>
           <div class="rail-section" data-goto="approvals">
             <div class="rail-head"><span>Approvals</span><span class="rail-count" id="rail-approvals">0</span></div>
           </div>

--- a/Web/wwwroot/index.html
+++ b/Web/wwwroot/index.html
@@ -21,28 +21,28 @@
 
       <nav class="nav">
         <button class="nav-item active" data-view="orchestrator">
-          <span class="nav-icon">◈</span> Orchestrator
+          <span class="nav-icon">◈</span><span class="nav-label">Orchestrator</span>
         </button>
         <button class="nav-item" data-view="overview">
-          <span class="nav-icon">▣</span> Overview
+          <span class="nav-icon">▣</span><span class="nav-label">Overview</span>
         </button>
         <button class="nav-item" data-view="agents">
-          <span class="nav-icon">⬡</span> Agents
+          <span class="nav-icon">⬡</span><span class="nav-label">Agents</span>
           <span class="nav-badge" id="badge-agents">0</span>
         </button>
         <button class="nav-item" data-view="work">
-          <span class="nav-icon">≡</span> Work
+          <span class="nav-icon">≡</span><span class="nav-label">Work</span>
           <span class="nav-badge" id="badge-work">0</span>
         </button>
         <button class="nav-item" data-view="sessions">
-          <span class="nav-icon">◷</span> Sessions
+          <span class="nav-icon">◷</span><span class="nav-label">Sessions</span>
         </button>
         <button class="nav-item" data-view="approvals">
-          <span class="nav-icon">⚑</span> Approvals
+          <span class="nav-icon">⚑</span><span class="nav-label">Approvals</span>
           <span class="nav-badge alert" id="badge-approvals">0</span>
         </button>
         <button class="nav-item" data-view="settings">
-          <span class="nav-icon">⚙</span> Settings
+          <span class="nav-icon">⚙</span><span class="nav-label">Settings</span>
         </button>
       </nav>
 

--- a/Web/wwwroot/index.html
+++ b/Web/wwwroot/index.html
@@ -110,10 +110,6 @@
               <button class="btn ghost sm" id="clear-activity">clear</button>
             </div>
             <ul class="activity-feed" id="activity-feed"></ul>
-            <div class="panel-head" style="margin-top:18px">
-              <h2>Scheduler queue</h2>
-            </div>
-            <ul class="wake-list" id="wake-list"></ul>
           </div>
         </div>
       </section>
@@ -161,6 +157,7 @@
             <button class="seg-item active" data-worktab="queue">Queue <span class="seg-count" id="workcount-queue"></span></button>
             <button class="seg-item" data-worktab="running">Running <span class="seg-count" id="workcount-running"></span></button>
             <button class="seg-item" data-worktab="history">History</button>
+            <button class="seg-item" data-worktab="schedule">Schedule</button>
           </div>
         </div>
 
@@ -209,6 +206,13 @@
             <button class="btn" id="btn-clear-tasks">Clear completed</button>
           </div>
           <div class="task-list" id="task-completed"></div>
+        </div>
+
+        <div class="work-pane" id="work-pane-schedule" hidden>
+          <div class="toolbar">
+            <span class="toolbar-title">Scheduler queue — wakes waiting for the orchestrator</span>
+          </div>
+          <ul class="wake-list" id="wake-list"></ul>
         </div>
       </section>
 

--- a/Web/wwwroot/index.html
+++ b/Web/wwwroot/index.html
@@ -424,23 +424,23 @@
   </div>
 
   <div class="drawer-backdrop" id="drawer-backdrop" hidden>
-    <aside class="drawer">
+    <aside class="drawer" id="drawer" role="dialog" aria-modal="true" aria-labelledby="drawer-title">
       <div class="drawer-head">
         <div class="drawer-titles">
           <h3 id="drawer-title">Transcript</h3>
           <span class="drawer-sub" id="drawer-sub"></span>
         </div>
-        <button class="btn ghost sm" id="drawer-close">✕</button>
+        <button class="btn ghost sm" id="drawer-close" aria-label="Close">✕</button>
       </div>
       <div class="drawer-body" id="drawer-body"></div>
     </aside>
   </div>
 
   <div class="modal-backdrop" id="modal-backdrop" hidden>
-    <div class="modal" id="modal">
+    <div class="modal" id="modal" role="dialog" aria-modal="true" aria-labelledby="modal-title">
       <div class="modal-head">
         <h3 id="modal-title">Modal</h3>
-        <button class="btn ghost sm" id="modal-close">✕</button>
+        <button class="btn ghost sm" id="modal-close" aria-label="Close">✕</button>
       </div>
       <div class="modal-body" id="modal-body"></div>
     </div>

--- a/Web/wwwroot/styles.css
+++ b/Web/wwwroot/styles.css
@@ -480,9 +480,11 @@ textarea.input { resize: vertical; font-family: inherit; }
 
 /* ---------- orchestrator ---------- */
 
-.orch-layout { display: flex; gap: 20px; height: 100%; justify-content: center; }
+/* Chat centers in the leftover space (auto margins absorb it); the rail
+   stays pinned to the far right edge. */
+.orch-layout { display: flex; gap: 20px; height: 100%; }
 
-.chat { display: flex; flex-direction: column; height: 100%; flex: 1; max-width: 1100px; min-width: 0; }
+.chat { display: flex; flex-direction: column; height: 100%; flex: 0 1 1100px; margin: 0 auto; min-width: 0; }
 
 .orch-rail {
   width: 236px;

--- a/Web/wwwroot/styles.css
+++ b/Web/wwwroot/styles.css
@@ -101,6 +101,25 @@ input, textarea, select { font: inherit; color: inherit; }
 .nav-badge.alert:not(:empty) { border-color: var(--warn); color: var(--warn); }
 .nav-badge.hidden { display: none; }
 
+/* Narrow windows: sidebar collapses to icons; badges shrink to corner chips. */
+@media (max-width: 900px) {
+  .sidebar { width: 64px; padding: 20px 8px 12px; }
+  .brand { justify-content: center; padding: 0 0 18px; }
+  .brand-text, .nav-label, #conn-label, .provider-chip { display: none; }
+  .nav-item { position: relative; justify-content: center; padding: 11px 8px; }
+  .nav-icon { width: auto; }
+  .nav-badge {
+    position: absolute;
+    top: 3px;
+    right: 3px;
+    min-width: 16px;
+    padding: 0 4px;
+    font-size: 9px;
+    line-height: 15px;
+  }
+  .sidebar-footer { align-items: center; }
+}
+
 .sidebar-footer { padding: 12px 10px 0; border-top: 1px solid var(--border); display: flex; flex-direction: column; gap: 8px; }
 .conn { display: flex; align-items: center; gap: 8px; font-size: 12px; color: var(--muted); }
 .conn-dot {

--- a/Web/wwwroot/styles.css
+++ b/Web/wwwroot/styles.css
@@ -855,6 +855,24 @@ button.task-badge:hover { background: var(--panel-3); }
 .toast.out { animation: toast-out 0.3s var(--ease) forwards; }
 .toast b { font-weight: 600; }
 
+.approval-toast { border-color: var(--border-strong); }
+.toast-title { font-weight: 600; font-size: 12.5px; margin-bottom: 4px; }
+.toast-body { color: var(--muted); font-size: 12.5px; }
+.toast-command {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 6px 8px;
+  margin-top: 6px;
+  white-space: pre-wrap;
+  word-break: break-all;
+  max-height: 76px;
+  overflow: hidden;
+}
+.toast-actions { display: flex; gap: 8px; margin-top: 10px; }
+
 /* ---------- markdown ---------- */
 
 .md { line-height: 1.6; overflow-wrap: break-word; }

--- a/Web/wwwroot/styles.css
+++ b/Web/wwwroot/styles.css
@@ -580,11 +580,6 @@ textarea.input { resize: vertical; font-family: inherit; }
   animation: rise-in 0.25s var(--ease);
 }
 
-/* Off-screen bubbles skip layout and paint entirely. */
-.chat-msg, .chat-task {
-  content-visibility: auto;
-  contain-intrinsic-size: auto 48px;
-}
 
 .chat-older {
   align-self: center;

--- a/Web/wwwroot/styles.css
+++ b/Web/wwwroot/styles.css
@@ -537,6 +537,9 @@ textarea.input { resize: vertical; font-family: inherit; }
 }
 .rail-list li > :last-child { overflow: hidden; text-overflow: ellipsis; }
 .rail-empty { color: var(--dim); font-size: 11.5px; }
+.rail-pri { width: 6px; height: 6px; border-radius: 50%; background: var(--dim); flex-shrink: 0; }
+.rail-pri.high { background: var(--warn); }
+.rail-pri.low { opacity: 0.5; }
 #rail-activity li { display: block; overflow: hidden; text-overflow: ellipsis; }
 #rail-activity b { color: var(--text); font-weight: 600; }
 

--- a/Web/wwwroot/styles.css
+++ b/Web/wwwroot/styles.css
@@ -906,6 +906,32 @@ button.task-badge:hover { background: var(--panel-3); }
   color: var(--muted);
 }
 
+/* ---------- popup menu ---------- */
+
+.popmenu {
+  position: fixed;
+  z-index: 60;
+  min-width: 130px;
+  background: var(--panel-2);
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  padding: 4px;
+  box-shadow: 0 8px 30px #000000aa;
+  display: flex;
+  flex-direction: column;
+  animation: fade-in 0.12s;
+}
+.popmenu button {
+  text-align: left;
+  padding: 7px 12px;
+  border-radius: 6px;
+  font-size: 12.5px;
+  color: var(--text);
+  transition: background 0.12s;
+}
+.popmenu button:hover { background: var(--panel-3); }
+.popmenu button.danger { color: var(--danger); }
+
 /* ---------- drawer ---------- */
 
 .drawer-backdrop {

--- a/Web/wwwroot/styles.css
+++ b/Web/wwwroot/styles.css
@@ -545,10 +545,21 @@ textarea.input { resize: vertical; font-family: inherit; }
 #rail-activity li { display: block; overflow: hidden; text-overflow: ellipsis; }
 #rail-activity b { color: var(--text); font-weight: 600; }
 
-.chat-log { flex: 1; overflow-y: auto; display: flex; flex-direction: column; gap: 12px; padding-bottom: 16px; }
+/* One scroll container holds the finished log and the live stream bubble,
+   so streaming output rides inside the conversation. */
+.chat-scroll {
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding-bottom: 16px;
+}
+.chat-log { display: flex; flex-direction: column; gap: 12px; }
 /* Anchor short conversations to the input, like any chat app — the slack
    collects above the conversation instead of between it and the input. */
-.chat-log > :first-child { margin-top: auto; }
+.chat-log { margin-top: auto; }
+.chat-log:empty { margin: auto 0; }
 .chat-log:empty::before {
   content: "No conversation yet. Give the orchestrator an instruction below — it can plan work, spawn sub-agents and hand tasks off to them.";
   color: var(--dim);
@@ -590,12 +601,18 @@ textarea.input { resize: vertical; font-family: inherit; }
 .chat-msg.assistant { align-self: flex-start; background: var(--panel-2); border: 1px solid var(--border); border-bottom-left-radius: 4px; }
 .chat-msg.system { align-self: center; color: var(--dim); font-size: 12px; background: none; padding: 2px; }
 
+/* The live stream is styled as an in-progress assistant bubble. */
 .chat-stream {
-  background: var(--panel);
-  border: 1px solid var(--border-strong);
-  border-radius: var(--radius);
+  align-self: flex-start;
+  width: fit-content;
+  min-width: 260px;
+  max-width: min(92%, 900px);
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  border-bottom-left-radius: 4px;
   padding: 12px 14px;
-  margin-bottom: 12px;
+  flex-shrink: 0;
   animation: rise-in 0.25s var(--ease);
 }
 .chat-stream-head { display: flex; align-items: center; gap: 8px; font-size: 12px; color: var(--muted); margin-bottom: 8px; flex-wrap: wrap; }

--- a/Web/wwwroot/styles.css
+++ b/Web/wwwroot/styles.css
@@ -482,7 +482,7 @@ textarea.input { resize: vertical; font-family: inherit; }
 
 .orch-layout { display: flex; gap: 20px; height: 100%; justify-content: center; }
 
-.chat { display: flex; flex-direction: column; height: 100%; flex: 1; max-width: 860px; min-width: 0; }
+.chat { display: flex; flex-direction: column; height: 100%; flex: 1; max-width: 1100px; min-width: 0; }
 
 .orch-rail {
   width: 236px;
@@ -541,6 +541,9 @@ textarea.input { resize: vertical; font-family: inherit; }
 #rail-activity b { color: var(--text); font-weight: 600; }
 
 .chat-log { flex: 1; overflow-y: auto; display: flex; flex-direction: column; gap: 12px; padding-bottom: 16px; }
+/* Anchor short conversations to the input, like any chat app — the slack
+   collects above the conversation instead of between it and the input. */
+.chat-log > :first-child { margin-top: auto; }
 .chat-log:empty::before {
   content: "No conversation yet. Give the orchestrator an instruction below — it can plan work, spawn sub-agents and hand tasks off to them.";
   color: var(--dim);
@@ -552,7 +555,7 @@ textarea.input { resize: vertical; font-family: inherit; }
 }
 
 .chat-msg {
-  max-width: 82%;
+  max-width: min(82%, 720px);
   padding: 10px 14px;
   border-radius: 12px;
   font-size: 13.5px;
@@ -1152,7 +1155,7 @@ button.task-badge:hover { background: var(--panel-3); }
 
 /* Markdown inside chat bubbles and panels */
 .chat-msg.md { white-space: normal; }
-.chat-msg.assistant.md { max-width: 88%; }
+.chat-msg.assistant.md { max-width: min(92%, 900px); }
 .result-pre.md { white-space: normal; font-family: inherit; font-size: 13px; color: var(--text); }
 .msg-content.md { white-space: normal; color: var(--text); }
 

--- a/Web/wwwroot/styles.css
+++ b/Web/wwwroot/styles.css
@@ -848,6 +848,42 @@ button.task-badge:hover { background: var(--panel-3); }
   color: var(--muted);
 }
 
+/* ---------- drawer ---------- */
+
+.drawer-backdrop {
+  position: fixed;
+  inset: 0;
+  background: #00000080;
+  z-index: 40;
+  animation: fade-in 0.2s;
+}
+.drawer {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: min(680px, 92vw);
+  background: var(--panel);
+  border-left: 1px solid var(--border-strong);
+  display: flex;
+  flex-direction: column;
+  animation: drawer-in 0.28s var(--ease);
+}
+.drawer-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 18px 20px 14px;
+  border-bottom: 1px solid var(--border);
+}
+.drawer-titles { min-width: 0; }
+.drawer-head h3 { font-size: 15px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.drawer-sub { font-family: var(--font-mono); font-size: 11px; color: var(--dim); display: block; margin-top: 3px; }
+.drawer-body { flex: 1; overflow-y: auto; padding: 16px 20px; }
+.drawer-msgs { max-height: none; }
+.drawer-msgs .msg-content { max-height: none; }
+
 /* ---------- toasts ---------- */
 
 .toasts {
@@ -1024,6 +1060,7 @@ button.task-badge:hover { background: var(--panel-3); }
 @keyframes rise-in { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: none; } }
 @keyframes slide-left { from { opacity: 0; transform: translateX(10px); } to { opacity: 1; transform: none; } }
 @keyframes modal-in { from { opacity: 0; transform: scale(0.95) translateY(8px); } to { opacity: 1; transform: none; } }
+@keyframes drawer-in { from { transform: translateX(40px); opacity: 0; } to { transform: none; opacity: 1; } }
 @keyframes toast-in { from { opacity: 0; transform: translateX(30px); } to { opacity: 1; transform: none; } }
 @keyframes toast-out { to { opacity: 0; transform: translateX(30px); } }
 @keyframes pulse { 0%, 100% { opacity: 1; transform: scale(1); } 50% { opacity: 0.35; transform: scale(0.8); } }

--- a/Web/wwwroot/styles.css
+++ b/Web/wwwroot/styles.css
@@ -1181,6 +1181,51 @@ button.task-badge:hover { background: var(--panel-3); }
 .result-pre.md { white-space: normal; font-family: inherit; font-size: 13px; color: var(--text); }
 .msg-content.md { white-space: normal; color: var(--text); }
 
+/* ---------- small screens ---------- */
+
+@media (max-width: 640px) {
+  .view { padding: 14px 14px 18px; }
+  .topbar { padding: 12px 14px; }
+  .topbar h1 { font-size: 15px; }
+  .uptime { display: none; }
+  .model-chip { max-width: 45vw; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .approval-banner { padding: 8px 14px; flex-wrap: wrap; }
+
+  .toolbar { flex-wrap: wrap; }
+  .toolbar .search { width: 100%; order: 9; }
+
+  .stat-grid { grid-template-columns: repeat(2, 1fr); gap: 10px; }
+  .stat-value { font-size: 26px; }
+
+  .todo-add { flex-wrap: wrap; }
+  .todo-add .input:first-child { flex: 1 1 100%; }
+  .todo-item { flex-wrap: wrap; }
+  .task-badges { order: 8; flex-basis: 100%; }
+
+  .task-row { flex-wrap: wrap; row-gap: 6px; }
+  .task-desc { flex-basis: 100%; order: 9; white-space: normal; }
+
+  .session-row { flex-wrap: wrap; row-gap: 6px; }
+  .session-title { flex-basis: 100%; order: 9; white-space: normal; }
+
+  .agent-grid { grid-template-columns: 1fr; }
+
+  .chat-msg { max-width: 94%; }
+  .chat-msg.assistant.md, .chat-stream { max-width: 96%; }
+  .chat-input { flex-wrap: wrap; }
+  .chat-input textarea { flex: 1 1 100%; }
+  .chat-buttons { flex-direction: row; width: 100%; justify-content: flex-end; }
+
+  .settings-row { grid-template-columns: 1fr; }
+  .field-row { flex-wrap: wrap; }
+
+  .modal { padding: 16px; }
+  .drawer { width: 100vw; border-left: none; }
+
+  .toasts { left: 14px; right: 14px; bottom: 14px; }
+  .toast { max-width: none; }
+}
+
 /* ---------- animations ---------- */
 
 @keyframes view-in { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: none; } }

--- a/Web/wwwroot/styles.css
+++ b/Web/wwwroot/styles.css
@@ -579,6 +579,25 @@ textarea.input { resize: vertical; font-family: inherit; }
   overflow-wrap: break-word;
   animation: rise-in 0.25s var(--ease);
 }
+
+/* Off-screen bubbles skip layout and paint entirely. */
+.chat-msg, .chat-task {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 48px;
+}
+
+.chat-older {
+  align-self: center;
+  color: var(--dim);
+  font-size: 11.5px;
+  font-family: var(--font-mono);
+  letter-spacing: 0.06em;
+  padding: 6px 14px;
+  border: 1px dashed var(--border-strong);
+  border-radius: 999px;
+  transition: color 0.15s, border-color 0.15s;
+}
+.chat-older:hover { color: var(--text); border-color: var(--muted); }
 .chat-msg.user { align-self: flex-end; background: var(--white); color: #000; border-bottom-right-radius: 4px; }
 .chat-msg.pending { opacity: 0.65; }
 .chat-msg.user.scheduler {

--- a/Web/wwwroot/styles.css
+++ b/Web/wwwroot/styles.css
@@ -461,7 +461,65 @@ textarea.input { resize: vertical; font-family: inherit; }
 
 /* ---------- orchestrator ---------- */
 
-.chat { display: flex; flex-direction: column; height: 100%; max-width: 860px; margin: 0 auto; }
+.orch-layout { display: flex; gap: 20px; height: 100%; justify-content: center; }
+
+.chat { display: flex; flex-direction: column; height: 100%; flex: 1; max-width: 860px; min-width: 0; }
+
+.orch-rail {
+  width: 236px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  overflow-y: auto;
+}
+@media (max-width: 1080px) { .orch-rail { display: none; } }
+
+.rail-section {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 12px 14px;
+}
+.rail-section[data-goto] { cursor: pointer; transition: border-color 0.2s var(--ease); }
+.rail-section[data-goto]:hover { border-color: var(--border-strong); }
+.rail-section.rail-grow { flex: 1; min-height: 120px; overflow-y: auto; }
+
+.rail-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--dim);
+}
+.rail-count { font-family: var(--font-mono); font-size: 12px; color: var(--muted); }
+.rail-count.warn { color: var(--warn); }
+
+.rail-list {
+  list-style: none;
+  margin-top: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  font-size: 12px;
+  color: var(--muted);
+}
+.rail-list:empty { display: none; }
+.rail-list li {
+  display: flex;
+  gap: 7px;
+  align-items: center;
+  overflow: hidden;
+  white-space: nowrap;
+  min-width: 0;
+}
+.rail-list li > :last-child { overflow: hidden; text-overflow: ellipsis; }
+.rail-empty { color: var(--dim); font-size: 11.5px; }
+#rail-activity li { display: block; overflow: hidden; text-overflow: ellipsis; }
+#rail-activity b { color: var(--text); font-weight: 600; }
 
 .chat-log { flex: 1; overflow-y: auto; display: flex; flex-direction: column; gap: 12px; padding-bottom: 16px; }
 .chat-log:empty::before {

--- a/Web/wwwroot/styles.css
+++ b/Web/wwwroot/styles.css
@@ -128,6 +128,18 @@ input, textarea, select { font: inherit; color: inherit; }
   border-radius: 999px;
 }
 
+.approval-banner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 28px;
+  border-bottom: 1px solid var(--border-strong);
+  background: var(--panel-2);
+  font-size: 12.5px;
+  animation: fade-in 0.25s var(--ease);
+}
+.approval-banner::before { content: "⚑"; }
+
 .view {
   display: none;
   flex: 1;

--- a/Web/wwwroot/styles.css
+++ b/Web/wwwroot/styles.css
@@ -11,6 +11,11 @@
   --muted: #9a9a9a;
   --dim: #5c5c5c;
   --white: #ffffff;
+  /* Semantic accents, used only for status: ok = running/healthy,
+     warn = waiting on the user, danger = failed/destructive. */
+  --ok: #7dd692;
+  --warn: #e2c26f;
+  --danger: #e2726f;
   --radius: 10px;
   --font-mono: ui-monospace, "Cascadia Code", "SF Mono", "Menlo", "Consolas", monospace;
   --ease: cubic-bezier(0.22, 1, 0.36, 1);
@@ -93,7 +98,7 @@ input, textarea, select { font: inherit; color: inherit; }
   transition: all 0.2s var(--ease);
 }
 .nav-item.active .nav-badge { background: var(--bg); }
-.nav-badge.alert:not(:empty) { border-color: var(--white); color: var(--white); }
+.nav-badge.alert:not(:empty) { border-color: var(--warn); color: var(--warn); }
 .nav-badge.hidden { display: none; }
 
 .sidebar-footer { padding: 12px 10px 0; border-top: 1px solid var(--border); display: flex; flex-direction: column; gap: 8px; }
@@ -103,7 +108,7 @@ input, textarea, select { font: inherit; color: inherit; }
   background: var(--dim);
   transition: background 0.3s;
 }
-.conn-dot.on { background: var(--white); box-shadow: 0 0 8px #ffffff66; animation: breathe 3s ease-in-out infinite; }
+.conn-dot.on { background: var(--ok); box-shadow: 0 0 8px #7dd69266; animation: breathe 3s ease-in-out infinite; }
 .provider-chip { font-family: var(--font-mono); font-size: 11px; color: var(--dim); padding: 0 2px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
 .main { flex: 1; display: flex; flex-direction: column; min-width: 0; }
@@ -138,7 +143,7 @@ input, textarea, select { font: inherit; color: inherit; }
   font-size: 12.5px;
   animation: fade-in 0.25s var(--ease);
 }
-.approval-banner::before { content: "⚑"; }
+.approval-banner::before { content: "⚑"; color: var(--warn); }
 
 .view {
   display: none;
@@ -167,7 +172,7 @@ input, textarea, select { font: inherit; color: inherit; }
 .btn:disabled { opacity: 0.4; pointer-events: none; }
 .btn.primary { background: var(--white); border-color: var(--white); color: #000; font-weight: 600; }
 .btn.primary:hover { background: #d9d9d9; border-color: #d9d9d9; }
-.btn.danger:hover { border-color: var(--white); }
+.btn.danger:hover { border-color: var(--danger); color: var(--danger); }
 .btn.ghost { border-color: transparent; background: transparent; color: var(--muted); }
 .btn.ghost:hover { color: var(--text); background: var(--panel-2); }
 .btn.sm { padding: 4px 9px; font-size: 12px; }
@@ -249,7 +254,7 @@ textarea.input { resize: vertical; font-family: inherit; }
 .field-row .input { flex: 1; }
 
 .switch-row { display: flex; align-items: center; justify-content: space-between; padding: 4px 0; cursor: pointer; }
-.switch-row.danger-row span::before { content: "⚠ "; color: var(--white); }
+.switch-row.danger-row span::before { content: "⚠ "; color: var(--danger); }
 .switch {
   appearance: none;
   width: 40px; height: 22px;
@@ -384,8 +389,8 @@ textarea.input { resize: vertical; font-family: inherit; }
 .agent-id { font-family: var(--font-mono); font-size: 10px; color: var(--dim); margin-left: auto; flex-shrink: 0; }
 
 .status-dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; background: var(--dim); }
-.status-dot.working { background: var(--white); animation: pulse 1.4s ease-in-out infinite; }
-.status-dot.error { background: var(--white); outline: 2px solid #ffffff44; }
+.status-dot.working { background: var(--ok); animation: pulse 1.4s ease-in-out infinite; }
+.status-dot.error { background: var(--danger); outline: 2px solid #e2726f44; }
 
 .agent-purpose {
   color: var(--muted);
@@ -446,9 +451,9 @@ textarea.input { resize: vertical; font-family: inherit; }
   min-width: 68px;
   text-align: center;
 }
-.task-status.running { color: var(--white); border-color: var(--white); animation: breathe 2s ease-in-out infinite; }
+.task-status.running { color: var(--ok); border-color: var(--ok); animation: breathe 2s ease-in-out infinite; }
 .task-status.done { color: var(--text); }
-.task-status.failed { color: var(--muted); text-decoration: line-through; }
+.task-status.failed { color: var(--danger); border-color: var(--danger); }
 
 .task-desc { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 13px; }
 .task-agent { font-family: var(--font-mono); font-size: 11px; color: var(--dim); flex-shrink: 0; }
@@ -572,11 +577,11 @@ textarea.input { resize: vertical; font-family: inherit; }
   align-self: stretch;
   background: var(--panel);
   border: 1px solid var(--border);
-  border-left: 2px solid var(--white);
+  border-left: 2px solid var(--ok);
   border-radius: 10px;
   animation: rise-in 0.25s var(--ease);
 }
-.chat-task.failed { border-left-style: dashed; }
+.chat-task.failed { border-left-color: var(--danger); }
 .chat-task summary {
   cursor: pointer;
   padding: 9px 14px;
@@ -588,8 +593,8 @@ textarea.input { resize: vertical; font-family: inherit; }
 .chat-task summary:hover { color: var(--text); }
 .chat-task summary::-webkit-details-marker { display: none; }
 .chat-task summary b { color: var(--text); }
-.chat-task-mark { font-weight: 700; color: var(--white); margin-right: 2px; }
-.chat-task.failed .chat-task-mark { opacity: 0.6; }
+.chat-task-mark { font-weight: 700; color: var(--ok); margin-right: 2px; }
+.chat-task.failed .chat-task-mark { color: var(--danger); }
 .chat-task-time { float: right; font-family: var(--font-mono); font-size: 10.5px; color: var(--dim); }
 .chat-task[open] summary { border-bottom: 1px solid var(--border); }
 .chat-task-body { padding: 12px 14px; font-size: 13px; max-height: 320px; overflow-y: auto; }
@@ -669,7 +674,7 @@ textarea.input { resize: vertical; font-family: inherit; }
   transition: all 0.15s;
   flex-shrink: 0;
 }
-.todo-pri.high { color: var(--white); border-color: var(--white); }
+.todo-pri.high { color: var(--warn); border-color: var(--warn); }
 .todo-pri.low { opacity: 0.6; }
 .todo-pri:hover { border-color: var(--muted); }
 
@@ -695,8 +700,8 @@ textarea.input { resize: vertical; font-family: inherit; }
   color: var(--dim);
   white-space: nowrap;
 }
-.task-badge.alert { border-color: var(--white); color: var(--white); }
-.task-badge.live { color: var(--text); border-color: var(--border-strong); animation: breathe 2s ease-in-out infinite; }
+.task-badge.alert { border-color: var(--warn); color: var(--warn); }
+.task-badge.live { color: var(--ok); border-color: var(--border-strong); animation: breathe 2s ease-in-out infinite; }
 button.task-badge { cursor: pointer; transition: background 0.15s; }
 button.task-badge:hover { background: var(--panel-3); }
 
@@ -783,7 +788,7 @@ button.task-badge:hover { background: var(--panel-3); }
 
 .approval-card {
   background: var(--panel);
-  border: 1px solid var(--white);
+  border: 1px solid var(--warn);
   border-radius: var(--radius);
   padding: 16px;
   animation: attention 0.5s var(--ease);
@@ -867,7 +872,7 @@ button.task-badge:hover { background: var(--panel-3); }
 .toast.out { animation: toast-out 0.3s var(--ease) forwards; }
 .toast b { font-weight: 600; }
 
-.approval-toast { border-color: var(--border-strong); }
+.approval-toast { border-color: var(--warn); }
 .toast-title { font-weight: 600; font-size: 12.5px; margin-bottom: 4px; }
 .toast-body { color: var(--muted); font-size: 12.5px; }
 .toast-command {

--- a/Web/wwwroot/styles.css
+++ b/Web/wwwroot/styles.css
@@ -264,6 +264,8 @@ textarea.input { resize: vertical; font-family: inherit; }
 .seg-item { padding: 4px 12px; border-radius: 6px; font-size: 12px; color: var(--muted); transition: all 0.15s var(--ease); }
 .seg-item:hover { color: var(--text); }
 .seg-item.active { background: var(--panel-3); color: var(--white); }
+.seg-count { font-family: var(--font-mono); font-size: 10px; color: var(--dim); }
+.seg-item.active .seg-count { color: var(--muted); }
 
 /* ---------- overview ---------- */
 


### PR DESCRIPTION
Reworks the web panel into a proper command center.

- Orchestrator is now the home view with a live status rail (agents, running tasks, queue, approvals, activity) pinned to the right edge; streaming output renders as an in-progress chat bubble inside the conversation
- Tasks, Todo List and the scheduler queue merge into one Work view with Queue, Running, History and Schedule tabs; completed tasks now record and show the original task description
- Approvals are actionable from anywhere via toasts with inline approve/deny plus a persistent banner
- Chat auto-scrolls on send and while streaming unless the user scrolled up, and the transcript is windowed (recent 20 in the DOM, older restored on scroll) to keep memory flat
- Semantic status colors, URL hash routing, session transcripts in a slide-over drawer, agent Log buttons, in-app confirm modals, todo overflow menu, keyboard shortcuts, and a mobile layout pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an Orchestrator workspace with live chat, activity rail, agent status, approvals, and task counts.
  - Added Work tabs for Queue, Running, History, and Schedule.
  - Added transcript drawers for viewing sessions and agent logs.
  - Added persistent approval notifications with actionable controls.
  - Added task descriptions to completed task details and reporting.
  - Added organized todo action menus and confirmation dialogs.

- **Improvements**
  - Improved navigation with hash-based view routing.
  - Enhanced chat streaming, scrolling, transcript handling, and responsive layouts.
  - Refined status colors, task indicators, approval banners, and toast notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->