### PR TITLE
Retry Cloudflare edge timeouts and keep retry notices out of transcripts

### DIFF
--- a/Agents/Core/AgentBase.cs
+++ b/Agents/Core/AgentBase.cs
@@ -1067,6 +1067,12 @@ namespace Saturn.Agents.Core
                         {
                             await onChunk(new StreamChunk { Content = "[Provider rejected streaming; falling back to non-streaming]", Role = "assistant", IsTransientNotice = true });
                             finalResponse = await ExecuteWithTools(currentMessages, cancellationToken);
+                            // The fallback ran outside the streaming loop, so its text was
+                            // never chunked; emit it or the consumer records an empty message.
+                            if (!string.IsNullOrEmpty(finalResponse?.Content))
+                            {
+                                await onChunk(new StreamChunk { Content = finalResponse.Content, Role = finalResponse.Role ?? "assistant" });
+                            }
                             contentBuffer.Clear();
                             toolCallBuffer.Clear();
                             continueProcessing = false;

--- a/Agents/Core/AgentBase.cs
+++ b/Agents/Core/AgentBase.cs
@@ -392,7 +392,10 @@ namespace Saturn.Agents.Core
             }
 
             // OpenRouter wraps transient upstream/routing failures in 5xx responses.
-            if (status == 500 || status == 502 || status == 503 || status == 529)
+            // Cloudflare fronts its edge, so a stalled upstream (e.g. a rate-limited
+            // provider) can also surface as a bare 52x such as "error code: 524".
+            if (status == 408 || status == 500 || status == 502 || status == 503 || status == 504
+                || (status >= 520 && status <= 527) || status == 529)
             {
                 return true;
             }
@@ -1045,7 +1048,8 @@ namespace Saturn.Agents.Core
                         await onChunk(new StreamChunk
                         {
                             Content = $"\n[Provider rate-limited/unavailable; waiting {delay.TotalSeconds:F0}s before retrying (attempt {retryAttempt}/{MaxProviderRetryAttempts})]\n",
-                            Role = "assistant"
+                            Role = "assistant",
+                            IsTransientNotice = true
                         });
                         await WaitForProviderRetryAsync(delay, cancellationToken);
                         attemptStream = true;
@@ -1061,7 +1065,7 @@ namespace Saturn.Agents.Core
 
                         if (looksLikeStreamingNotAllowed)
                         {
-                            await onChunk(new StreamChunk { Content = "[Provider rejected streaming; falling back to non-streaming]", Role = "assistant" });
+                            await onChunk(new StreamChunk { Content = "[Provider rejected streaming; falling back to non-streaming]", Role = "assistant", IsTransientNotice = true });
                             finalResponse = await ExecuteWithTools(currentMessages, cancellationToken);
                             contentBuffer.Clear();
                             toolCallBuffer.Clear();

--- a/OpenRouter/Models/Api/Chat/StreamChunk.cs
+++ b/OpenRouter/Models/Api/Chat/StreamChunk.cs
@@ -10,6 +10,10 @@ namespace Saturn.OpenRouter.Models.Api.Chat
         // current response (e.g. when a retry is about to re-send the turn).
         public bool ResetContent { get; set; }
 
+        // Status text for live display only (e.g. "waiting 2s before retrying");
+        // consumers must not persist it as part of the assistant's message.
+        public bool IsTransientNotice { get; set; }
+
         public string? Content { get; set; }
 
         public string? Role { get; set; }

--- a/Saturn.Tests/Providers/AgentProviderRetryTests.cs
+++ b/Saturn.Tests/Providers/AgentProviderRetryTests.cs
@@ -95,6 +95,34 @@ namespace Saturn.Tests.Providers
         }
 
         [Fact]
