### PR TITLE
Harden the agent git tools

### DIFF
--- a/Saturn.Tests/Tools/GitToolsTests.cs
+++ b/Saturn.Tests/Tools/GitToolsTests.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Saturn.Tools.Git;
+using Xunit;
+
+namespace Saturn.Tests.Tools
+{
+    public class GitToolsTests : IAsyncLifetime
+    {
+        private readonly string _repo;
+
+        public GitToolsTests()
+        {
+            _repo = Path.Combine(Path.GetTempPath(), $"SaturnGitTest_{Guid.NewGuid():N}");
+            Directory.CreateDirectory(_repo);
+        }
+
+        public async Task InitializeAsync()
+        {
+            await Git("init");
+            await Git("config", "user.name", "Test");
+            await Git("config", "user.email", "test@test.local");
+            await Git("config", "commit.gpgsign", "false");
+            File.WriteAllText(Path.Combine(_repo, "tracked.txt"), "original\n");
+            await Git("add", "tracked.txt");
+            await Git("commit", "-m", "initial");
+        }
+
+        public Task DisposeAsync()
+        {
+            try
+            {
+                // Clear read-only attributes .git objects carry on Windows.
+                foreach (var file in Directory.EnumerateFiles(_repo, "*", SearchOption.AllDirectories))
+                {
+                    File.SetAttributes(file, FileAttributes.Normal);
+                }
+                Directory.Delete(_repo, recursive: true);
+            }
+            catch
+            {
+            }
+            return Task.CompletedTask;
+        }
+
+        private async Task Git(params string[] args)
+        {
+            var result = await GitHelper.RunGitCommandAsync(args, _repo);
+            result.Success.Should().BeTrue($"git {string.Join(" ", args)} should succeed but got: {result.Error}");
+        }
+
+        [Theory]
+        [InlineData("plain.txt", "plain.txt")]
+        [InlineData("\"with space.txt\"", "with space.txt")]
+        [InlineData("\"quote\\\".txt\"", "quote\".txt")]
+        [InlineData("\"tab\\there\"", "tab\there")]
+        public void UnquoteGitPath_ResolvesCStyleQuoting(string input, string expected)
+        {
+            GetGitStatusTool.UnquoteGitPath(input).Should().Be(expected);
+        }
+
+        [Fact]
+        public async Task Status_ReportsModifiedAndUntrackedFiles()
+        {
+            File.WriteAllText(Path.Combine(_repo, "tracked.txt"), "changed\n");
+            File.WriteAllText(Path.Combine(_repo, "new.txt"), "hi\n");
+
+            var result = await new GetGitStatusTool().ExecuteAsync(new Dictionary<string, object>
+            {
+                ["workingDirectory"] = _repo
+            });
+
+            result.Success.Should().BeTrue();
+            result.FormattedOutput.Should().Contain("tracked.txt");
+            result.FormattedOutput.Should().Contain("[??] new.txt");
+        }
+
+        [Fact]
+        public async Task Status_ReportsRenameWithOldAndNewPath()
+        {
+            await Git("mv", "tracked.txt", "renamed.txt");
+
+            var result = await new GetGitStatusTool().ExecuteAsync(new Dictionary<string, object>
+            {
+                ["workingDirectory"] = _repo
+            });
+
+            result.Success.Should().BeTrue();
+            result.FormattedOutput.Should().Contain("tracked.txt -> renamed.txt");
+        }
+
+        [Fact]
+        public async Task Diff_NoTrackedChanges_MentionsUntrackedFiles()
+        {
+            File.WriteAllText(Path.Combine(_repo, "brand-new.txt"), "hi\n");
+
+            var result = await new GetGitDiffTool().ExecuteAsync(new Dictionary<string, object>
+            {
+                ["workingDirectory"] = _repo
+            });
+
+            result.Success.Should().BeTrue();
+            result.FormattedOutput.Should().Contain("No differences found.");
+            result.FormattedOutput.Should().Contain("untracked");
+            result.FormattedOutput.Should().Contain("brand-new.txt");
+        }
+
+        [Fact]
+        public async Task Commit_WithFiles_CommitsOnlyThoseFiles()
+        {
+            File.WriteAllText(Path.Combine(_repo, "a.txt"), "a\n");
+            File.WriteAllText(Path.Combine(_repo, "b.txt"), "b\n");
+
+            var result = await new GitCommitTool().ExecuteAsync(new Dictionary<string, object>
+            {
+                ["message"] = "add a only",
+                ["files"] = new[] { "a.txt" },
+                ["workingDirectory"] = _repo
+            });
+
+            result.Success.Should().BeTrue();
+
+            var status = await GitHelper.RunGitCommandAsync(new[] { "status", "--porcelain" }, _repo);
+            status.Output.Should().Contain("b.txt");
+            status.Output.Should().NotContain("a.txt");
+        }
+
+        [Fact]
+        public async Task Commit_FileArgumentLookingLikeFlag_IsNotTreatedAsFlag()
+        {
+            File.WriteAllText(Path.Combine(_repo, "secret.txt"), "do not stage me\n");
+
+            var result = await new GitCommitTool().ExecuteAsync(new Dictionary<string, object>
+            {
+                ["message"] = "sneaky",
+                ["files"] = new[] { "-A" },
+                ["workingDirectory"] = _repo
+            });
+
+            // "-A" must be rejected as a pathspec, not honored as add-everything.
+            result.Success.Should().BeFalse();
+
+            var status = await GitHelper.RunGitCommandAsync(new[] { "status", "--porcelain" }, _repo);
+            status.Output.Should().Contain("?? secret.txt");
+        }
+
+        [Fact]
+        public async Task Helper_Timeout_ReportsTimeoutInsteadOfHanging()
+        {
+            // "git log" through a pager could hang, but redirected output never pages;
+            // use a genuinely slow operation instead: fetch from a non-routable remote.
+            var result = await GitHelper.RunGitCommandAsync(
+                new[] { "fetch", "https://10.255.255.1/nonexistent.git" }, _repo, timeoutSeconds: 2);
+
+            result.Success.Should().BeFalse();
+            result.Error.Should().MatchRegex("timed out|fatal|unable");
+        }
+    }
+}

