### PR TITLE
Fix flaky background command output test

### DIFF
--- a/Saturn.Tests/Tools/ExecuteCommandToolTests.cs
+++ b/Saturn.Tests/Tools/ExecuteCommandToolTests.cs
@@ -79,7 +79,9 @@ namespace Saturn.Tests.Tools
 
             var collected = "";
             var status = "running";
-            for (var i = 0; i < 50 && status == "running"; i++)
+            // Keep polling after the status flips to exited: the exit notification can
+            // arrive before the async output readers deliver the final buffered lines.
+            for (var i = 0; i < 50 && (status == "running" || !collected.Contains("bg_marker")); i++)
             {
                 await Task.Delay(100);
                 var poll = await getOutput.ExecuteAsync(new Dictionary<string, object> { ["command_id"] = commandId });


### PR DESCRIPTION
Background_StartsPollsAndCompletes was flaky on windows-latest (run 29642770095): the process exit event can fire before the async output readers deliver the final buffered stdout, so the poll loop stopped on status "exited" with nothing collected.

Nothing is dropped in the product; get_command_output already documents that one more call shortly after exit may return final output still being flushed. The test now keeps polling (same 5s bound) until the marker shows up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved background command completion testing to account for delayed asynchronous output.
  * Prevented intermittent test failures when completion notifications arrive before buffered output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->