+        public async Task Execute_CloudflareEdgeTimeout524_IsRetried()
+        {
+            var client = new FakeLlmClient();
+            // A stalled upstream surfaces as a bare Cloudflare status with no JSON body.
+            client.ChatExceptionQueue.Enqueue(new OpenRouterException((HttpStatusCode)524, "error code: 524"));
+            var agent = CreateAgent(client);
+
+            var result = await agent.Execute<Message>("hello");
+
+            result.Content.GetString().Should().Be("ok");
+            client.Requests.Should().HaveCount(2);
+            agent.RetryWaits.Should().HaveCount(1);
+        }
+
+        [Fact]
+        public async Task Execute_GatewayTimeout504_IsRetried()
+        {
+            var client = new FakeLlmClient();
+            client.ChatExceptionQueue.Enqueue(new OpenRouterException(HttpStatusCode.GatewayTimeout, "Provider returned error"));
+            var agent = CreateAgent(client);
+
+            var result = await agent.Execute<Message>("hello");
+
+            result.Content.GetString().Should().Be("ok");
+            client.Requests.Should().HaveCount(2);
+        }
+
+        [Fact]
         public async Task Execute_NonRetryableError_ThrowsWithoutRetrying()
         {
             var client = new FakeLlmClient();
@@ -140,12 +168,12 @@ namespace Saturn.Tests.Providers
             });
             var agent = CreateAgent(client, enableStreaming: true);
 
-            var notices = new List<string>();
+            var chunks = new List<StreamChunk>();
             var result = await agent.ExecuteStreamAsync("hello", chunk =>
             {
                 if (!string.IsNullOrEmpty(chunk.Content))
                 {
-                    notices.Add(chunk.Content);
+                    chunks.Add(chunk);
                 }
                 return Task.CompletedTask;
             });
@@ -153,7 +181,9 @@ namespace Saturn.Tests.Providers
             result.Content.GetString().Should().Be("hello back");
             client.Requests.Should().HaveCount(2);
             agent.RetryWaits.Should().HaveCount(1);
-            notices.Should().Contain(n => n.Contains("retrying"));
+            // The retry notice is display-only status; the real content is not.
+            chunks.Should().Contain(c => c.Content.Contains("retrying") && c.IsTransientNotice);
+            chunks.Should().Contain(c => c.Content == "hello back" && !c.IsTransientNotice);
             agent.ChatHistory.Select(m => m.Role).Should().Equal("system", "user", "assistant");
             agent.ChatHistory[^1].Content.GetString().Should().Be("hello back");
         }

--- a/Saturn.Tests/Providers/AgentProviderRetryTests.cs
+++ b/Saturn.Tests/Providers/AgentProviderRetryTests.cs
@@ -182,10 +182,32 @@ namespace Saturn.Tests.Providers
             client.Requests.Should().HaveCount(2);
             agent.RetryWaits.Should().HaveCount(1);
             // The retry notice is display-only status; the real content is not.
-            chunks.Should().Contain(c => c.Content.Contains("retrying") && c.IsTransientNotice);
+            chunks.Should().Contain(c => c.Content!.Contains("retrying") && c.IsTransientNotice);
             chunks.Should().Contain(c => c.Content == "hello back" && !c.IsTransientNotice);
             agent.ChatHistory.Select(m => m.Role).Should().Equal("system", "user", "assistant");
             agent.ChatHistory[^1].Content.GetString().Should().Be("hello back");
+        }
+
+        [Fact]
+        public async Task ExecuteStream_ProviderRejectsStreaming_EmitsFallbackTextAsContent()
+        {
+            var client = new FakeLlmClient();
+            client.StreamExceptionQueue.Enqueue(new OpenRouterException(
+                HttpStatusCode.BadRequest, "Streaming is unsupported for this model"));
+            var agent = CreateAgent(client, enableStreaming: true);
+
+            var chunks = new List<StreamChunk>();
+            var result = await agent.ExecuteStreamAsync("hello", chunk =>
+            {
+                chunks.Add(chunk);
+                return Task.CompletedTask;
+            });
+
+            // The non-streaming fallback answered; its text must reach the consumer
+            // as a real content chunk, not just the transient fallback notice.
+            result.Content.GetString().Should().Be("ok");
+            chunks.Should().Contain(c => c.Content == "ok" && !c.IsTransientNotice);
+            chunks.Should().Contain(c => c.IsTransientNotice && c.Content!.Contains("falling back"));
         }
 
         [Fact]