--- a/Tools/Git/GetGitDiffTool.cs
+++ b/Tools/Git/GetGitDiffTool.cs
@@ -91,16 +91,25 @@ namespace Saturn.Tools.Git
                 }
 
                 var output = result.Output;
-                
+
                 if (string.IsNullOrEmpty(output))
                 {
-                    return CreateSuccessResult(new { Diff = "" }, "No differences found.");
+                    // Plain "git diff" cannot see untracked files; without this hint an
+                    // agent that just created new files concludes nothing has changed.
+                    var untrackedNote = staged ? "" : await DescribeUntrackedFilesAsync(workingDirectory, filePath);
+                    return CreateSuccessResult(new { Diff = "" }, $"No differences found.{untrackedNote}");
                 }
 
                 // Truncate if it's too large and not just a stat
                 if (!statOnly && output.Length > 50000)
                 {
-                    output = output.Substring(0, 50000) + "\n\n... [Diff truncated due to length. Use statOnly=true for a summary.]";
+                    var cut = 50000;
+                    // Never split a surrogate pair at the truncation boundary.
+                    if (char.IsHighSurrogate(output[cut - 1]))
+                    {
+                        cut--;
+                    }
+                    output = output.Substring(0, cut) + "\n\n... [Diff truncated due to length. Use statOnly=true for a summary.]";
                 }
 
                 return CreateSuccessResult(new { Diff = output }, output);
@@ -109,6 +118,32 @@ namespace Saturn.Tools.Git
             {
                 return CreateErrorResult($"Exception executing git diff: {ex.Message}");
             }
