### PR TITLE
Fix agent transcripts showing null for tool-call messages

### DIFF
--- a/Data/ChatHistoryRepository.cs
+++ b/Data/ChatHistoryRepository.cs
@@ -210,6 +210,15 @@ public class ChatHistoryRepository : IDisposable
     private Task WithDbLockAsync(Func<Task> action, CancellationToken cancellationToken = default)
         => WithWriteLockAsync(action, cancellationToken);
 
+    // Tool-call-only assistant messages carry a JSON null content; store those as
+    // empty rather than the literal "null" GetRawText() would produce.
+    private static string ContentToString(JsonElement content) => content.ValueKind switch
+    {
+        JsonValueKind.String => content.GetString() ?? string.Empty,
+        JsonValueKind.Null or JsonValueKind.Undefined => string.Empty,
+        _ => content.GetRawText()
+    };
+
     public async Task<ChatSession> CreateSessionAsync(string title, string chatType = "main", 
         string? parentSessionId = null, string? agentName = null, string? model = null,
         string? systemPrompt = null, double? temperature = null, int? maxTokens = null,
@@ -265,9 +274,7 @@ public class ChatHistoryRepository : IDisposable
             {
                 SessionId = sessionId,
                 Role = message.Role ?? "assistant",
-                Content = message.Content.ValueKind == JsonValueKind.String 
-                    ? message.Content.GetString() ?? string.Empty
-                    : message.Content.GetRawText(),
+                Content = ContentToString(message.Content),
                 Name = message.Name,
                 AgentName = agentName,
                 SequenceNumber = sequenceNumber ?? await GetNextSequenceNumberAsync(sessionId, cancellationToken),
@@ -331,9 +338,7 @@ public class ChatHistoryRepository : IDisposable
                     {
                         SessionId = sessionId,
                         Role = message.Role ?? "assistant",
-                        Content = message.Content.ValueKind == JsonValueKind.String 
-                            ? message.Content.GetString() ?? string.Empty
-                            : message.Content.GetRawText(),
+                        Content = ContentToString(message.Content),
                         Name = message.Name,
                         AgentName = agentName,
                         SequenceNumber = startSequence++,

--- a/Saturn.Tests/Data/ChatHistoryRepositoryTests.cs
+++ b/Saturn.Tests/Data/ChatHistoryRepositoryTests.cs
@@ -1,0 +1,103 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Saturn.Data;
+using Saturn.OpenRouter.Models.Api.Chat;
+using Xunit;
+
+namespace Saturn.Tests.Data
+{
+    public class ChatHistoryRepositoryTests : IDisposable
+    {
+        private readonly string _workspace;
+
+        public ChatHistoryRepositoryTests()
+        {
+            _workspace = Path.Combine(Path.GetTempPath(), $"SaturnHistoryTest_{Guid.NewGuid():N}");
+            Directory.CreateDirectory(_workspace);
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(_workspace, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+
+        private static JsonElement JsonNull() => JsonDocument.Parse("null").RootElement;
+
+        [Fact]
+        public async Task SaveMessage_WithNullContent_StoresEmptyStringNotLiteralNull()
+        {
+            using var repository = new ChatHistoryRepository(_workspace);
+            var session = await repository.CreateSessionAsync("test");
+
+            var toolCallMessage = new Message
+            {
+                Role = "assistant",
+                Content = JsonNull(),
+                ToolCalls = new[]
+                {
+                    new ToolCallRequest
+                    {
+                        Id = "call_1",
+                        Function = new ToolCallRequest.FunctionCall { Name = "grep_files", Arguments = "{}" }
+                    }
+                }
+            };
+
+            await repository.SaveMessageAsync(session.Id, toolCallMessage, "TestAgent");
+
+            var messages = await repository.GetMessagesAsync(session.Id);
+            messages.Should().ContainSingle();
+            messages[0].Content.Should().BeEmpty();
+            messages[0].ToolCallsJson.Should().Contain("grep_files");
+        }
+
+        [Fact]
+        public async Task SaveMessageBatch_WithNullContent_StoresEmptyStringNotLiteralNull()
+        {
+            using var repository = new ChatHistoryRepository(_workspace);
+            var session = await repository.CreateSessionAsync("test");
+
+            var messages = new[]
+            {
+                new Message { Role = "assistant", Content = JsonNull() },
+                new Message { Role = "assistant", Content = JsonSerializer.SerializeToElement("real text") }
+            }.ToList();
+
+            await repository.SaveMessageBatchAsync(session.Id, messages, "TestAgent");
+
+            var loaded = await repository.GetMessagesAsync(session.Id);
+            loaded.Should().HaveCount(2);
+            loaded[0].Content.Should().BeEmpty();
+            loaded[1].Content.Should().Be("real text");
+        }
+
+        [Fact]
+        public async Task SaveMessage_WithStringContent_RoundTrips()
+        {
+            using var repository = new ChatHistoryRepository(_workspace);
+            var session = await repository.CreateSessionAsync("test");
+
+            var message = new Message
+            {
+                Role = "user",
+                Content = JsonSerializer.SerializeToElement("hello world")
+            };
+
+            await repository.SaveMessageAsync(session.Id, message);
+
+            var messages = await repository.GetMessagesAsync(session.Id);
+            messages.Should().ContainSingle();
+            messages[0].Content.Should().Be("hello world");
+        }
+    }
+}

--- a/Web/WebServer.cs
+++ b/Web/WebServer.cs
@@ -775,7 +775,9 @@ namespace Saturn.Web
                     m.Content,
                     m.AgentName,
                     m.Timestamp,
-                    m.SequenceNumber
+                    m.SequenceNumber,
+                    ToolCalls = ExtractToolCallNames(m.ToolCallsJson),
+                    ToolName = m.Role == "tool" ? m.Name : null
                 }));
             });
 
