### PR TITLE
Add chat history management to the orchestrator web UI

### DIFF
--- a/Data/ChatHistoryRepository.cs
+++ b/Data/ChatHistoryRepository.cs
@@ -633,6 +633,80 @@ public class ChatHistoryRepository : IDisposable
         });
     }
 
+    public async Task SetSessionActiveAsync(string sessionId)
+    {
+        await WithDbLockAsync(async () =>
+        {
+            using var connection = CreateConnection();
+
+            var sql = "UPDATE ChatSessions SET IsActive = 1 WHERE Id = @Id";
+            using var cmd = new SqliteCommand(sql, connection);
+            cmd.Parameters.AddWithValue("@Id", sessionId);
+
+            await cmd.ExecuteNonQueryAsync();
+        });
+    }
+
+    public async Task<bool> RenameSessionAsync(string sessionId, string title)
+    {
+        return await WithDbLockAsync(async () =>
+        {
+            using var connection = CreateConnection();
+
+            var sql = "UPDATE ChatSessions SET Title = @Title, UpdatedAt = @UpdatedAt WHERE Id = @Id";
+            using var cmd = new SqliteCommand(sql, connection);
+            cmd.Parameters.AddWithValue("@Id", sessionId);
+            cmd.Parameters.AddWithValue("@Title", title);
+            cmd.Parameters.AddWithValue("@UpdatedAt", DateTime.UtcNow.ToString("O"));
+
+            return await cmd.ExecuteNonQueryAsync() > 0;
+        });
+    }
+
+    public async Task<bool> DeleteSessionAsync(string sessionId)
+    {
+        return await WithDbLockAsync(async () =>
+        {
+            using var connection = CreateConnection();
+            using var transaction = connection.BeginTransaction();
+
+            try
+            {
+                // Sub-agent sessions hang off the parent; removing a chat removes
+                // the whole tree so no orphaned rows survive.
+                var scope = "SELECT Id FROM ChatSessions WHERE Id = @Id OR ParentSessionId = @Id";
+
+                foreach (var sql in new[]
+                {
+                    $"DELETE FROM ToolCalls WHERE SessionId IN ({scope})",
+                    $"DELETE FROM ChatMessages WHERE SessionId IN ({scope})",
+                    $"DELETE FROM SessionTodos WHERE SessionId IN ({scope})",
+                })
+                {
+                    using var cmd = new SqliteCommand(sql, connection, transaction);
+                    cmd.Parameters.AddWithValue("@Id", sessionId);
+                    await cmd.ExecuteNonQueryAsync();
+                }
+
+                int deleted;
+                using (var cmd = new SqliteCommand(
+                    "DELETE FROM ChatSessions WHERE Id = @Id OR ParentSessionId = @Id", connection, transaction))
+                {
+                    cmd.Parameters.AddWithValue("@Id", sessionId);
+                    deleted = await cmd.ExecuteNonQueryAsync();
+                }
+
+                await transaction.CommitAsync();
+                return deleted > 0;
+            }
+            catch
+            {
+                await transaction.RollbackAsync();
+                throw;
+            }
+        });
+    }
+
     public async Task SaveSessionTodosAsync(string sessionId, string? todosJson)
     {
         await WithDbLockAsync(async () =>

--- a/Web/ApiModels.cs
+++ b/Web/ApiModels.cs
@@ -52,6 +52,8 @@ namespace Saturn.Web
 
     public record ApprovalDecisionRequest(bool Approved);
 
+    public record SessionRenameRequest(string? Title);
+
     public record ProviderSwitchRequest(string Provider, Dictionary<string, string?>? Settings, string? Model);
 
     public record SearchProviderSwitchRequest(string? Provider, Dictionary<string, string?>? Settings);

--- a/Web/OrchestratorService.cs
+++ b/Web/OrchestratorService.cs
@@ -47,6 +47,8 @@ namespace Saturn.Web
 
         public string Model => _agent.Configuration.Model;
 
+        public string? CurrentSessionId => _agent.CurrentSessionId;
+
         public List<TranscriptEntry> GetTranscript()
         {
             lock (_transcriptLock)
@@ -65,22 +67,7 @@ namespace Saturn.Web
                     return;
                 }
 
-                var messages = await history.GetMessagesAsync(sessions[0].Id);
-                // Tool-call turns are stored with a literal "null" content; they are not part of the visible conversation.
-                var restored = messages
-                    .Where(m => (m.Role == "user" || m.Role == "assistant")
-                        && !string.IsNullOrWhiteSpace(m.Content)
-                        && m.Content != "null")
-                    .Select(m => new TranscriptEntry
-                    {
-                        Role = m.Role,
-                        Content = m.Content,
-                        Timestamp = m.Timestamp,
-                        // Persisted messages carry no source; recover the scheduler tag
-                        // from the prompt prefix so they keep their styling after restart.
-                        Source = m.Role == "user" && m.Content.StartsWith("[Saturn Scheduler]") ? "scheduler" : "user"
-                    })
-                    .ToList();
+                var restored = ToTranscriptEntries(await history.GetMessagesAsync(sessions[0].Id));
 
                 if (restored.Count == 0)
                 {
@@ -234,6 +221,56 @@ namespace Saturn.Web
                 _transcript.Add(entry);
             }
             _hub.Publish("orchestrator.message", entry);
+        }
+
+        // Tool-call turns are stored with a literal "null" content; they are not part of the visible conversation.
+        private static List<TranscriptEntry> ToTranscriptEntries(IEnumerable<Saturn.Data.Models.ChatMessage> messages)
+        {
+            return messages
+                .Where(m => (m.Role == "user" || m.Role == "assistant")
+                    && !string.IsNullOrWhiteSpace(m.Content)
+                    && m.Content != "null")
+                .Select(m => new TranscriptEntry
+                {
+                    Role = m.Role,
+                    Content = m.Content,
+                    Timestamp = m.Timestamp,
+                    // Persisted messages carry no source; recover the scheduler tag
+                    // from the prompt prefix so they keep their styling after restart.
+                    Source = m.Role == "user" && m.Content.StartsWith("[Saturn Scheduler]") ? "scheduler" : "user"
+                })
+                .ToList();
+        }
+
+        /// <summary>
+        /// Points the orchestrator at an existing main-chat session: the current
+        /// session is closed and the target's history becomes the live context.
+        /// Returns false when a run is in flight — switching mid-response would
+        /// interleave two conversations.
+        /// </summary>
+        public async Task<bool> SwitchSessionAsync(string sessionId, ChatHistoryRepository history)
+        {
+            if (IsBusy)
+            {
+                return false;
+            }
+
+            var restored = ToTranscriptEntries(await history.GetMessagesAsync(sessionId));
+
+            _agent.ClearHistory();
+            _parentWired = false;
+            _agent.CurrentSessionId = sessionId;
+            await history.SetSessionActiveAsync(sessionId);
+            _agent.RehydrateHistory(restored.Select(e => (e.Role, e.Content)).ToList());
+
+            lock (_transcriptLock)
+            {
+                _sessionEpoch++;
+                _transcript.Clear();
+                _transcript.AddRange(restored);
+            }
+            _hub.Publish("orchestrator.session", new { sessionId });
+            return true;
         }
 
         public void StartNewSession()

--- a/Web/WebServer.cs
+++ b/Web/WebServer.cs
@@ -722,6 +722,7 @@ namespace Saturn.Web
             {
                 busy = _orchestrator.IsBusy,
                 model = _orchestrator.Model,
+                sessionId = _orchestrator.CurrentSessionId,
                 entries = _orchestrator.GetTranscript()
             }));
 