+        }
+
+        private static async Task<string> DescribeUntrackedFilesAsync(string workingDirectory, string filePath)
+        {
+            var args = new List<string> { "ls-files", "--others", "--exclude-standard" };
+            if (!string.IsNullOrEmpty(filePath))
+            {
+                args.Add("--");
+                args.Add(filePath);
+            }
+
+            var result = await GitHelper.RunGitCommandAsync(args, workingDirectory);
+            if (!result.Success)
+            {
+                return "";
+            }
+
+            var untracked = result.Output.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+            if (untracked.Length == 0)
+            {
+                return "";
+            }
+
+            var listed = string.Join(", ", untracked.Take(10));
+            var suffix = untracked.Length > 10 ? $" (and {untracked.Length - 10} more)" : "";
+            return $" Note: {untracked.Length} untracked file(s) are not shown by git diff: {listed}{suffix}";
         }
     }
 }

--- a/Tools/Git/GetGitDiffTool.cs
+++ b/Tools/Git/GetGitDiffTool.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Saturn.Tools.Core;
+
+namespace Saturn.Tools.Git
+{
+    public class GetGitDiffTool : ToolBase
+    {
+        public override string Name => "get_git_diff";
+        public override string Description => "Gets the current uncommitted changes in a structured format or raw diff.";
+
+        protected override Dictionary<string, object> GetParameterProperties()
+        {
+            return new Dictionary<string, object>
+            {
+                {
+                    "filePath", new Dictionary<string, object>
+                    {
+                        { "type", "string" },
+                        { "description", "If provided, only get diff for this file." }
+                    }
+                },
+                {
+                    "staged", new Dictionary<string, object>
+                    {
+                        { "type", "boolean" },
+                        { "description", "If true, get diff of staged changes (git diff --cached)." }
+                    }
+                },
+                {
+                    "statOnly", new Dictionary<string, object>
+                    {
+                        { "type", "boolean" },
+                        { "description", "If true, only return the diff stat (summary) instead of the full diff." }
+                    }
+                },
+                {
+                    "workingDirectory", new Dictionary<string, object>
+                    {
+                        { "type", "string" },
+                        { "description", "The working directory to run git diff in. Defaults to current directory." }
+                    }
+                }
+            };
+        }
+
+        protected override string[] GetRequiredParameters()
+        {
+            return Array.Empty<string>();
+        }
+
+        public override async Task<ToolResult> ExecuteAsync(Dictionary<string, object> parameters)
+        {
+            var filePath = GetParameter<string>(parameters, "filePath", string.Empty);
+            var staged = GetParameter<bool>(parameters, "staged", false);
+            var statOnly = GetParameter<bool>(parameters, "statOnly", false);
+            var workingDirectory = GetParameter<string>(parameters, "workingDirectory", Environment.CurrentDirectory);
+
+            if (!Directory.Exists(workingDirectory))
+            {
+                return CreateErrorResult($"Working directory does not exist: {workingDirectory}");
+            }
+
+            try
+            {
+                var arguments = new List<string> { "diff" };
+                
+                if (staged)
+                {
+                    arguments.Add("--cached");
+                }
+                
+                if (statOnly)
+                {
+                    arguments.Add("--stat");
+                }
+                
+                if (!string.IsNullOrEmpty(filePath))
+                {
+                    arguments.Add("--");
+                    arguments.Add(filePath);
+                }
+
+                var result = await GitHelper.RunGitCommandAsync(arguments, workingDirectory);
+
+                if (!result.Success)
+                {
+                    return CreateErrorResult($"Git diff failed. Error: {result.Error}");
+                }
+
+                var output = result.Output;
+                
+                if (string.IsNullOrEmpty(output))
+                {
+                    return CreateSuccessResult(new { Diff = "" }, "No differences found.");
+                }
+
+                // Truncate if it's too large and not just a stat
+                if (!statOnly && output.Length > 50000)
+                {
+                    output = output.Substring(0, 50000) + "\n\n... [Diff truncated due to length. Use statOnly=true for a summary.]";
+                }
+
+                return CreateSuccessResult(new { Diff = output }, output);
+            }
+            catch (Exception ex)
+            {
+                return CreateErrorResult($"Exception executing git diff: {ex.Message}");
+            }
+        }
+    }
+}