--- a/Web/OrchestratorService.cs
+++ b/Web/OrchestratorService.cs
@@ -134,10 +134,26 @@ namespace Saturn.Web
 
                     await _agent.ExecuteStreamAsync(message, chunk =>
                     {
+                        // A retry is about to re-send the turn; drop the partial output
+                        // so it is not duplicated in the final transcript entry.
+                        if (chunk.ResetContent)
+                        {
+                            buffer.Clear();
+                            _hub.Publish("orchestrator.chunk", new { reset = true });
+                        }
                         if (!string.IsNullOrEmpty(chunk.Content) && !chunk.IsToolCall)
                         {
-                            buffer.Append(chunk.Content);
-                            _hub.Publish("orchestrator.chunk", new { content = chunk.Content });
+                            // Transient notices (rate-limit waits etc.) are live status,
+                            // not message content — stream them but never persist them.
+                            if (chunk.IsTransientNotice)
+                            {
+                                _hub.Publish("orchestrator.chunk", new { content = chunk.Content, transient = true });
+                            }
+                            else
+                            {
+                                buffer.Append(chunk.Content);
+                                _hub.Publish("orchestrator.chunk", new { content = chunk.Content });
+                            }
                         }
                         return Task.CompletedTask;
                     }, cts.Token);

--- a/Web/wwwroot/app.js
+++ b/Web/wwwroot/app.js
@@ -907,6 +907,9 @@ $("#work-tabs").addEventListener("click", (e) => {
 /* ---------- orchestrator ---------- */
 
 let streamBuffer = "";
+// Live status line (e.g. a rate-limit retry wait) shown under the streamed
+// text; it is display-only and never part of the final message.
+let streamNotice = "";
 let streamRenderPending = false;
 
 // Re-parsing the whole buffer per chunk is wasteful at high token rates;
@@ -921,7 +924,7 @@ function scheduleStreamRender() {
     // the follow margin must exceed that or following silently stops.
     const stick = isNearBottom(340);
     const el = $("#chat-stream-text");
-    renderMarkdown(el, streamBuffer);
+    renderMarkdown(el, streamNotice ? `${streamBuffer}\n\n*${streamNotice}*` : streamBuffer);
     el.scrollTop = el.scrollHeight;
     if (stick) scrollChatToBottom();
   }, 80);
@@ -1082,6 +1085,7 @@ function setOrchestratorBusy(busy) {
     $("#chat-stream-text").innerHTML = "";
     $("#tool-log").innerHTML = "";
     streamBuffer = "";
+    streamNotice = "";
   }
 }
 
@@ -2258,7 +2262,16 @@ function connectEvents() {
 
   es.addEventListener("orchestrator.chunk", (e) => {
     const d = JSON.parse(e.data);
-    streamBuffer += d.content;
+    if (d.reset) streamBuffer = "";
+    if (d.content) {
+      if (d.transient) {
+        streamNotice = d.content.trim();
+      } else {
+        // Real content arriving means any retry wait is over.
+        streamBuffer += d.content;
+        streamNotice = "";
+      }
+    }
     $("#chat-stream").hidden = false;
     scheduleStreamRender();
   });


### PR DESCRIPTION
Sub-agent tasks were failing with "error code: 524" when OpenRouter hit a Cloudflare edge timeout on a rate-limited upstream (Vertex). 524, its 52x siblings, 504 and 408 are now retryable like 429/5xx.

Retry notices were also being persisted into the orchestrator transcript. They are now transient status chunks: shown live under the streaming bubble, dropped from the final message. The orchestrator now honors ResetContent so partial output is not duplicated after a mid-stream retry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer retry handling for temporary provider and gateway failures.
  * Streaming status messages, such as retry notices and fallback updates, are now displayed separately from assistant responses.
  * Temporary notices are excluded from saved conversation content.
  * Partial streamed responses are cleared when a reset is requested.

* **Bug Fixes**
  * Improved recovery from Cloudflare timeouts, gateway timeouts, and other transient service errors.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->