### PR TITLE
Route git_commit through the command approval pipeline

### DIFF
--- a/Saturn.Tests/Tools/GitCommitToolTests.cs
+++ b/Saturn.Tests/Tools/GitCommitToolTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+using FluentAssertions;
+using Saturn.Tools.Git;
+using Saturn.Tools.Core;
+
+namespace Saturn.Tests.Tools
+{
+    public class GitCommitToolTests : IDisposable
+    {
+        private sealed class FakeApprovalService : ICommandApprovalService
+        {
+            public bool Approve;
+            public string? LastCommand;
+            public string? LastWorkingDirectory;
+
+            public Task<bool> RequestApprovalAsync(string command, string workingDirectory)
+            {
+                LastCommand = command;
+                LastWorkingDirectory = workingDirectory;
+                return Task.FromResult(Approve);
+            }
+        }
+
+        private readonly string _repoPath;
+
+        public GitCommitToolTests()
+        {
+            _repoPath = Path.Combine(Path.GetTempPath(), "saturn-git-commit-tests-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_repoPath);
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(_repoPath, recursive: true);
+            }
+            catch { }
+        }
+
+        private async Task InitRepoAsync()
+        {
+            (await GitHelper.RunGitCommandAsync(new[] { "init" }, _repoPath)).Success.Should().BeTrue();
+            (await GitHelper.RunGitCommandAsync(new[] { "config", "user.email", "test@example.com" }, _repoPath)).Success.Should().BeTrue();
+            (await GitHelper.RunGitCommandAsync(new[] { "config", "user.name", "Test" }, _repoPath)).Success.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task DeniedApproval_ReturnsErrorAndDoesNotCommit()
+        {
+            await InitRepoAsync();
+            await File.WriteAllTextAsync(Path.Combine(_repoPath, "file.txt"), "content");
+
+            var approval = new FakeApprovalService { Approve = false };
+            var tool = new GitCommitTool(approval);
+
+            var result = await tool.ExecuteAsync(new Dictionary<string, object>
+            {
+                ["message"] = "should not land",
+                ["files"] = new[] { "file.txt" },
+                ["workingDirectory"] = _repoPath
+            });
+
+            result.Success.Should().BeFalse();
+            result.Error.Should().Contain("denied");
+            approval.LastCommand.Should().Contain("git add file.txt");
+            approval.LastCommand.Should().Contain("git commit");
+            approval.LastWorkingDirectory.Should().Be(_repoPath);
+
+            var log = await GitHelper.RunGitCommandAsync(new[] { "log", "--oneline" }, _repoPath);
+            log.Success.Should().BeFalse("no commit should exist in the repo");
+        }
+
+        [Fact]
+        public async Task ApprovedCommit_Succeeds()
+        {
+            await InitRepoAsync();
+            await File.WriteAllTextAsync(Path.Combine(_repoPath, "file.txt"), "content");
+
+            var approval = new FakeApprovalService { Approve = true };
+            var tool = new GitCommitTool(approval);
+
+            var result = await tool.ExecuteAsync(new Dictionary<string, object>
+            {
+                ["message"] = "test commit",
+                ["files"] = new[] { "file.txt" },
+                ["workingDirectory"] = _repoPath
+            });
+
+            result.Success.Should().BeTrue();
+
+            var log = await GitHelper.RunGitCommandAsync(new[] { "log", "--oneline" }, _repoPath);
+            log.Success.Should().BeTrue();
+            log.Output.Should().Contain("test commit");
+        }
+    }
+}

--- a/Saturn.Tests/Tools/GitToolsTests.cs
+++ b/Saturn.Tests/Tools/GitToolsTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Saturn.Tools.Core;
 using Saturn.Tools.Git;
 using Xunit;
 
@@ -114,7 +115,7 @@ namespace Saturn.Tests.Tools
             File.WriteAllText(Path.Combine(_repo, "a.txt"), "a\n");
             File.WriteAllText(Path.Combine(_repo, "b.txt"), "b\n");
 
-            var result = await new GitCommitTool().ExecuteAsync(new Dictionary<string, object>
+            var result = await new GitCommitTool(new CommandApprovalService(false)).ExecuteAsync(new Dictionary<string, object>
             {
                 ["message"] = "add a only",
                 ["files"] = new[] { "a.txt" },
@@ -133,7 +134,7 @@ namespace Saturn.Tests.Tools
         {
             File.WriteAllText(Path.Combine(_repo, "secret.txt"), "do not stage me\n");
 
-            var result = await new GitCommitTool().ExecuteAsync(new Dictionary<string, object>
+            var result = await new GitCommitTool(new CommandApprovalService(false)).ExecuteAsync(new Dictionary<string, object>
             {
                 ["message"] = "sneaky",
                 ["files"] = new[] { "-A" },

--- a/Tools/Git/GitCommitTool.cs
+++ b/Tools/Git/GitCommitTool.cs
@@ -8,8 +8,17 @@ namespace Saturn.Tools.Git
 {
     public class GitCommitTool : ToolBase
     {
+        private readonly ICommandApprovalService _approvalService;
+
+        public GitCommitTool() : this(null!) { }
+
+        public GitCommitTool(ICommandApprovalService approvalService)
+        {
+            _approvalService = approvalService ?? new CommandApprovalService(true);
+        }
+
         public override string Name => "git_commit";
-        public override string Description => "Creates a new git commit with the specified message.";
+        public override string Description => "Creates a new git commit with the specified message. The user may be asked to approve the commit before it runs; a denied commit returns an error.";
 
         protected override Dictionary<string, object> GetParameterProperties()
         {
@@ -61,6 +70,16 @@ namespace Saturn.Tools.Git
                 return CreateErrorResult($"Working directory does not exist: {workingDirectory}");
             }
 
+            if (AgentContext.RequireCommandApproval)
+            {
+                var approved = await _approvalService.RequestApprovalAsync(
+                    DescribeCommand(message, files), workingDirectory);
+                if (!approved)
+                {
+                    return CreateErrorResult("Git commit denied by user");
+                }
+            }
+
             try
             {
                 if (files != null && files.Length > 0)
@@ -91,6 +110,16 @@ namespace Saturn.Tools.Git
             {
                 return CreateErrorResult($"Exception executing git commit: {ex.Message}");
             }
+        }
+
+        private static string DescribeCommand(string message, string[]? files)
+        {
+            var commit = $"git commit -m \"{message}\"";
+            if (files == null || files.Length == 0)
+            {
+                return commit;
+            }
+            return $"git add {string.Join(" ", files)} && {commit}";
         }
     }
 }


### PR DESCRIPTION
git_commit ran `git add` and `git commit` without going through the approval pipeline, so sub-agents (which get every registered tool by default) could commit with no oversight.

The tool now requests approval the same way execute_command does: honoring RequireCommandApproval and delegating to the coordinator's judge/user-queue tiers via CommandApprovalService. Denied commits return an error before touching the index.

Adds tests for the approved and denied paths, and updates the existing git tool tests to inject a non-prompting approval service.