--- a/Tools/Git/GetGitStatusTool.cs
+++ b/Tools/Git/GetGitStatusTool.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Saturn.Tools.Core;
+
+namespace Saturn.Tools.Git
+{
+    public class GetGitStatusTool : ToolBase
+    {
+        public override string Name => "get_git_status";
+        public override string Description => "Returns a structured list of modified, added, and untracked files in the current git repository.";
+
+        protected override Dictionary<string, object> GetParameterProperties()
+        {
+            return new Dictionary<string, object>
+            {
+                {
+                    "workingDirectory", new Dictionary<string, object>
+                    {
+                        { "type", "string" },
+                        { "description", "The working directory to run git status in. Defaults to current directory." }
+                    }
+                }
+            };
+        }
+
+        protected override string[] GetRequiredParameters()
+        {
+            return Array.Empty<string>();
+        }
+
+        public override async Task<ToolResult> ExecuteAsync(Dictionary<string, object> parameters)
+        {
+            var workingDirectory = GetParameter<string>(parameters, "workingDirectory", Environment.CurrentDirectory);
+
+            if (!Directory.Exists(workingDirectory))
+            {
+                return CreateErrorResult($"Working directory does not exist: {workingDirectory}");
+            }
+
+            try
+            {
+                var result = await GitHelper.RunGitCommandAsync(new[] { "status", "--porcelain" }, workingDirectory);
+
+                if (!result.Success)
+                {
+                    return CreateErrorResult($"Git status failed. Error: {result.Error}");
+                }
+
+                var lines = result.Output.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+
+                var statusList = new List<GitFileStatus>();
+                foreach (var line in lines)
+                {
+                    if (line.Length >= 4)
+                    {
+                        var status = line.Substring(0, 2);
+                        var filePath = line.Substring(3);
+                        statusList.Add(new GitFileStatus { Status = status, FilePath = filePath });
+                    }
+                }
+
+                var formattedOutput = string.Join(Environment.NewLine, statusList.Select(s => $"[{s.Status}] {s.FilePath}"));
+                if (string.IsNullOrEmpty(formattedOutput))
+                {
+                    formattedOutput = "Working tree clean.";
+                }
+
+                return CreateSuccessResult(statusList, formattedOutput);
+            }
+            catch (Exception ex)
+            {
+                return CreateErrorResult($"Exception executing git status: {ex.Message}");
+            }
+        }
+
+        public class GitFileStatus
+        {
+            public string Status { get; set; } = string.Empty;
+            public string FilePath { get; set; } = string.Empty;
+        }
+    }
+}

