### PR TITLE
Isolate todo store persistence in unit tests

### DIFF
--- a/Saturn.Tests/TestHelpers/TodoStoreTestSetup.cs
+++ b/Saturn.Tests/TestHelpers/TodoStoreTestSetup.cs
@@ -18,6 +18,18 @@ namespace Saturn.Tests.TestHelpers
             var workspace = Path.Combine(Path.GetTempPath(), $"SaturnTodoStoreTest_{Guid.NewGuid():N}");
             Directory.CreateDirectory(workspace);
             TodoStore.OverrideRepositoryFactory(() => new ChatHistoryRepository(workspace));
+
+            AppDomain.CurrentDomain.ProcessExit += (_, _) =>
+            {
+                try
+                {
+                    Directory.Delete(workspace, recursive: true);
+                }
+                catch
+                {
+                    // Best-effort cleanup; the DB file may still be locked.
+                }
+            };
         }
     }
 }

--- a/Saturn.Tests/TestHelpers/TodoStoreTestSetup.cs
+++ b/Saturn.Tests/TestHelpers/TodoStoreTestSetup.cs
@@ -1,0 +1,23 @@
+using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+using Saturn.Data;
+using Saturn.Tools.Todo;
+
+namespace Saturn.Tests.TestHelpers
+{
+    // TodoStore is a process-wide static that by default persists to
+    // .saturn/chats.db in the current directory. Redirect it to an isolated
+    // per-run workspace before any test touches it, so unit tests never
+    // depend on (or corrupt) a shared database file.
+    internal static class TodoStoreTestSetup
+    {
+        [ModuleInitializer]
+        internal static void RedirectTodoPersistenceToTempWorkspace()
+        {
+            var workspace = Path.Combine(Path.GetTempPath(), $"SaturnTodoStoreTest_{Guid.NewGuid():N}");
+            Directory.CreateDirectory(workspace);
+            TodoStore.OverrideRepositoryFactory(() => new ChatHistoryRepository(workspace));
+        }
+    }
+}

--- a/Tools/Todo/TodoStore.cs
+++ b/Tools/Todo/TodoStore.cs
@@ -31,7 +31,9 @@ namespace Saturn.Tools.Todo
 
         // Own repository instance on the shared chats.db; per-agent repositories
         // already coexist on the same file (WAL + busy_timeout).
-        private static readonly Lazy<ChatHistoryRepository?> _repository = new(() =>
+        private static Lazy<ChatHistoryRepository?> _repository = new(CreateDefaultRepository);
+
+        private static ChatHistoryRepository? CreateDefaultRepository()
         {
             try
             {
@@ -42,7 +44,20 @@ namespace Saturn.Tools.Todo
                 Console.Error.WriteLine($"Failed to open todo persistence store: {ex.Message}");
                 return null;
             }
-        });
+        }
+
+        // Test seam: unit tests must not share the process-wide chats.db in the
+        // current directory, so Saturn.Tests redirects persistence to an
+        // isolated workspace before any repository access happens.
+        internal static void OverrideRepositoryFactory(Func<ChatHistoryRepository?> factory)
+        {
+            var previous = _repository;
+            _repository = new Lazy<ChatHistoryRepository?>(factory);
+            if (previous.IsValueCreated)
+            {
+                previous.Value?.Dispose();
+            }
+        }
 
         public static string CurrentKey()
         {


### PR DESCRIPTION
TodoStore opened .saturn/chats.db from the current directory via a fixed static Lazy, so a single SQLite failure on CI (disk I/O error in run 29609640691) made every persistable SetAsync return false and broke UpdateTodosToolTests with an unexpected persistence warning.

Adds an internal repository factory override on TodoStore, and a module initializer in Saturn.Tests that redirects todo persistence to an isolated temp workspace so unit tests never touch a shared database file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by giving each test run its own temporary data workspace.
  * Prevented test data from affecting or being affected by other runs.

* **Reliability**
  * Improved handling of todo data storage initialization and cleanup during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->