@@ -982,6 +983,57 @@ namespace Saturn.Web
             api.MapPost("/orchestrator/new-session", () =>
             {
                 _orchestrator.StartNewSession();
+                return Results.Ok();
+            });
+
+            api.MapPost("/orchestrator/sessions/{id}/switch", async (string id) =>
+            {
+                var session = await _history.GetSessionAsync(id);
+                if (session == null || session.ChatType != "main")
+                {
+                    return Results.NotFound(new { error = $"Chat session {id} not found" });
+                }
+                if (id == _orchestrator.CurrentSessionId)
+                {
+                    return Results.Ok(new { sessionId = id });
+                }
+                if (!await _orchestrator.SwitchSessionAsync(id, _history))
+                {
+                    return Results.Conflict(new { error = "Orchestrator is busy; cancel the current run first" });
+                }
+                return Results.Ok(new { sessionId = id });
+            });
+
+            api.MapPut("/sessions/{id}", async (string id, SessionRenameRequest request) =>
+            {
+                var title = request.Title?.Trim();
+                if (string.IsNullOrEmpty(title))
+                {
+                    return Results.BadRequest(new { error = "Title is required" });
+                }
+                if (!await _history.RenameSessionAsync(id, title))
+                {
+                    return Results.NotFound(new { error = $"Session {id} not found" });
+                }
+                _hub.Publish("sessions.changed", new { sessionId = id });
+                return Results.Ok();
+            });
+
+            api.MapDelete("/sessions/{id}", async (string id) =>
+            {
+                if (id == _orchestrator.CurrentSessionId)
+                {
+                    if (_orchestrator.IsBusy)
+                    {
+                        return Results.Conflict(new { error = "Orchestrator is busy; cancel the current run first" });
+                    }
+                    _orchestrator.StartNewSession();
+                }
+                if (!await _history.DeleteSessionAsync(id))
+                {
+                    return Results.NotFound(new { error = $"Session {id} not found" });
+                }
+                _hub.Publish("sessions.changed", new { sessionId = id });
                 return Results.Ok();
             });
         }