--- a/Tools/Git/GetGitStatusTool.cs
+++ b/Tools/Git/GetGitStatusTool.cs
@@ -42,7 +42,9 @@ namespace Saturn.Tools.Git
 
             try
             {
-                var result = await GitHelper.RunGitCommandAsync(new[] { "status", "--porcelain" }, workingDirectory);
+                // quotepath=off keeps non-ASCII paths readable instead of octal-escaped.
+                var result = await GitHelper.RunGitCommandAsync(
+                    new[] { "-c", "core.quotepath=off", "status", "--porcelain" }, workingDirectory);
 
                 if (!result.Success)
                 {
@@ -54,15 +56,38 @@ namespace Saturn.Tools.Git
                 var statusList = new List<GitFileStatus>();
                 foreach (var line in lines)
                 {
-                    if (line.Length >= 4)
+                    if (line.Length < 4)
                     {
-                        var status = line.Substring(0, 2);
-                        var filePath = line.Substring(3);
-                        statusList.Add(new GitFileStatus { Status = status, FilePath = filePath });
+                        continue;
                     }
+
+                    var status = line.Substring(0, 2);
+                    var pathPart = line.Substring(3);
+                    string? oldPath = null;
+
+                    // Renames and copies come through as "old -> new".
+                    if (status[0] == 'R' || status[0] == 'C')
+                    {
+                        var arrow = pathPart.IndexOf(" -> ", StringComparison.Ordinal);
+                        if (arrow >= 0)
+                        {
+                            oldPath = UnquoteGitPath(pathPart.Substring(0, arrow));
+                            pathPart = pathPart.Substring(arrow + 4);
+                        }
+                    }
+
+                    statusList.Add(new GitFileStatus
+                    {
+                        Status = status,
+                        FilePath = UnquoteGitPath(pathPart),
+                        OldPath = oldPath
+                    });
                 }
 
-                var formattedOutput = string.Join(Environment.NewLine, statusList.Select(s => $"[{s.Status}] {s.FilePath}"));
+                var formattedOutput = string.Join(Environment.NewLine,
+                    statusList.Select(s => s.OldPath != null
+                        ? $"[{s.Status}] {s.OldPath} -> {s.FilePath}"
+                        : $"[{s.Status}] {s.FilePath}"));
                 if (string.IsNullOrEmpty(formattedOutput))
                 {
                     formattedOutput = "Working tree clean.";
@@ -76,10 +101,43 @@ namespace Saturn.Tools.Git
             }
         }
 
+        // Paths with special characters (quotes, newlines) arrive C-style quoted
+        // even with quotepath=off; strip the quotes and resolve the escapes.
+        internal static string UnquoteGitPath(string path)
+        {
+            if (path.Length < 2 || path[0] != '"' || path[path.Length - 1] != '"')
+            {
+                return path;
+            }
+
+            var inner = path.Substring(1, path.Length - 2);
+            var sb = new System.Text.StringBuilder(inner.Length);
+            for (var i = 0; i < inner.Length; i++)
+            {
+                var c = inner[i];
+                if (c != '\\' || i + 1 >= inner.Length)
+                {
+                    sb.Append(c);
+                    continue;
+                }
+
+                var next = inner[++i];
+                sb.Append(next switch
+                {
+                    'n' => '\n',
+                    't' => '\t',
+                    'r' => '\r',
+                    _ => next
+                });
+            }
+            return sb.ToString();
+        }
+
         public class GitFileStatus
         {
             public string Status { get; set; } = string.Empty;
             public string FilePath { get; set; } = string.Empty;
+            public string? OldPath { get; set; }
         }
     }
 }

--- a/Tools/Git/GitCommitTool.cs
+++ b/Tools/Git/GitCommitTool.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Saturn.Tools.Core;
+
+namespace Saturn.Tools.Git
+{
+    public class GitCommitTool : ToolBase
+    {
+        public override string Name => "git_commit";
+        public override string Description => "Creates a new git commit with the specified message.";
+
+        protected override Dictionary<string, object> GetParameterProperties()
+        {
+            return new Dictionary<string, object>
+            {
+                {
+                    "message", new Dictionary<string, object>
+                    {
+                        { "type", "string" },
+                        { "description", "The commit message." }
+                    }
+                },
+                {
+                    "files", new Dictionary<string, object>
+                    {
+                        { "type", "array" },
+                        { "items", new Dictionary<string, object> { { "type", "string" } } },
+                        { "description", "List of specific files to add before committing. If empty, only already staged changes are committed." }
+                    }
+                },
+                {
+                    "workingDirectory", new Dictionary<string, object>
+                    {
+                        { "type", "string" },
+                        { "description", "The working directory to run git commit in. Defaults to current directory." }
+                    }
+                }
+            };
+        }
+
+        protected override string[] GetRequiredParameters()
+        {
+            return new[] { "message" };
+        }
+
+        public override async Task<ToolResult> ExecuteAsync(Dictionary<string, object> parameters)
+        {
+            var message = GetParameter<string>(parameters, "message");
+            var files = GetParameter<string[]>(parameters, "files", Array.Empty<string>());
+            var workingDirectory = GetParameter<string>(parameters, "workingDirectory", Environment.CurrentDirectory);
+
+            if (string.IsNullOrEmpty(message))
+            {
+                return CreateErrorResult("Commit message is required.");
+            }
+
+            if (!Directory.Exists(workingDirectory))
+            {
+                return CreateErrorResult($"Working directory does not exist: {workingDirectory}");
+            }
+
+            try
+            {
+                if (files != null && files.Length > 0)
+                {
+                    var addArgs = new List<string> { "add" };
+                    addArgs.AddRange(files);
+                    
+                    var addResult = await GitHelper.RunGitCommandAsync(addArgs, workingDirectory);
+                    if (!addResult.Success)
+                    {
+                        return CreateErrorResult($"Failed to add files: {addResult.Error}");
+                    }
+                }
+
+                var commitArgs = new List<string> { "commit", "-m", message };
+                var commitResult = await GitHelper.RunGitCommandAsync(commitArgs, workingDirectory);
+                
+                if (!commitResult.Success)
+                {
+                    return CreateErrorResult($"Git commit failed: {commitResult.Error}");
+                }
+
+                return CreateSuccessResult(new { Output = commitResult.Output }, commitResult.Output);
+            }
+            catch (Exception ex)
+            {
+                return CreateErrorResult($"Exception executing git commit: {ex.Message}");
+            }
+        }
+    }
+}