@@ -982,6 +984,31 @@ namespace Saturn.Web
                 _orchestrator.StartNewSession();
                 return Results.Ok();
             });
+        }
+
+        // ToolCallsJson stores the provider-shaped tool_call array; the UI only
+        // needs the function names to label the row.
+        private static string[]? ExtractToolCallNames(string? toolCallsJson)
+        {
+            if (string.IsNullOrEmpty(toolCallsJson)) return null;
+            try
+            {
+                using var doc = JsonDocument.Parse(toolCallsJson);
+                if (doc.RootElement.ValueKind != JsonValueKind.Array) return null;
+                var names = doc.RootElement.EnumerateArray()
+                    .Select(tc => tc.TryGetProperty("function", out var fn) && fn.ValueKind == JsonValueKind.Object
+                        && fn.TryGetProperty("name", out var name) && name.ValueKind == JsonValueKind.String
+                            ? name.GetString()
+                            : null)
+                    .Where(n => !string.IsNullOrEmpty(n))
+                    .Select(n => n!)
+                    .ToArray();
+                return names.Length > 0 ? names : null;
+            }
+            catch (JsonException)
+            {
+                return null;
+            }
         }
 
         private static object ProjectTaskView(TaskView view)

--- a/Web/wwwroot/app.js
+++ b/Web/wwwroot/app.js
@@ -1694,6 +1694,12 @@ function renderSessions() {
   );
 }
 
+// Tool-call-only assistant rows were historically persisted with the literal
+// string "null" as content; treat those as empty so old sessions render clean.
+function msgContent(m) {
+  return m.content === "null" && m.toolCalls?.length ? "" : m.content;
+}
+
 async function openSessionDrawer(session) {
   try {
     const messages = await api.get(`/sessions/${session.id}/messages`);
@@ -1705,17 +1711,18 @@ async function openSessionDrawer(session) {
       .map(
         (m, i) => `
         <div class="msg-row">
-          <div class="msg-role">${esc(m.role)}${m.agentName ? ` · ${esc(m.agentName)}` : ""}</div>
-          <div class="msg-content${m.role === "assistant" ? " md" : ""}" data-msg-index="${i}"></div>
+          <div class="msg-role">${esc(m.role)}${m.role === "tool" && m.toolName ? ` · ${esc(m.toolName)}` : ""}${m.agentName ? ` · ${esc(m.agentName)}` : ""}</div>
+          ${m.toolCalls?.length ? `<div class="msg-content" style="opacity:.7;font-style:italic">→ ${m.toolCalls.map(esc).join(", ")}</div>` : ""}
+          ${msgContent(m) ? `<div class="msg-content${m.role === "assistant" ? " md" : ""}" data-msg-index="${i}"></div>` : ""}
         </div>`
       )
       .join("") || '<div class="hint">No messages in this session.</div>'}</div>`;
     body.querySelectorAll("[data-msg-index]").forEach((el) => {
       const m = messages[Number(el.dataset.msgIndex)];
-      if (m.role === "assistant" && m.content !== "null") {
-        renderMarkdown(el, m.content);
+      if (m.role === "assistant") {
+        renderMarkdown(el, msgContent(m));
       } else {
-        el.textContent = m.content;
+        el.textContent = msgContent(m);
       }
     });
   } catch (err) {


### PR DESCRIPTION
Tool-call assistant messages are stored with JSON null content, which the history repository serialized as the literal string null. Every tool-call row in the web UI session drawer then rendered as null.

Stores null content as empty, returns tool call names from the messages API, and renders tool-call rows in the drawer. Old rows already stored as null render clean too. Adds regression tests for message persistence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session history now displays tool names and agent names alongside relevant messages.
  * Tool-call details are shown in a clearer, muted format when no message text is present.
  * API responses now include tool-call metadata for session messages.

* **Bug Fixes**
  * Prevented historical messages from displaying the literal text `"null"`.
  * Improved handling of empty and null message content for consistent rendering.
  * Preserved message text correctly when saving and loading chat history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->