--- a/Web/wwwroot/app.js
+++ b/Web/wwwroot/app.js
@@ -204,6 +204,8 @@ const state = {
   todoScope: "all",
   todoBoard: null,
   sessions: [],
+  chatSessions: [],
+  chatSessionId: null,
   approvals: [],
   transcript: [],
   orchestratorBusy: false,
@@ -231,6 +233,7 @@ function showView(name) {
   state.view = name;
   $$(".nav-item").forEach((b) => b.classList.toggle("active", b.dataset.view === name));
   $$(".view").forEach((v) => v.classList.toggle("active", v.id === `view-${name}`));
+  $("#nav-chats").hidden = name !== "orchestrator";
   $("#view-title").textContent = VIEW_TITLES[name] || name;
   updateApprovalBanner();
   syncHash();
@@ -242,7 +245,7 @@ async function refreshView(name) {
     if (name === "overview") await loadOverview();
     else if (name === "agents") await loadAgents();
     else if (name === "work") await Promise.all([loadTodos(), loadTasks(), loadWakes()]);
-    else if (name === "orchestrator") await Promise.all([loadTranscript(), loadAgents(), loadTasks(), loadTodos()]);
+    else if (name === "orchestrator") await Promise.all([loadTranscript(), loadChatSessions(), loadAgents(), loadTasks(), loadTodos()]);
     else if (name === "sessions") await loadSessions();
     else if (name === "approvals") await loadApprovals();
     else if (name === "settings") await loadSettings();
@@ -945,8 +948,118 @@ function isNearBottom(margin = 160) {
 async function loadTranscript() {
   const t = await api.get("/orchestrator/transcript");
   state.transcript = t.entries;
+  state.chatSessionId = t.sessionId;
   setOrchestratorBusy(t.busy);
   renderTranscript({ stick: true });
+  renderChatSessions();
+}
+
+/* ---------- sidebar chat history ---------- */
+
+async function loadChatSessions() {
+  const sessions = await api.get("/sessions?limit=100");
+  state.chatSessions = sessions.filter((s) => s.chatType === "main");
+  renderChatSessions();
+}
+
+function renderChatSessions() {
+  const list = $("#nav-chat-list");
+  list.innerHTML = state.chatSessions
+    .map(
+      (s) => `
+      <li class="nav-chat${s.id === state.chatSessionId ? " active" : ""}" data-chat="${esc(s.id)}" title="${esc(s.title || s.id)}">
+        <span class="nav-chat-title">${esc(s.title || s.id)}</span>
+        <span class="nav-chat-actions">
+          <button class="nav-chat-btn" data-chat-rename="${esc(s.id)}" title="rename">✎</button>
+          <button class="nav-chat-btn danger" data-chat-delete="${esc(s.id)}" title="delete">✕</button>
+        </span>
+      </li>`
+    )
+    .join("");
+
+  list.querySelectorAll("[data-chat]").forEach((row) =>
+    row.addEventListener("click", () => switchChatSession(row.dataset.chat))
+  );
+  list.querySelectorAll("[data-chat-rename]").forEach((btn) =>
+    btn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      startChatRename(btn.dataset.chatRename);
+    })
+  );
+  list.querySelectorAll("[data-chat-delete]").forEach((btn) =>
+    btn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      deleteChatSession(btn.dataset.chatDelete);
+    })
+  );
+}
+
+async function switchChatSession(id) {
+  if (id === state.chatSessionId) return;
+  if (state.orchestratorBusy) {
+    toast("The assistant is busy — cancel the current run before switching chats.");
+    return;
+  }
+  try {
+    await api.post(`/orchestrator/sessions/${id}/switch`);
+    await loadTranscript();
+  } catch (err) {
+    toast(`<b>Error:</b> ${esc(err.message)}`);
+  }
+}
+
+// Rename happens inline: the title swaps for an input; Enter saves, Escape or
+// clicking away cancels.
+function startChatRename(id) {
+  const row = $(`#nav-chat-list [data-chat="${CSS.escape(id)}"]`);
+  const session = state.chatSessions.find((s) => s.id === id);
+  if (!row || !session) return;
+  const input = document.createElement("input");
+  input.className = "input nav-chat-edit";
+  input.value = session.title || "";
+  row.replaceChildren(input);
+  input.focus();
+  input.select();
+
+  let done = false;
+  const finish = async (save) => {
+    if (done) return;
+    done = true;
+    const title = input.value.trim();
+    if (save && title && title !== session.title) {
+      try {
+        await api.put(`/sessions/${id}`, { title });
+        session.title = title;
+      } catch (err) {
+        toast(`<b>Error:</b> ${esc(err.message)}`);
+      }
+    }
+    renderChatSessions();
+  };
+  input.addEventListener("keydown", (e) => {
+    e.stopPropagation();
+    if (e.key === "Enter") finish(true);
+    if (e.key === "Escape") finish(false);
+  });
+  input.addEventListener("blur", () => finish(true));
+  input.addEventListener("click", (e) => e.stopPropagation());
+}
+
+async function deleteChatSession(id) {
+  const session = state.chatSessions.find((s) => s.id === id);
+  const ok = await confirmModal(
+    "Delete this chat?",
+    `“${esc(session?.title || id)}” and its messages are removed permanently.`,
+    "Delete"
+  );
+  if (!ok) return;
+  try {
+    await api.del(`/sessions/${id}`);
+    state.chatSessions = state.chatSessions.filter((s) => s.id !== id);
+    renderChatSessions();
+  } catch (err) {
+    toast(`<b>Error:</b> ${esc(err.message)}`);
+  }
 }
 
 function summarizeToolArgs(argsJson) {
@@ -1118,6 +1231,7 @@ $("#chat-form").addEventListener("submit", async (e) => {
   currentTurnTools = [];
   setOrchestratorBusy(true);
   $("#chat-text").value = "";
+  autosizeChatText();
 
   try {
     await api.post("/orchestrator/message", { message });
@@ -1125,6 +1239,7 @@ $("#chat-form").addEventListener("submit", async (e) => {
     state.transcript = state.transcript.filter((x) => x !== entry);
     renderTranscript();
     $("#chat-text").value = message;
+    autosizeChatText();
     if (err.status === 409) {
       // A scheduler-initiated run is already in progress; the server's state
       // events keep driving the busy UI, so don't tear down the live stream.
@@ -1146,19 +1261,26 @@ $("#chat-text").addEventListener("keydown", (e) => {
 $("#chat-cancel").addEventListener("click", () => api.post("/orchestrator/cancel").catch(() => {}));
 
 $("#chat-new").addEventListener("click", async () => {
-  const ok = await confirmModal(
-    "Start a fresh conversation?",
-    "The current chat context is closed. History stays available in Sessions.",
-    "New chat",
-    false
-  );
-  if (!ok) return;
+  // Already on a blank chat — nothing to do.
+  if (!state.chatSessionId && state.transcript.length === 0) return;
   try {
     await api.post("/orchestrator/new-session");
+    state.chatSessionId = null;
+    await loadChatSessions();
   } catch (err) {
     toast(`<b>Error:</b> ${esc(err.message)}`);
   }
 });
+
+// The input starts one row tall and grows with the draft, like any chat app.
+const chatText = $("#chat-text");
+function autosizeChatText() {
+  chatText.style.height = "auto";
+  // scrollHeight excludes the 2px of border that border-box height includes;
+  // without it the field shrinks 2px on first input.
+  chatText.style.height = `${Math.min(chatText.scrollHeight + 2, 200)}px`;
+}
+chatText.addEventListener("input", autosizeChatText);
 
 /* ---------- todos / task manager ---------- */
 
@@ -2258,6 +2380,12 @@ function connectEvents() {
       renderToolLog();
     }
     setOrchestratorBusy(d.busy);
+    // A finished turn may have created the session (first message) or bumped
+    // its timestamp — refresh the sidebar list.
+    if (!d.busy && state.view === "orchestrator") {
+      loadChatSessions().catch(() => {});
+      if (!state.chatSessionId) loadTranscript().catch(() => {});
+    }
   });
 
   es.addEventListener("orchestrator.chunk", (e) => {
@@ -2307,10 +2435,26 @@ function connectEvents() {
 
   es.addEventListener("orchestrator.cleared", () => {
     state.transcript = [];
+    state.chatSessionId = null;
     currentTurnTools = [];
     setOrchestratorBusy(false);
-    if (state.view === "orchestrator") renderTranscript({ stick: true });
+    if (state.view === "orchestrator") {
+      renderTranscript({ stick: true });
+      renderChatSessions();
+    }
     toast("Started a <b>new conversation</b>");
+  });
+
+  es.addEventListener("orchestrator.session", () => {
+    if (state.view === "orchestrator") {
+      loadTranscript().catch(() => {});
+      loadChatSessions().catch(() => {});
+    }
+  });
+
+  es.addEventListener("sessions.changed", () => {
+    if (state.view === "orchestrator") loadChatSessions().catch(() => {});
+    if (state.view === "sessions") loadSessions().catch(() => {});
   });
 
   es.addEventListener("provider.changed", (e) => {

--- a/Web/wwwroot/index.html
+++ b/Web/wwwroot/index.html
@@ -23,6 +23,10 @@
         <button class="nav-item active" data-view="orchestrator">
           <span class="nav-icon">◈</span><span class="nav-label">Orchestrator</span>
         </button>
+        <div class="nav-chats" id="nav-chats" hidden>
+          <button class="nav-chats-new" id="chat-new">+ New chat</button>
+          <ul class="nav-chat-list" id="nav-chat-list"></ul>
+        </div>
         <button class="nav-item" data-view="overview">
           <span class="nav-icon">▣</span><span class="nav-label">Overview</span>
         </button>
@@ -148,11 +152,10 @@
             </div>
           </div>
           <form class="chat-input" id="chat-form">
-            <textarea id="chat-text" rows="2" placeholder="Instruct the orchestrator… (Enter to send, Shift+Enter for newline)"></textarea>
+            <textarea id="chat-text" rows="1" placeholder="Instruct the orchestrator… (Enter to send, Shift+Enter for newline)"></textarea>
             <div class="chat-buttons">
               <button type="submit" class="btn primary" id="chat-send">Send</button>
               <button type="button" class="btn danger" id="chat-cancel" hidden>Cancel</button>
-              <button type="button" class="btn ghost sm" id="chat-new" title="start a fresh conversation">New chat</button>
             </div>
           </form>
         </div>

--- a/Web/wwwroot/styles.css
+++ b/Web/wwwroot/styles.css
@@ -16,7 +16,7 @@
   --ok: #7dd692;
   --warn: #e2c26f;
   --danger: #e2726f;
-  --radius: 10px;
+  --radius: 6px;
   --font-mono: ui-monospace, "Cascadia Code", "SF Mono", "Menlo", "Consolas", monospace;
   --ease: cubic-bezier(0.22, 1, 0.36, 1);
 }
@@ -39,7 +39,7 @@ input, textarea, select { font: inherit; color: inherit; }
 ::selection { background: #ffffff33; }
 
 ::-webkit-scrollbar { width: 10px; height: 10px; }
-::-webkit-scrollbar-thumb { background: #2c2c2c; border-radius: 5px; border: 2px solid var(--bg); }
+::-webkit-scrollbar-thumb { background: #2c2c2c; border-radius: 3px; border: 2px solid var(--bg); }
 ::-webkit-scrollbar-thumb:hover { background: #3d3d3d; }
 ::-webkit-scrollbar-track { background: transparent; }
 
@@ -74,7 +74,7 @@ input, textarea, select { font: inherit; color: inherit; }
   align-items: center;
   gap: 10px;
   padding: 9px 12px;
-  border-radius: 8px;
+  border-radius: 4px;
   color: var(--muted);
   text-align: left;
   transition: background 0.18s var(--ease), color 0.18s var(--ease), transform 0.12s var(--ease);
@@ -101,11 +101,63 @@ input, textarea, select { font: inherit; color: inherit; }
 .nav-badge.alert:not(:empty) { border-color: var(--warn); color: var(--warn); }
 .nav-badge.hidden { display: none; }
 
+/* Chat history nested under the Orchestrator tab. */
+.nav-chats {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin: 2px 0 8px;
+  padding-left: 18px;
+  min-height: 0;
+  overflow-y: auto;
+  max-height: 40vh;
+}
+.nav-chats-new {
+  text-align: left;
+  padding: 6px 10px;
+  border-radius: 4px;
+  font-size: 12px;
+  color: var(--muted);
+  transition: background 0.18s var(--ease), color 0.18s var(--ease);
+}
+.nav-chats-new:hover { background: var(--panel-2); color: var(--text); }
+.nav-chat-list { list-style: none; display: flex; flex-direction: column; gap: 1px; }
+.nav-chat {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 5px 8px 5px 10px;
+  border-radius: 4px;
+  font-size: 12px;
+  color: var(--muted);
+  cursor: pointer;
+  transition: background 0.18s var(--ease), color 0.18s var(--ease);
+}
+.nav-chat:hover { background: var(--panel-2); color: var(--text); }
+.nav-chat.active { background: var(--panel-3); color: var(--white); }
+.nav-chat-title { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.nav-chat-actions { display: none; gap: 2px; flex-shrink: 0; }
+.nav-chat:hover .nav-chat-actions { display: flex; }
+.nav-chat-btn {
+  padding: 0 4px;
+  border-radius: 3px;
+  font-size: 11px;
+  color: var(--dim);
+  transition: color 0.15s, background 0.15s;
+}
+.nav-chat-btn:hover { background: var(--panel-3); color: var(--text); }
+.nav-chat-btn.danger:hover { color: var(--danger); }
+.nav-chat-edit {
+  width: 100%;
+  padding: 3px 8px;
+  font-size: 12px;
+}
+
 /* Narrow windows: sidebar collapses to icons; badges shrink to corner chips. */
 @media (max-width: 900px) {
   .sidebar { width: 64px; padding: 20px 8px 12px; }
   .brand { justify-content: center; padding: 0 0 18px; }
-  .brand-text, .nav-label, #conn-label, .provider-chip { display: none; }
+  .brand-text, .nav-label, #conn-label, .provider-chip, .nav-chats { display: none; }
   .nav-item { position: relative; justify-content: center; padding: 11px 8px; }
   .nav-icon { width: auto; }
   .nav-badge {
@@ -179,7 +231,7 @@ input, textarea, select { font: inherit; color: inherit; }
   align-items: center;
   gap: 6px;
   padding: 7px 14px;
-  border-radius: 8px;
+  border-radius: 4px;
   border: 1px solid var(--border-strong);
   background: var(--panel-2);
   color: var(--text);
@@ -199,7 +251,7 @@ input, textarea, select { font: inherit; color: inherit; }
 .input {
   background: var(--panel);
   border: 1px solid var(--border-strong);
-  border-radius: 8px;
+  border-radius: 4px;
   padding: 8px 12px;
   color: var(--text);
   outline: none;
@@ -296,8 +348,8 @@ textarea.input { resize: vertical; font-family: inherit; }
 .switch:checked { background: var(--white); border-color: var(--white); }
 .switch:checked::after { transform: translateX(18px); background: #000; }
 
-.seg { display: inline-flex; background: var(--panel); border: 1px solid var(--border); border-radius: 8px; padding: 3px; gap: 2px; }
-.seg-item { padding: 4px 12px; border-radius: 6px; font-size: 12px; color: var(--muted); transition: all 0.15s var(--ease); }
+.seg { display: inline-flex; background: var(--panel); border: 1px solid var(--border); border-radius: 4px; padding: 3px; gap: 2px; }
+.seg-item { padding: 4px 12px; border-radius: 3px; font-size: 12px; color: var(--muted); transition: all 0.15s var(--ease); }
 .seg-item:hover { color: var(--text); }
 .seg-item.active { background: var(--panel-3); color: var(--white); }
 .seg-count { font-family: var(--font-mono); font-size: 10px; color: var(--dim); }
@@ -426,7 +478,7 @@ textarea.input { resize: vertical; font-family: inherit; }
 .agent-task {
   background: var(--panel-2);
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: 4px;
   padding: 8px 10px;
   font-size: 12px;
   color: var(--muted);
@@ -480,11 +532,11 @@ textarea.input { resize: vertical; font-family: inherit; }
 
 /* ---------- orchestrator ---------- */
 
-/* Chat centers in the leftover space (auto margins absorb it); the rail
-   stays pinned to the far right edge. */
-.orch-layout { display: flex; gap: 20px; height: 100%; }
+.orch-layout { display: flex; gap: 10px; height: 100%; }
 
-.chat { display: flex; flex-direction: column; height: 100%; flex: 0 1 1100px; margin: 0 auto; min-width: 0; }
+#view-orchestrator { padding: 24px 10px; }
+
+.chat { display: flex; flex-direction: column; height: 100%; flex: 1 1 auto; min-width: 0; }
 
 .orch-rail {
   width: 236px;
@@ -554,6 +606,7 @@ textarea.input { resize: vertical; font-family: inherit; }
   flex-direction: column;
   gap: 12px;
   padding-bottom: 16px;
+  padding-right: 14px;
 }
 .chat-log { display: flex; flex-direction: column; gap: 12px; }
 /* Anchor short conversations to the input, like any chat app — the slack
@@ -573,7 +626,7 @@ textarea.input { resize: vertical; font-family: inherit; }
 .chat-msg {
   max-width: min(82%, 720px);
   padding: 10px 14px;
-  border-radius: 12px;
+  border-radius: 8px;
   font-size: 13.5px;
   white-space: pre-wrap;
   overflow-wrap: break-word;
@@ -593,7 +646,7 @@ textarea.input { resize: vertical; font-family: inherit; }
   transition: color 0.15s, border-color 0.15s;
 }
 .chat-older:hover { color: var(--text); border-color: var(--muted); }
-.chat-msg.user { align-self: flex-end; background: var(--white); color: #000; border-bottom-right-radius: 4px; }
+.chat-msg.user { align-self: flex-end; background: var(--white); color: #000; border-bottom-right-radius: 3px; }
 .chat-msg.pending { opacity: 0.65; }
 .chat-msg.user.scheduler {
   align-self: center;
@@ -612,7 +665,7 @@ textarea.input { resize: vertical; font-family: inherit; }
   color: var(--dim);
   margin-bottom: 4px;
 }
-.chat-msg.assistant { align-self: flex-start; background: var(--panel-2); border: 1px solid var(--border); border-bottom-left-radius: 4px; }
+.chat-msg.assistant { align-self: flex-start; background: var(--panel-2); border: 1px solid var(--border); border-bottom-left-radius: 3px; }
 .chat-msg.system { align-self: center; color: var(--dim); font-size: 12px; background: none; padding: 2px; }
 
 /* The live stream is styled as an in-progress assistant bubble. */
@@ -623,8 +676,8 @@ textarea.input { resize: vertical; font-family: inherit; }
   max-width: min(92%, 900px);
   background: var(--panel-2);
   border: 1px solid var(--border);
-  border-radius: 12px;
-  border-bottom-left-radius: 4px;
+  border-radius: 8px;
+  border-bottom-left-radius: 3px;
   padding: 12px 14px;
   flex-shrink: 0;
   animation: rise-in 0.25s var(--ease);
@@ -669,7 +722,7 @@ textarea.input { resize: vertical; font-family: inherit; }
 .tool-strip {
   margin: -2px 0 10px;
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: 4px;
   background: var(--panel);
   font-size: 12px;
 }
@@ -694,7 +747,7 @@ textarea.input { resize: vertical; font-family: inherit; }
   background: var(--panel);
   border: 1px solid var(--border);
   border-left: 2px solid var(--ok);
-  border-radius: 10px;
+  border-radius: 6px;
   animation: rise-in 0.25s var(--ease);
 }
 .chat-task.failed { border-left-color: var(--danger); }
@@ -716,12 +769,16 @@ textarea.input { resize: vertical; font-family: inherit; }
 .chat-task-body { padding: 12px 14px; font-size: 13px; max-height: 320px; overflow-y: auto; }
 
 .chat-input { display: flex; gap: 10px; align-items: flex-end; border-top: 1px solid var(--border); padding-top: 14px; }
+/* One row is exactly 42px (20 line + 2×10 padding + 2×1 border); the buttons
+   are fixed to the same 42px, so with align-items:flex-end all four edges line
+   up when the textarea is a single row, and bottoms stay flush as it grows. */
 .chat-input textarea {
   flex: 1;
   background: var(--panel);
   border: 1px solid var(--border-strong);
-  border-radius: 10px;
+  border-radius: 4px;
   padding: 10px 14px;
+  line-height: 20px;
   color: var(--text);
   outline: none;
   resize: none;
@@ -729,6 +786,7 @@ textarea.input { resize: vertical; font-family: inherit; }
 }
 .chat-input textarea:focus { border-color: #6b6b6b; }
 .chat-buttons { display: flex; flex-direction: column; gap: 6px; }
+.chat-buttons .btn { height: 42px; padding: 0 18px; justify-content: center; }
 
 /* ---------- todos ---------- */
 
@@ -756,7 +814,7 @@ textarea.input { resize: vertical; font-family: inherit; }
   appearance: none;
   width: 18px; height: 18px;
   border: 1.5px solid var(--border-strong);
-  border-radius: 6px;
+  border-radius: 3px;
   cursor: pointer;
   flex-shrink: 0;
   position: relative;
@@ -776,7 +834,7 @@ textarea.input { resize: vertical; font-family: inherit; }
 }
 
 .todo-title { flex: 1; font-size: 13.5px; min-width: 0; overflow: hidden; text-overflow: ellipsis; }
-.todo-title[contenteditable="true"]:focus { outline: 1px solid var(--border-strong); border-radius: 4px; padding: 0 4px; }
+.todo-title[contenteditable="true"]:focus { outline: 1px solid var(--border-strong); border-radius: 3px; padding: 0 4px; }
 
 .todo-pri {
   font-family: var(--font-mono);
@@ -828,7 +886,7 @@ button.task-badge:hover { background: var(--panel-3); }
   display: inline-grid;
   place-items: center;
   border: 1px solid var(--border-strong);
-  border-radius: 5px;
+  border-radius: 3px;
   color: var(--muted);
   flex-shrink: 0;
 }
@@ -856,7 +914,7 @@ button.task-badge:hover { background: var(--panel-3); }
   max-height: 160px;
   overflow-y: auto;
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: 4px;
   padding: 8px 12px;
   background: var(--panel);
 }
@@ -894,7 +952,7 @@ button.task-badge:hover { background: var(--panel-3); }
 .session-meta { font-family: var(--font-mono); font-size: 11px; color: var(--dim); flex-shrink: 0; }
 
 .msg-view { display: flex; flex-direction: column; gap: 10px; max-height: 55vh; overflow-y: auto; }
-.msg-row { border: 1px solid var(--border); border-radius: 8px; padding: 10px 12px; background: var(--panel-2); }
+.msg-row { border: 1px solid var(--border); border-radius: 4px; padding: 10px 12px; background: var(--panel-2); }
 .msg-role { font-family: var(--font-mono); font-size: 10px; text-transform: uppercase; letter-spacing: 0.1em; color: var(--dim); margin-bottom: 4px; }
 .msg-content { font-size: 12.5px; white-space: pre-wrap; overflow-wrap: break-word; color: var(--muted); max-height: 200px; overflow-y: auto; }
 
@@ -914,7 +972,7 @@ button.task-badge:hover { background: var(--panel-3); }
   font-size: 13px;
   background: var(--bg);
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: 4px;
   padding: 10px 12px;
   margin: 10px 0;
   white-space: pre-wrap;
@@ -941,7 +999,7 @@ button.task-badge:hover { background: var(--panel-3); }
   overflow-y: auto;
   background: var(--panel);
   border: 1px solid var(--border-strong);
-  border-radius: 14px;
+  border-radius: 8px;
   padding: 20px;
   animation: modal-in 0.25s var(--ease);
 }
@@ -957,7 +1015,7 @@ button.task-badge:hover { background: var(--panel-3); }
   overflow-wrap: break-word;
   background: var(--bg);
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: 4px;
   padding: 14px;
   max-height: 50vh;
   overflow-y: auto;
@@ -972,7 +1030,7 @@ button.task-badge:hover { background: var(--panel-3); }
   min-width: 130px;
   background: var(--panel-2);
   border: 1px solid var(--border-strong);
-  border-radius: 8px;
+  border-radius: 4px;
   padding: 4px;
   box-shadow: 0 8px 30px #000000aa;
   display: flex;
@@ -982,7 +1040,7 @@ button.task-badge:hover { background: var(--panel-3); }
 .popmenu button {
   text-align: left;
   padding: 7px 12px;
-  border-radius: 6px;
+  border-radius: 3px;
   font-size: 12.5px;
   color: var(--text);
   transition: background 0.12s;
@@ -1040,7 +1098,7 @@ button.task-badge:hover { background: var(--panel-3); }
 .toast {
   background: var(--panel-2);
   border: 1px solid var(--border-strong);
-  border-radius: 10px;
+  border-radius: 6px;
   padding: 10px 16px;
   font-size: 13px;
   box-shadow: 0 8px 30px #000000aa;
@@ -1058,7 +1116,7 @@ button.task-badge:hover { background: var(--panel-3); }
   font-size: 11.5px;
   background: var(--bg);
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: 3px;
   padding: 6px 8px;
   margin-top: 6px;
   white-space: pre-wrap;
@@ -1112,14 +1170,14 @@ button.task-badge:hover { background: var(--panel-3); }
   font-size: 0.88em;
   background: var(--panel-3);
   border: 1px solid var(--border);
-  border-radius: 5px;
+  border-radius: 3px;
   padding: 0.12em 0.4em;
 }
 
 .md .codeblock {
   margin: 0.8em 0;
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: 4px;
   overflow: hidden;
   background: var(--bg);
 }
@@ -1143,7 +1201,7 @@ button.task-badge:hover { background: var(--panel-3); }
   text-transform: uppercase;
   color: var(--muted);
   padding: 2px 8px;
-  border-radius: 5px;
+  border-radius: 3px;
   transition: color 0.15s, background 0.15s;
 }
 .codeblock-copy:hover { color: var(--white); background: var(--panel-3); }
@@ -1179,7 +1237,7 @@ button.task-badge:hover { background: var(--panel-3); }
 }
 .md tr:nth-child(even) td { background: var(--panel); }
 
-.md img { max-width: 100%; border-radius: 8px; }
+.md img { max-width: 100%; border-radius: 4px; }
 
 .md .katex { font-size: 1.05em; }
 .md .katex-display {


### PR DESCRIPTION
Moves the New chat button into the sidebar under the Orchestrator tab, with a list of past conversations you can switch to, rename inline, or delete (cascades to messages, tool calls and sub-agent sessions).
Adds switch/rename/delete API endpoints and repository methods; the orchestrator rehydrates the model context when switching so old conversations continue where they left off.
Also slims the composer (single-row auto-growing input, send button pixel-aligned with it) and normalizes corner radii onto a consistent sharper scale.