--- a/Tools/Git/GitCommitTool.cs
+++ b/Tools/Git/GitCommitTool.cs
@@ -65,7 +65,9 @@ namespace Saturn.Tools.Git
             {
                 if (files != null && files.Length > 0)
                 {
-                    var addArgs = new List<string> { "add" };
+                    // "--" stops flag parsing so a "file" like -A cannot silently
+                    // re-enable the add-everything behavior this parameter prevents.
+                    var addArgs = new List<string> { "add", "--" };
                     addArgs.AddRange(files);
                     
                     var addResult = await GitHelper.RunGitCommandAsync(addArgs, workingDirectory);

--- a/Tools/Git/GitHelper.cs
+++ b/Tools/Git/GitHelper.cs
@@ -42,8 +42,17 @@ namespace Saturn.Tools.Git
             }
             catch (OperationCanceledException)
             {
-                process.Kill();
-                return (false, "", "Git command timed out.");
+                // Git spawns children (hooks, credential helpers); killing only the
+                // parent leaves them orphaned and holding the index lock.
+                try
+                {
+                    process.Kill(entireProcessTree: true);
+                }
+                catch (InvalidOperationException)
+                {
+                    // Already exited between the timeout and the kill.
+                }
+                return (false, "", $"Git command timed out after {timeoutSeconds}s.");
             }
 
             var output = await outputTask;

--- a/Tools/Git/GitHelper.cs
+++ b/Tools/Git/GitHelper.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Saturn.Tools.Git
+{
+    public static class GitHelper
+    {
+        public static async Task<(bool Success, string Output, string Error)> RunGitCommandAsync(IEnumerable<string> arguments, string workingDirectory, int timeoutSeconds = 30)
+        {
+            var processStartInfo = new ProcessStartInfo
+            {
+                FileName = "git",
+                WorkingDirectory = workingDirectory,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            foreach (var arg in arguments)
+            {
+                processStartInfo.ArgumentList.Add(arg);
+            }
+
+            using var process = Process.Start(processStartInfo);
+            if (process == null)
+            {
+                return (false, "", "Failed to start git process.");
+            }
+
+            var outputTask = process.StandardOutput.ReadToEndAsync();
+            var errorTask = process.StandardError.ReadToEndAsync();
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(timeoutSeconds));
+            try
+            {
+                await process.WaitForExitAsync(cts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                process.Kill();
+                return (false, "", "Git command timed out.");
+            }
+
+            var output = await outputTask;
+            var error = await errorTask;
+
+            return (process.ExitCode == 0, output, error);
+        }
+    }
+}


### PR DESCRIPTION
Includes the agent-authored git tools (unpushed local commit) plus hardening fixes from review:

- git add uses a "--" separator so a files entry like "-A" cannot silently stage everything
- Timeouts kill the whole git process tree, not just the parent
- Status parsing handles renames, unquotes special-character paths, disables octal quoting
- git diff with no tracked changes lists untracked files instead of a misleading "No differences found"
- Diff truncation no longer splits UTF-16 surrogate pairs

Adds integration tests for the injection guard, rename and untracked reporting, selective commits, and helper timeouts.
