### PR TITLE
Add runtime workspace selection and switching

### DIFF
--- a/Agents/Core/AgentBase.cs
+++ b/Agents/Core/AgentBase.cs
@@ -68,10 +68,13 @@ namespace Saturn.Agents.Core
         /// </summary>
         public void ReinitializeRepository()
         {
+            // Queued flush tasks read the live Repository property, so it must stay
+            // set (and undisposed) until they drain or they would silently drop the
+            // old session's tail messages.
+            WaitForPendingFlushes();
             var old = Repository;
             Repository = null;
             CurrentSessionId = null;
-            WaitForPendingFlushes();
             old?.Dispose();
             InitializeRepository();
         }

--- a/Agents/Core/AgentBase.cs
+++ b/Agents/Core/AgentBase.cs
@@ -61,6 +61,38 @@ namespace Saturn.Agents.Core
             }
         }
 
+        /// <summary>
+        /// Reopens chat persistence after a workspace switch: the repository path is
+        /// resolved from the current workspace at construction, so the old instance
+        /// must be replaced and the session restarted in the new workspace's DB.
+        /// </summary>
+        public void ReinitializeRepository()
+        {
+            var old = Repository;
+            Repository = null;
+            CurrentSessionId = null;
+            WaitForPendingFlushes();
+            old?.Dispose();
+            InitializeRepository();
+        }
+
+        private void WaitForPendingFlushes()
+        {
+            Task[] pendingFlushes;
+            lock (_pendingMessagesLock)
+            {
+                pendingFlushes = _pendingFlushTasks.Where(t => !t.IsCompleted).ToArray();
+                _pendingFlushTasks.Clear();
+            }
+
+            if (pendingFlushes.Length > 0)
+            {
+                // Give queued persistence work a chance to finish before the
+                // repository goes away; flush failures log rather than throw.
+                try { Task.WaitAll(pendingFlushes, TimeSpan.FromSeconds(5)); } catch { }
+            }
+        }
+
         public async Task InitializeSessionAsync(string? chatType = "main", string? parentSessionId = null)
         {
             if (Repository != null)
@@ -1624,19 +1656,7 @@ namespace Saturn.Agents.Core
         {
             if (disposing)
             {
-                Task[] pendingFlushes;
-                lock (_pendingMessagesLock)
-                {
-                    pendingFlushes = _pendingFlushTasks.Where(t => !t.IsCompleted).ToArray();
-                    _pendingFlushTasks.Clear();
-                }
-
-                if (pendingFlushes.Length > 0)
-                {
-                    // Give queued persistence work a chance to finish before the
-                    // repository goes away; flush failures log rather than throw.
-                    try { Task.WaitAll(pendingFlushes, TimeSpan.FromSeconds(5)); } catch { }
-                }
+                WaitForPendingFlushes();
 
                 Repository?.Dispose();
                 Repository = null;

--- a/Agents/SystemPrompt.cs
+++ b/Agents/SystemPrompt.cs
@@ -59,28 +59,32 @@ namespace Saturn.Agents
             if (string.IsNullOrWhiteSpace(fullPrompt))
                 return fullPrompt;
 
-            var dirStartIndex = fullPrompt.IndexOf(DirectorySectionStart);
-            var dirEndIndex = fullPrompt.IndexOf(DirectorySectionEnd);
-            if (dirStartIndex >= 0 && dirEndIndex > dirStartIndex)
-            {
-                fullPrompt = fullPrompt.Remove(dirStartIndex, dirEndIndex - dirStartIndex + DirectorySectionEnd.Length);
-            }
-
-            var rulesStartIndex = fullPrompt.IndexOf(UserRulesSectionStart);
-            var rulesEndIndex = fullPrompt.IndexOf(UserRulesSectionEnd);
-            if (rulesStartIndex >= 0 && rulesEndIndex > rulesStartIndex)
-            {
-                fullPrompt = fullPrompt.Remove(rulesStartIndex, rulesEndIndex - rulesStartIndex + UserRulesSectionEnd.Length);
-            }
-
-            var skillsStartIndex = fullPrompt.IndexOf("\n<skills>");
-            var skillsEndIndex = fullPrompt.IndexOf("</skills>");
-            if (skillsStartIndex >= 0 && skillsEndIndex > skillsStartIndex)
-            {
-                fullPrompt = fullPrompt.Remove(skillsStartIndex, skillsEndIndex - skillsStartIndex + "</skills>".Length);
-            }
+            // Generated sections are appended after the base prompt in the order
+            // directory, rules, skills, so strip from the tail in reverse order.
+            // Anchoring on the last occurrence (and requiring it to sit at the end)
+            // keeps base prompts that merely mention the markers intact.
+            fullPrompt = StripTrailingSection(fullPrompt, "\n<skills>", "</skills>");
+            fullPrompt = StripTrailingSection(fullPrompt, UserRulesSectionStart, UserRulesSectionEnd);
+            fullPrompt = StripTrailingSection(fullPrompt, DirectorySectionStart, DirectorySectionEnd);
 
             return fullPrompt.TrimEnd();
+        }
+
+        private static string StripTrailingSection(string prompt, string sectionStart, string sectionEnd)
+        {
+            var startIndex = prompt.LastIndexOf(sectionStart, StringComparison.Ordinal);
+            if (startIndex < 0)
+                return prompt;
+
+            var endIndex = prompt.IndexOf(sectionEnd, startIndex, StringComparison.Ordinal);
+            if (endIndex < 0)
+                return prompt;
+
+            var afterEnd = endIndex + sectionEnd.Length;
+            if (prompt.AsSpan(afterEnd).Trim().Length > 0)
+                return prompt;
+
+            return prompt.Remove(startIndex);
         }
 
         /// <summary>

--- a/Agents/SystemPrompt.cs
+++ b/Agents/SystemPrompt.cs
@@ -1,10 +1,12 @@
-﻿using Saturn.Core;
+﻿using Saturn.Agents.Core;
+using Saturn.Core;
 using Saturn.Tools;
 using Saturn.Tools.Core;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace Saturn.Agents
@@ -46,6 +48,71 @@ namespace Saturn.Agents
 
             var result = output.ToString();
             return result;
+        }
+
+        /// <summary>
+        /// Strips the generated sections (directory view, user rules, skills catalog)
+        /// from a composed prompt, returning the base prompt they were appended to.
+        /// </summary>
+        public static string ExtractBase(string fullPrompt)
+        {
+            if (string.IsNullOrWhiteSpace(fullPrompt))
+                return fullPrompt;
+
+            var dirStartIndex = fullPrompt.IndexOf(DirectorySectionStart);
+            var dirEndIndex = fullPrompt.IndexOf(DirectorySectionEnd);
+            if (dirStartIndex >= 0 && dirEndIndex > dirStartIndex)
+            {
+                fullPrompt = fullPrompt.Remove(dirStartIndex, dirEndIndex - dirStartIndex + DirectorySectionEnd.Length);
+            }
+
+            var rulesStartIndex = fullPrompt.IndexOf(UserRulesSectionStart);
+            var rulesEndIndex = fullPrompt.IndexOf(UserRulesSectionEnd);
+            if (rulesStartIndex >= 0 && rulesEndIndex > rulesStartIndex)
+            {
+                fullPrompt = fullPrompt.Remove(rulesStartIndex, rulesEndIndex - rulesStartIndex + UserRulesSectionEnd.Length);
+            }
+
+            var skillsStartIndex = fullPrompt.IndexOf("\n<skills>");
+            var skillsEndIndex = fullPrompt.IndexOf("</skills>");
+            if (skillsStartIndex >= 0 && skillsEndIndex > skillsStartIndex)
+            {
+                fullPrompt = fullPrompt.Remove(skillsStartIndex, skillsEndIndex - skillsStartIndex + "</skills>".Length);
+            }
+
+            return fullPrompt.TrimEnd();
+        }
+
+        /// <summary>
+        /// Rebuilds the agent's composed system prompt against the current workspace
+        /// (fresh directory view, rules, and skills catalog) and patches the live
+        /// session's system message so the next turn uses it.
+        /// </summary>
+        public static async Task<string> RecomposeAsync(AgentBase agent)
+        {
+            var basePrompt = ExtractBase(agent.Configuration.SystemPrompt);
+
+            var skillsSection = agent.Configuration.EnableSkills
+                ? Saturn.Skills.SkillPrompts.BuildSystemPromptSection(
+                    agent.Configuration.SkillAudience, agent.Configuration.SubAgentTypeName)
+                : null;
+
+            var freshSystemPrompt = await Create(
+                basePrompt,
+                includeDirectories: true,
+                includeUserRules: agent.Configuration.EnableUserRules,
+                skillsSection: skillsSection);
+
+            agent.Configuration.SystemPrompt = freshSystemPrompt;
+
+            if (agent.ChatHistory.Count > 0 && agent.ChatHistory[0].Role == "system")
+            {
+                agent.ChatHistory[0].Content = JsonDocument.Parse(
+                    JsonSerializer.Serialize(freshSystemPrompt)
+                ).RootElement;
+            }
+
+            return freshSystemPrompt;
         }
 
         private static async Task<string> GenerateDirectoryView()

--- a/Configuration/ConfigurationManager.cs
+++ b/Configuration/ConfigurationManager.cs
@@ -149,13 +149,15 @@ namespace Saturn.Configuration
             try
             {
                 if (config.ActiveProvider == null || config.Providers == null ||
-                    config.SearchProvider == null || config.SearchProviders == null)
+                    config.SearchProvider == null || config.SearchProviders == null ||
+                    config.RecentWorkspaces == null)
                 {
                     var existing = await LoadForRewriteAsync();
                     config.ActiveProvider ??= existing?.ActiveProvider;
                     config.Providers ??= existing?.Providers;
                     config.SearchProvider ??= existing?.SearchProvider;
                     config.SearchProviders ??= existing?.SearchProviders;
+                    config.RecentWorkspaces ??= existing?.RecentWorkspaces;
                 }
 
                 if (!string.IsNullOrWhiteSpace(config.ActiveProvider) && !string.IsNullOrWhiteSpace(config.Model))
@@ -239,6 +241,34 @@ namespace Saturn.Configuration
             }
 
             await SaveConfigurationLockedAsync(config);
+        }
+
+        public static async Task AddRecentWorkspaceAsync(string path)
+        {
+            await SaveLock.WaitAsync();
+            try
+            {
+                var config = await LoadForRewriteAsync() ?? new PersistedAgentConfiguration();
+
+                var recent = config.RecentWorkspaces ?? new List<string>();
+                recent.RemoveAll(p => string.Equals(p, path, StringComparison.OrdinalIgnoreCase));
+                recent.Insert(0, path);
+                if (recent.Count > 10)
+                {
+                    recent.RemoveRange(10, recent.Count - 10);
+                }
+                config.RecentWorkspaces = recent;
+
+                await SaveConfigurationLockedAsync(config);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"Failed to save recent workspace: {ex.Message}");
+            }
+            finally
+            {
+                SaveLock.Release();
+            }
         }
 
         public static ProviderSettings GetProviderSettings(PersistedAgentConfiguration? config, string providerName)
@@ -351,10 +381,12 @@ namespace Saturn.Configuration
                 ToolNames = config.ToolNames,
                 RequireCommandApproval = config.RequireCommandApproval,
                 EnableUserRules = config.EnableUserRules,
+                EnableSkills = config.EnableSkills,
                 ActiveProvider = config.ActiveProvider,
                 Providers = protectedProviders ?? config.Providers,
                 SearchProvider = config.SearchProvider,
-                SearchProviders = protectedSearchProviders ?? config.SearchProviders
+                SearchProviders = protectedSearchProviders ?? config.SearchProviders,
+                RecentWorkspaces = config.RecentWorkspaces
             };
         }
 

--- a/Configuration/Objects/PersistedAgentConfiguration.cs
+++ b/Configuration/Objects/PersistedAgentConfiguration.cs
@@ -29,6 +29,8 @@ namespace Saturn.Configuration.Objects
         public string? SearchProvider { get; set; }
 
         public Dictionary<string, PersistedProviderConfiguration>? SearchProviders { get; set; }
+
+        public List<string>? RecentWorkspaces { get; set; }
     }
 
     public class PersistedProviderConfiguration

--- a/Core/GitManager.cs
+++ b/Core/GitManager.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Saturn.Core.Workspace;
 
 namespace Saturn.Core
 {
@@ -38,13 +39,13 @@ namespace Saturn.Core
 
         public static bool IsRepository(string? path = null)
         {
-            path ??= Environment.CurrentDirectory;
+            path ??= WorkspaceManager.CurrentWorkspace;
             return Directory.Exists(Path.Combine(path, ".git"));
         }
 
         public static async Task<(bool success, string message)> InitializeRepository(string? path = null)
         {
-            path ??= Environment.CurrentDirectory;
+            path ??= WorkspaceManager.CurrentWorkspace;
 
             if (!IsGitInstalled())
             {
@@ -170,7 +171,7 @@ namespace Saturn.Core
                     {
                         FileName = "git",
                         Arguments = arguments,
-                        WorkingDirectory = workingDirectory ?? Environment.CurrentDirectory,
+                        WorkingDirectory = workingDirectory ?? WorkspaceManager.CurrentWorkspace,
                         RedirectStandardOutput = true,
                         RedirectStandardError = true,
                         UseShellExecute = false,

--- a/Core/UserRulesManager.cs
+++ b/Core/UserRulesManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
+using Saturn.Core.Workspace;
 
 namespace Saturn.Core
 {
@@ -13,7 +14,7 @@ namespace Saturn.Core
         
         public static string GetRulesFilePath()
         {
-            var saturnDir = Path.Combine(Environment.CurrentDirectory, ".saturn");
+            var saturnDir = Path.Combine(WorkspaceManager.CurrentWorkspace, ".saturn");
             if (!Directory.Exists(saturnDir))
             {
                 Directory.CreateDirectory(saturnDir);

--- a/Core/Workspace/WorkspaceManager.cs
+++ b/Core/Workspace/WorkspaceManager.cs
@@ -38,6 +38,15 @@ namespace Saturn.Core.Workspace
 
         public static event Action<string, string>? WorkspaceChanged;
 
+        /// <summary>
+        /// Path equality semantics for the local filesystem: case-insensitive on
+        /// Windows and macOS, case-sensitive elsewhere.
+        /// </summary>
+        public static StringComparison PathComparison =>
+            OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal;
+
         public static void Initialize(string? path)
         {
             lock (Sync)
@@ -89,7 +98,7 @@ namespace Saturn.Core.Workspace
                 }
 
                 oldPath = _current ?? Environment.CurrentDirectory;
-                if (string.Equals(oldPath, normalized, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(oldPath, normalized, PathComparison))
                 {
                     return new WorkspaceSwitchResult(true, normalized, null);
                 }

--- a/Core/Workspace/WorkspaceManager.cs
+++ b/Core/Workspace/WorkspaceManager.cs
@@ -1,0 +1,125 @@
+using System;
+using System.IO;
+
+namespace Saturn.Core.Workspace
+{
+    public record WorkspaceSwitchResult(bool Success, string? NormalizedPath, string? Error);
+
+    /// <summary>
+    /// Owns the current workspace root. Until <see cref="Initialize"/> is called the
+    /// workspace falls back to the live process working directory, so code (and tests)
+    /// that rely on Directory.SetCurrentDirectory keep working unchanged.
+    /// </summary>
+    public static class WorkspaceManager
+    {
+        private static readonly object Sync = new();
+        private static string? _current;
+
+        public static string CurrentWorkspace
+        {
+            get
+            {
+                lock (Sync)
+                {
+                    return _current ?? Environment.CurrentDirectory;
+                }
+            }
+        }
+
+        public static string WorkspaceName
+        {
+            get
+            {
+                var path = CurrentWorkspace;
+                var name = Path.GetFileName(Path.TrimEndingDirectorySeparator(path));
+                return string.IsNullOrEmpty(name) ? path : name;
+            }
+        }
+
+        public static event Action<string, string>? WorkspaceChanged;
+
+        public static void Initialize(string? path)
+        {
+            lock (Sync)
+            {
+                if (string.IsNullOrWhiteSpace(path))
+                {
+                    _current = Normalize(Environment.CurrentDirectory);
+                    return;
+                }
+
+                var normalized = Normalize(path);
+                if (!Directory.Exists(normalized))
+                {
+                    throw new DirectoryNotFoundException($"Workspace directory does not exist: {normalized}");
+                }
+
+                _current = normalized;
+            }
+        }
+
+        public static WorkspaceSwitchResult TrySwitch(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return new WorkspaceSwitchResult(false, null, "Workspace path is empty.");
+            }
+
+            string oldPath;
+            string normalized;
+            lock (Sync)
+            {
+                try
+                {
+                    normalized = Normalize(path);
+                }
+                catch (Exception ex)
+                {
+                    return new WorkspaceSwitchResult(false, null, $"Invalid workspace path: {ex.Message}");
+                }
+
+                if (File.Exists(normalized))
+                {
+                    return new WorkspaceSwitchResult(false, null, "Workspace path points to a file, not a directory.");
+                }
+
+                if (!Directory.Exists(normalized))
+                {
+                    return new WorkspaceSwitchResult(false, null, $"Directory does not exist: {normalized}");
+                }
+
+                oldPath = _current ?? Environment.CurrentDirectory;
+                if (string.Equals(oldPath, normalized, StringComparison.OrdinalIgnoreCase))
+                {
+                    return new WorkspaceSwitchResult(true, normalized, null);
+                }
+
+                _current = normalized;
+            }
+
+            WorkspaceChanged?.Invoke(oldPath, normalized);
+            return new WorkspaceSwitchResult(true, normalized, null);
+        }
+
+        private static string Normalize(string path)
+        {
+            // Relative paths resolve against the current workspace (which is the
+            // launch CWD before Initialize), not the raw process CWD.
+            var basePath = _current ?? Environment.CurrentDirectory;
+            var full = Path.GetFullPath(path, basePath);
+
+            var trimmed = Path.TrimEndingDirectorySeparator(full);
+            // TrimEndingDirectorySeparator("C:\") returns "C:", which is a
+            // drive-relative path; keep the root form for drive roots.
+            return Path.GetPathRoot(full) == full ? full : trimmed;
+        }
+
+        internal static void ResetForTests()
+        {
+            lock (Sync)
+            {
+                _current = null;
+            }
+        }
+    }
+}

--- a/Data/ChatHistoryRepository.cs
+++ b/Data/ChatHistoryRepository.cs
@@ -20,9 +20,9 @@ public class ChatHistoryRepository : IDisposable
 
     public ChatHistoryRepository(string? workspacePath = null)
     {
-        var saturnDir = workspacePath != null 
+        var saturnDir = workspacePath != null
             ? Path.Combine(workspacePath, ".saturn")
-            : Path.Combine(Environment.CurrentDirectory, ".saturn");
+            : Path.Combine(Saturn.Core.Workspace.WorkspaceManager.CurrentWorkspace, ".saturn");
         
         if (!Directory.Exists(saturnDir))
         {

--- a/Data/Tasks/TaskStore.cs
+++ b/Data/Tasks/TaskStore.cs
@@ -47,20 +47,38 @@ namespace Saturn.Data.Tasks
 
     public class TaskStore : IDisposable
     {
-        public TaskRepository Project { get; }
+        public TaskRepository Project { get; private set; }
         public TaskRepository Global { get; }
+
+        private readonly object _projectSwapLock = new();
 
         public event Action<string, SaturnTask>? OnTaskChanged;
 
         public TaskStore(string? workspacePath = null, string? globalDirectory = null)
         {
-            var projectDir = Path.Combine(workspacePath ?? Directory.GetCurrentDirectory(), ".saturn");
+            var projectDir = Path.Combine(workspacePath ?? Saturn.Core.Workspace.WorkspaceManager.CurrentWorkspace, ".saturn");
             var globalDir = globalDirectory
                 ?? Environment.GetEnvironmentVariable("SATURN_CONFIG_DIR")
                 ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Saturn");
 
             Project = new TaskRepository(Path.Combine(projectDir, "tasks.db"), includeRuntimeTables: true);
             Global = new TaskRepository(Path.Combine(globalDir, "tasks.db"), includeRuntimeTables: false);
+        }
+
+        /// <summary>
+        /// Repoints the project-scope repository at a new workspace's tasks.db. The
+        /// TaskStore instance (and its OnTaskChanged subscribers) stays the same;
+        /// callers must ensure no task work is in flight before switching.
+        /// </summary>
+        public void SwitchWorkspace(string workspacePath)
+        {
+            lock (_projectSwapLock)
+            {
+                var old = Project;
+                var projectDir = Path.Combine(workspacePath, ".saturn");
+                Project = new TaskRepository(Path.Combine(projectDir, "tasks.db"), includeRuntimeTables: true);
+                old.Dispose();
+            }
         }
 
         public TaskRepository RepoFor(string scope) => scope == TaskScopes.Global ? Global : Project;
@@ -426,7 +444,7 @@ namespace Saturn.Data.Tasks
 
         public async Task<int> ImportLegacyTodosAsync(string? workspacePath = null)
         {
-            var todosPath = Path.Combine(workspacePath ?? Directory.GetCurrentDirectory(), ".saturn", "todos.json");
+            var todosPath = Path.Combine(workspacePath ?? Saturn.Core.Workspace.WorkspaceManager.CurrentWorkspace, ".saturn", "todos.json");
             if (!File.Exists(todosPath))
             {
                 return 0;

--- a/Program.cs
+++ b/Program.cs
@@ -19,10 +19,27 @@ namespace Saturn
         {
             try
             {
-                if (!GitManager.IsRepository())
+                if (!TryParseOptions(args, out var options))
+                {
+                    Environment.Exit(1);
+                }
+
+                try
+                {
+                    Saturn.Core.Workspace.WorkspaceManager.Initialize(options.Workspace);
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Invalid workspace: {ex.Message}");
+                    Environment.Exit(1);
+                }
+
+                var workspacePath = Saturn.Core.Workspace.WorkspaceManager.CurrentWorkspace;
+
+                if (!GitManager.IsRepository(workspacePath))
                 {
                     Console.Clear();
-                    var shouldContinue = await GitRepositoryPrompt.ShowPrompt();
+                    var shouldContinue = await GitRepositoryPrompt.ShowPrompt(workspacePath);
                     
                     if (!shouldContinue)
                     {
@@ -35,13 +52,14 @@ namespace Saturn
                     await Task.Delay(1000);
                 }
 
-                var isWebMode = TryParseWebOptions(args, out var port);
-                var (agent, client) = await CreateAgent(isWebMode);
+                var (agent, client) = await CreateAgent(options.IsWebMode);
 
-                if (isWebMode)
+                await ConfigurationManager.AddRecentWorkspaceAsync(workspacePath);
+
+                if (options.IsWebMode)
                 {
                     agent.IsOrchestrator = true;
-                    var server = new Saturn.Web.WebServer(agent, client, port);
+                    var server = new Saturn.Web.WebServer(agent, client, options.Port);
                     Console.WriteLine($"Saturn web UI running at {server.Url}");
                     Console.WriteLine("Press Ctrl+C to stop.");
                     await server.RunAsync(onReady: () => TryOpenBrowser(server.Url));
@@ -66,10 +84,13 @@ namespace Saturn
         }
         
 
-        static bool TryParseWebOptions(string[] args, out int port)
+        internal sealed record StartupOptions(bool IsWebMode, int Port, string? Workspace);
+
+        static bool TryParseOptions(string[] args, out StartupOptions options)
         {
-            port = 5225;
+            var port = 5225;
             var webRequested = false;
+            string? workspace = null;
 
             for (var i = 0; i < args.Length; i++)
             {
@@ -82,9 +103,22 @@ namespace Saturn
                     port = parsed;
                     i++;
                 }
+                else if (args[i] == "--workspace")
+                {
+                    if (i + 1 >= args.Length || string.IsNullOrWhiteSpace(args[i + 1]))
+                    {
+                        Console.WriteLine("--workspace requires a directory path.");
+                        options = new StartupOptions(webRequested, port, null);
+                        return false;
+                    }
+
+                    workspace = args[i + 1];
+                    i++;
+                }
             }
 
-            return webRequested;
+            options = new StartupOptions(webRequested, port, workspace);
+            return true;
         }
 
         static void TryOpenBrowser(string url)

--- a/Saturn.Tests/Core/WorkspaceManagerTests.cs
+++ b/Saturn.Tests/Core/WorkspaceManagerTests.cs
@@ -104,6 +104,32 @@ namespace Saturn.Tests.Core
             WorkspaceManager.WorkspaceChanged += handler;
             try
             {
+                var result = WorkspaceManager.TrySwitch(target);
+                result.Success.Should().BeTrue();
+                raised.Should().BeFalse();
+            }
+            finally
+            {
+                WorkspaceManager.WorkspaceChanged -= handler;
+            }
+        }
+
+        [Fact]
+        public void TrySwitch_SamePathDifferentCase_IsNoOpOnCaseInsensitiveFilesystems()
+        {
+            if (!OperatingSystem.IsWindows() && !OperatingSystem.IsMacOS())
+            {
+                return; // case-variant paths name distinct directories elsewhere
+            }
+
+            var target = _files.CreateDirectory("workspace-case");
+            WorkspaceManager.TrySwitch(target).Success.Should().BeTrue();
+
+            var raised = false;
+            Action<string, string> handler = (_, _) => raised = true;
+            WorkspaceManager.WorkspaceChanged += handler;
+            try
+            {
                 var result = WorkspaceManager.TrySwitch(target.ToUpperInvariant());
                 result.Success.Should().BeTrue();
                 raised.Should().BeFalse();

--- a/Saturn.Tests/Core/WorkspaceManagerTests.cs
+++ b/Saturn.Tests/Core/WorkspaceManagerTests.cs
@@ -1,0 +1,140 @@
+using System;
+using System.IO;
+using FluentAssertions;
+using Saturn.Core.Workspace;
+using Saturn.Tests.TestHelpers;
+using Xunit;
+
+namespace Saturn.Tests.Core
+{
+    [Collection("WorkingDirectory")]
+    public class WorkspaceManagerTests : IDisposable
+    {
+        private readonly FileTestHelper _files = new();
+
+        public void Dispose()
+        {
+            WorkspaceManager.ResetForTests();
+            _files.Dispose();
+        }
+
+        [Fact]
+        public void CurrentWorkspace_Uninitialized_TracksProcessWorkingDirectory()
+        {
+            WorkspaceManager.ResetForTests();
+            WorkspaceManager.CurrentWorkspace.Should().Be(Environment.CurrentDirectory);
+        }
+
+        [Fact]
+        public void Initialize_NullPath_UsesCurrentDirectory()
+        {
+            WorkspaceManager.Initialize(null);
+            WorkspaceManager.CurrentWorkspace.Should().Be(
+                Path.TrimEndingDirectorySeparator(Path.GetFullPath(Environment.CurrentDirectory)));
+        }
+
+        [Fact]
+        public void Initialize_NonexistentPath_Throws()
+        {
+            var missing = Path.Combine(_files.TestDirectory, "does-not-exist");
+            var act = () => WorkspaceManager.Initialize(missing);
+            act.Should().Throw<DirectoryNotFoundException>();
+        }
+
+        [Fact]
+        public void TrySwitch_ValidDirectory_SwitchesAndNormalizes()
+        {
+            var target = _files.CreateDirectory("workspace-a");
+
+            var result = WorkspaceManager.TrySwitch(target + Path.DirectorySeparatorChar);
+
+            result.Success.Should().BeTrue();
+            result.NormalizedPath.Should().Be(target);
+            WorkspaceManager.CurrentWorkspace.Should().Be(target);
+            WorkspaceManager.WorkspaceName.Should().Be("workspace-a");
+        }
+
+        [Fact]
+        public void TrySwitch_RelativePath_ResolvesAgainstCurrentWorkspace()
+        {
+            var root = _files.CreateDirectory("root");
+            var child = _files.CreateDirectory(Path.Combine("root", "child"));
+            WorkspaceManager.TrySwitch(root).Success.Should().BeTrue();
+
+            var result = WorkspaceManager.TrySwitch("child");
+
+            result.Success.Should().BeTrue();
+            result.NormalizedPath.Should().Be(child);
+        }
+
+        [Fact]
+        public void TrySwitch_NonexistentDirectory_Fails()
+        {
+            var missing = Path.Combine(_files.TestDirectory, "missing");
+            var result = WorkspaceManager.TrySwitch(missing);
+
+            result.Success.Should().BeFalse();
+            result.Error.Should().Contain("does not exist");
+        }
+
+        [Fact]
+        public void TrySwitch_FilePath_Fails()
+        {
+            var file = _files.CreateFile("a-file.txt", "content");
+            var result = WorkspaceManager.TrySwitch(file);
+
+            result.Success.Should().BeFalse();
+            result.Error.Should().Contain("file");
+        }
+
+        [Fact]
+        public void TrySwitch_EmptyPath_Fails()
+        {
+            WorkspaceManager.TrySwitch("  ").Success.Should().BeFalse();
+        }
+
+        [Fact]
+        public void TrySwitch_SamePath_IsNoOpSuccessAndDoesNotRaiseEvent()
+        {
+            var target = _files.CreateDirectory("workspace-b");
+            WorkspaceManager.TrySwitch(target).Success.Should().BeTrue();
+
+            var raised = false;
+            Action<string, string> handler = (_, _) => raised = true;
+            WorkspaceManager.WorkspaceChanged += handler;
+            try
+            {
+                var result = WorkspaceManager.TrySwitch(target.ToUpperInvariant());
+                result.Success.Should().BeTrue();
+                raised.Should().BeFalse();
+            }
+            finally
+            {
+                WorkspaceManager.WorkspaceChanged -= handler;
+            }
+        }
+
+        [Fact]
+        public void TrySwitch_RaisesWorkspaceChangedWithOldAndNewPaths()
+        {
+            var first = _files.CreateDirectory("first");
+            var second = _files.CreateDirectory("second");
+            WorkspaceManager.TrySwitch(first).Success.Should().BeTrue();
+
+            string? oldPath = null, newPath = null;
+            Action<string, string> handler = (o, n) => { oldPath = o; newPath = n; };
+            WorkspaceManager.WorkspaceChanged += handler;
+            try
+            {
+                WorkspaceManager.TrySwitch(second).Success.Should().BeTrue();
+            }
+            finally
+            {
+                WorkspaceManager.WorkspaceChanged -= handler;
+            }
+
+            oldPath.Should().Be(first);
+            newPath.Should().Be(second);
+        }
+    }
+}

--- a/Saturn.Tests/Core/WorkspaceSwitchFlowTests.cs
+++ b/Saturn.Tests/Core/WorkspaceSwitchFlowTests.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Saturn.Core.Workspace;
+using Saturn.Data;
+using Saturn.Data.Tasks;
+using Saturn.Tests.TestHelpers;
+using Saturn.Tools;
+using Xunit;
+
+namespace Saturn.Tests.Core
+{
+    [Collection("WorkingDirectory")]
+    public class WorkspaceSwitchFlowTests : IDisposable
+    {
+        private readonly FileTestHelper _files = new();
+        private readonly string _globalDir;
+
+        public WorkspaceSwitchFlowTests()
+        {
+            _globalDir = _files.CreateDirectory("global");
+        }
+
+        public void Dispose()
+        {
+            WorkspaceManager.ResetForTests();
+            _files.Dispose();
+        }
+
+        [Fact]
+        public void ChatHistoryRepository_AfterSwitch_CreatesDbInNewWorkspace()
+        {
+            var wsA = _files.CreateDirectory("ws-a");
+            var wsB = _files.CreateDirectory("ws-b");
+
+            WorkspaceManager.TrySwitch(wsA).Success.Should().BeTrue();
+            using (var repoA = new ChatHistoryRepository())
+            {
+                File.Exists(Path.Combine(wsA, ".saturn", "chats.db")).Should().BeTrue();
+            }
+
+            WorkspaceManager.TrySwitch(wsB).Success.Should().BeTrue();
+            using (var repoB = new ChatHistoryRepository())
+            {
+                File.Exists(Path.Combine(wsB, ".saturn", "chats.db")).Should().BeTrue();
+            }
+        }
+
+        [Fact]
+        public async Task TaskStore_SwitchWorkspace_RepointsProjectDbAndKeepsSubscribers()
+        {
+            var wsA = _files.CreateDirectory("tasks-a");
+            var wsB = _files.CreateDirectory("tasks-b");
+
+            using var store = new TaskStore(wsA, _globalDir);
+            var changes = new List<string>();
+            store.OnTaskChanged += (change, _) => changes.Add(change);
+
+            await store.CreateAsync(new TaskCreateSpec { Title = "in A" });
+            File.Exists(Path.Combine(wsA, ".saturn", "tasks.db")).Should().BeTrue();
+
+            store.SwitchWorkspace(wsB);
+
+            var tasksInB = await store.ListAsync();
+            tasksInB.Should().BeEmpty("workspace B starts with a fresh tasks.db");
+
+            await store.CreateAsync(new TaskCreateSpec { Title = "in B" });
+            File.Exists(Path.Combine(wsB, ".saturn", "tasks.db")).Should().BeTrue();
+            changes.Should().HaveCount(2, "OnTaskChanged subscribers survive the switch");
+
+            // Workspace A's data is untouched by work done in B.
+            using var reopenedA = new TaskStore(wsA, _globalDir);
+            var tasksInA = await reopenedA.ListAsync();
+            tasksInA.Should().ContainSingle(v => v.Task.Title == "in A");
+        }
+
+        [Fact]
+        public async Task ReadFileTool_SandboxFollowsWorkspaceNotProcessCwd()
+        {
+            var workspace = _files.CreateDirectory("sandbox-ws");
+            var outside = _files.CreateDirectory("outside");
+            var insideFile = Path.Combine(workspace, "inside.txt");
+            var outsideFile = Path.Combine(outside, "outside.txt");
+            File.WriteAllText(insideFile, "inside content");
+            File.WriteAllText(outsideFile, "outside content");
+
+            WorkspaceManager.TrySwitch(workspace).Success.Should().BeTrue();
+            // Process CWD deliberately left elsewhere: the sandbox boundary must
+            // come from the workspace, not from Directory.GetCurrentDirectory().
+            Directory.GetCurrentDirectory().Should().NotBe(workspace);
+
+            var tool = new ReadFileTool();
+
+            var inside = await tool.ExecuteAsync(new Dictionary<string, object> { { "path", insideFile } });
+            inside.Success.Should().BeTrue();
+            inside.FormattedOutput.Should().Contain("inside content");
+
+            // A relative path resolves against the workspace.
+            var relative = await tool.ExecuteAsync(new Dictionary<string, object> { { "path", "inside.txt" } });
+            relative.Success.Should().BeTrue();
+
+            var escape = await tool.ExecuteAsync(new Dictionary<string, object> { { "path", outsideFile } });
+            escape.Success.Should().BeFalse();
+        }
+    }
+}

--- a/Saturn.Tests/Providers/ConfigurationManagerRecentWorkspacesTests.cs
+++ b/Saturn.Tests/Providers/ConfigurationManagerRecentWorkspacesTests.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Saturn.Configuration;
+using Saturn.Configuration.Objects;
+using Saturn.Providers;
+using Xunit;
+
+namespace Saturn.Tests.Providers
+{
+    [Collection("Configuration")]
+    public class ConfigurationManagerRecentWorkspacesTests : IDisposable
+    {
+        private readonly string _configDir;
+
+        public ConfigurationManagerRecentWorkspacesTests()
+        {
+            _configDir = Path.Combine(Path.GetTempPath(), "SaturnTests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_configDir);
+            Environment.SetEnvironmentVariable("SATURN_CONFIG_DIR", _configDir);
+        }
+
+        public void Dispose()
+        {
+            Environment.SetEnvironmentVariable("SATURN_CONFIG_DIR", null);
+            try
+            {
+                Directory.Delete(_configDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+
+        [Fact]
+        public async Task AddRecentWorkspace_RoundTrips()
+        {
+            await ConfigurationManager.AddRecentWorkspaceAsync(@"C:\projects\alpha");
+
+            var config = await ConfigurationManager.LoadConfigurationAsync();
+            config!.RecentWorkspaces.Should().Equal(@"C:\projects\alpha");
+        }
+
+        [Fact]
+        public async Task AddRecentWorkspace_DedupesCaseInsensitivelyAndMovesToFront()
+        {
+            await ConfigurationManager.AddRecentWorkspaceAsync(@"C:\projects\alpha");
+            await ConfigurationManager.AddRecentWorkspaceAsync(@"C:\projects\beta");
+            await ConfigurationManager.AddRecentWorkspaceAsync(@"C:\PROJECTS\ALPHA");
+
+            var config = await ConfigurationManager.LoadConfigurationAsync();
+            config!.RecentWorkspaces.Should().Equal(@"C:\PROJECTS\ALPHA", @"C:\projects\beta");
+        }
+
+        [Fact]
+        public async Task AddRecentWorkspace_CapsAtTen()
+        {
+            for (var i = 0; i < 12; i++)
+            {
+                await ConfigurationManager.AddRecentWorkspaceAsync($@"C:\projects\ws{i}");
+            }
+
+            var config = await ConfigurationManager.LoadConfigurationAsync();
+            config!.RecentWorkspaces.Should().HaveCount(10);
+            config.RecentWorkspaces![0].Should().Be(@"C:\projects\ws11");
+            config.RecentWorkspaces.Should().NotContain(@"C:\projects\ws0");
+            config.RecentWorkspaces.Should().NotContain(@"C:\projects\ws1");
+        }
+
+        [Fact]
+        public async Task OtherSaves_PreserveRecentWorkspaces()
+        {
+            await ConfigurationManager.AddRecentWorkspaceAsync(@"C:\projects\alpha");
+
+            await ConfigurationManager.SaveConfigurationAsync(new PersistedAgentConfiguration
+            {
+                Name = "Assistant",
+                Model = "some-model"
+            });
+
+            var config = await ConfigurationManager.LoadConfigurationAsync();
+            config!.RecentWorkspaces.Should().Equal(@"C:\projects\alpha");
+        }
+
+        [Fact]
+        public async Task SecretProtection_PreservesRecentWorkspacesAndEnableSkills()
+        {
+            // A registered provider with a secret setting forces the
+            // WithProtectedSecrets copy path, which must not drop fields.
+            var providerName = "recent-ws-prov-" + Guid.NewGuid().ToString("N");
+            ProviderRegistry.Register(new FakeProvider
+            {
+                Name = providerName,
+                SettingDescriptors = new[]
+                {
+                    new ProviderSettingDescriptor
+                    {
+                        Key = "apiKey",
+                        Label = "API Key",
+                        Kind = ProviderSettingKind.Secret
+                    }
+                }
+            });
+
+            await ConfigurationManager.AddRecentWorkspaceAsync(@"C:\projects\alpha");
+
+            var config = await ConfigurationManager.LoadConfigurationAsync() ?? new PersistedAgentConfiguration();
+            config.EnableSkills = false;
+            config.ActiveProvider = providerName;
+            config.Providers = new Dictionary<string, PersistedProviderConfiguration>(StringComparer.OrdinalIgnoreCase)
+            {
+                [providerName] = new()
+                {
+                    Settings = new Dictionary<string, string?> { ["apiKey"] = "sk-secret" }
+                }
+            };
+            await ConfigurationManager.SaveConfigurationAsync(config);
+
+            var reloaded = await ConfigurationManager.LoadConfigurationAsync();
+            reloaded!.RecentWorkspaces.Should().Equal(@"C:\projects\alpha");
+            reloaded.EnableSkills.Should().BeFalse();
+            reloaded.Providers![providerName].Settings!["apiKey"].Should().StartWith("enc:v1:");
+        }
+    }
+}

--- a/Skills/SkillManager.cs
+++ b/Skills/SkillManager.cs
@@ -43,7 +43,7 @@ namespace Saturn.Skills
         internal static string? WorkspaceRootOverride { get; set; }
 
         public static string WorkspaceSkillsDirectory =>
-            Path.Combine(WorkspaceRootOverride ?? Environment.CurrentDirectory, ".saturn", "skills");
+            Path.Combine(WorkspaceRootOverride ?? Saturn.Core.Workspace.WorkspaceManager.CurrentWorkspace, ".saturn", "skills");
 
         /// <summary>All skills, workspace skills shadowing global ones on a name collision.</summary>
         public static IReadOnlyList<Skill> GetAllSkills()

--- a/Tools/ApplyDiffTool.cs
+++ b/Tools/ApplyDiffTool.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Security;
 using System.Text;
 using System.Threading.Tasks;
+using Saturn.Core.Workspace;
 using Saturn.Tools.Core;
 using Saturn.Tools.Objects;
 
@@ -145,7 +146,7 @@ The format also supports '*** Add File: path' (every content line prefixed with 
                 {
                     foreach (var file in allFiles)
                     {
-                        var absPath = Path.GetFullPath(file);
+                        var absPath = Path.GetFullPath(file, WorkspaceManager.CurrentWorkspace);
                         lock (FileLocks)
                         {
                             if (FileLocks.Contains(absPath))
@@ -266,7 +267,7 @@ The format also supports '*** Add File: path' (every content line prefixed with 
             foreach (var filePath in files)
             {
                 ValidatePathSecurity(filePath);
-                var absPath = Path.GetFullPath(filePath);
+                var absPath = Path.GetFullPath(filePath, WorkspaceManager.CurrentWorkspace);
                 
                 if (!File.Exists(absPath))
                 {
@@ -293,7 +294,7 @@ The format also supports '*** Add File: path' (every content line prefixed with 
             foreach (var filePath in files)
             {
                 ValidatePathSecurity(filePath);
-                var absPath = Path.GetFullPath(filePath);
+                var absPath = Path.GetFullPath(filePath, WorkspaceManager.CurrentWorkspace);
                 
                 if (File.Exists(absPath))
                 {
@@ -311,7 +312,7 @@ The format also supports '*** Add File: path' (every content line prefixed with 
             foreach (var filePath in files)
             {
                 ValidatePathSecurity(filePath);
-                var absPath = Path.GetFullPath(filePath);
+                var absPath = Path.GetFullPath(filePath, WorkspaceManager.CurrentWorkspace);
                 var content = await File.ReadAllTextAsync(absPath);
                 currentFiles[filePath] = content;
             }
@@ -614,7 +615,7 @@ The format also supports '*** Add File: path' (every content line prefixed with 
                 var filePath = kvp.Key;
                 var change = kvp.Value;
                 ValidatePathSecurity(filePath);
-                var absPath = Path.GetFullPath(filePath);
+                var absPath = Path.GetFullPath(filePath, WorkspaceManager.CurrentWorkspace);
                 
                 if (change.Type == ChangeType.Delete)
                 {
@@ -644,7 +645,7 @@ The format also supports '*** Add File: path' (every content line prefixed with 
             
             foreach (var kvp in commit.Changes)
             {
-                var filePath = Path.GetFullPath(kvp.Key);
+                var filePath = Path.GetFullPath(kvp.Key, WorkspaceManager.CurrentWorkspace);
                 stats.ChangedFiles.Add(filePath);
                 
                 if (kvp.Value.Type == ChangeType.Add)

--- a/Tools/Core/PathSecurity.cs
+++ b/Tools/Core/PathSecurity.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Security;
+using Saturn.Core.Workspace;
 
 namespace Saturn.Tools.Core
 {
@@ -13,8 +14,8 @@ namespace Saturn.Tools.Core
                 throw new ArgumentException("Path cannot be null or empty");
             }
 
-            var fullPath = Path.GetFullPath(path);
-            var workingDirectory = Path.GetFullPath(Directory.GetCurrentDirectory());
+            var workingDirectory = Path.GetFullPath(WorkspaceManager.CurrentWorkspace);
+            var fullPath = Path.GetFullPath(path, workingDirectory);
 
             // Lexical check first: cheap, and catches plain traversal even when
             // the filesystem cannot be probed.

--- a/Tools/DeleteFileTool.cs
+++ b/Tools/DeleteFileTool.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Security;
 using System.Threading.Tasks;
+using Saturn.Core.Workspace;
 using Saturn.Tools.Core;
 using Saturn.Tools.Objects;
 
@@ -99,7 +100,7 @@ Safety features:
             
             try
             {
-                var fullPath = Path.GetFullPath(path);
+                var fullPath = Path.GetFullPath(path, WorkspaceManager.CurrentWorkspace);
 
                 try
                 {
@@ -110,7 +111,7 @@ Safety features:
                     return CreateErrorResult(ex.Message);
                 }
 
-                var workingDirectory = Path.GetFullPath(Directory.GetCurrentDirectory());
+                var workingDirectory = Path.GetFullPath(WorkspaceManager.CurrentWorkspace);
                 var relativeToWorkingDir = Path.GetRelativePath(workingDirectory, fullPath);
                 if (relativeToWorkingDir == ".")
                 {

--- a/Tools/ExecuteCommandTool.cs
+++ b/Tools/ExecuteCommandTool.cs
@@ -122,6 +122,16 @@ Prefer the dedicated file tools (read_file, write_file, grep, glob, list_files) 
                 }
                 
                 var workingDirectory = GetParameter<string>(arguments, "workingDirectory", WorkspaceManager.CurrentWorkspace);
+                try
+                {
+                    // Relative paths must resolve against the active workspace, not the
+                    // process CWD, or they escape workspace isolation after a switch.
+                    workingDirectory = Path.GetFullPath(workingDirectory, WorkspaceManager.CurrentWorkspace);
+                }
+                catch (Exception ex)
+                {
+                    return CreateErrorResult($"Invalid working directory: {ex.Message}");
+                }
                 var timeoutSeconds = GetParameter<int>(arguments, "timeout", _config.DefaultTimeout);
                 if (timeoutSeconds <= 0)
                 {

--- a/Tools/ExecuteCommandTool.cs
+++ b/Tools/ExecuteCommandTool.cs
@@ -7,6 +7,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Saturn.Core.Workspace;
 using Saturn.Tools.Core;
 using Saturn.Tools.Objects;
 
@@ -120,7 +121,7 @@ Prefer the dedicated file tools (read_file, write_file, grep, glob, list_files) 
                     return CreateErrorResult("Command parameter is required");
                 }
                 
-                var workingDirectory = GetParameter<string>(arguments, "workingDirectory", Directory.GetCurrentDirectory());
+                var workingDirectory = GetParameter<string>(arguments, "workingDirectory", WorkspaceManager.CurrentWorkspace);
                 var timeoutSeconds = GetParameter<int>(arguments, "timeout", _config.DefaultTimeout);
                 if (timeoutSeconds <= 0)
                 {

--- a/Tools/Git/GetGitDiffTool.cs
+++ b/Tools/Git/GetGitDiffTool.cs
@@ -56,7 +56,7 @@ namespace Saturn.Tools.Git
             var filePath = GetParameter<string>(parameters, "filePath", string.Empty);
             var staged = GetParameter<bool>(parameters, "staged", false);
             var statOnly = GetParameter<bool>(parameters, "statOnly", false);
-            var workingDirectory = GetParameter<string>(parameters, "workingDirectory", Environment.CurrentDirectory);
+            var workingDirectory = GetParameter<string>(parameters, "workingDirectory", Saturn.Core.Workspace.WorkspaceManager.CurrentWorkspace);
 
             if (!Directory.Exists(workingDirectory))
             {

--- a/Tools/Git/GetGitStatusTool.cs
+++ b/Tools/Git/GetGitStatusTool.cs
@@ -33,7 +33,7 @@ namespace Saturn.Tools.Git
 
         public override async Task<ToolResult> ExecuteAsync(Dictionary<string, object> parameters)
         {
-            var workingDirectory = GetParameter<string>(parameters, "workingDirectory", Environment.CurrentDirectory);
+            var workingDirectory = GetParameter<string>(parameters, "workingDirectory", Saturn.Core.Workspace.WorkspaceManager.CurrentWorkspace);
 
             if (!Directory.Exists(workingDirectory))
             {

--- a/Tools/Git/GitCommitTool.cs
+++ b/Tools/Git/GitCommitTool.cs
@@ -58,7 +58,7 @@ namespace Saturn.Tools.Git
         {
             var message = GetParameter<string>(parameters, "message");
             var files = GetParameter<string[]>(parameters, "files", Array.Empty<string>());
-            var workingDirectory = GetParameter<string>(parameters, "workingDirectory", Environment.CurrentDirectory);
+            var workingDirectory = GetParameter<string>(parameters, "workingDirectory", Saturn.Core.Workspace.WorkspaceManager.CurrentWorkspace);
 
             if (string.IsNullOrEmpty(message))
             {

--- a/Tools/GlobTool.cs
+++ b/Tools/GlobTool.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Security;
 using System.Threading.Tasks;
+using Saturn.Core.Workspace;
 using Saturn.Tools.Core;
 using Saturn.Tools.Objects;
 
@@ -127,7 +128,7 @@ Note: Use this before grep when you need to find files first, then search within
         public override async Task<ToolResult> ExecuteAsync(Dictionary<string, object> parameters)
         {
             var pattern = GetParameter<string>(parameters, "pattern");
-            var basePath = GetParameter<string>(parameters, "path", Directory.GetCurrentDirectory());
+            var basePath = GetParameter<string>(parameters, "path", WorkspaceManager.CurrentWorkspace);
             var includeDirectories = GetParameter<bool>(parameters, "includeDirectories", false);
             var caseSensitive = GetParameter<bool>(parameters, "caseSensitive", false);
             var maxResults = GetParameter<int>(parameters, "maxResults", 1000);

--- a/Tools/ListFilesTool.cs
+++ b/Tools/ListFilesTool.cs
@@ -6,6 +6,7 @@ using System.Security;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Saturn.Core.Workspace;
 using Saturn.Tools.Core;
 using Saturn.Tools.Objects;
 
@@ -127,7 +128,7 @@ Examples
         
         public override string GetDisplaySummary(Dictionary<string, object> parameters)
         {
-            var path = GetParameter<string>(parameters, "path", Directory.GetCurrentDirectory());
+            var path = GetParameter<string>(parameters, "path", WorkspaceManager.CurrentWorkspace);
             var recursive = GetParameter<bool>(parameters, "recursive", false);
             var displayPath = FormatPath(path);
             return $"Listing {displayPath} (recursive: {recursive})";
@@ -137,7 +138,7 @@ Examples
         {
             try
             {
-                var path = GetParameter<string>(parameters, "path", Directory.GetCurrentDirectory());
+                var path = GetParameter<string>(parameters, "path", WorkspaceManager.CurrentWorkspace);
                 var recursive = GetParameter<bool>(parameters, "recursive", false);
                 var includeHidden = GetParameter<bool>(parameters, "includeHidden", false);
                 var pattern = GetParameter<string?>(parameters, "pattern", null);
@@ -155,7 +156,7 @@ Examples
                 }
                 
                 ValidatePathSecurity(path);
-                var fullPath = Path.GetFullPath(path);
+                var fullPath = Path.GetFullPath(path, WorkspaceManager.CurrentWorkspace);
                 var root = Path.GetPathRoot(fullPath) ?? string.Empty;
                 if (fullPath.Length > root.Length)
                 {
@@ -273,7 +274,7 @@ Examples
                             {
                                 Name = dir.Name,
                                 FullPath = dir.FullName,
-                                RelativePath = Path.GetRelativePath(Directory.GetCurrentDirectory(), dir.FullName),
+                                RelativePath = Path.GetRelativePath(WorkspaceManager.CurrentWorkspace, dir.FullName),
                                 IsDirectory = true,
                                 Size = 0,
                                 CreatedDate = dir.CreationTimeUtc,
@@ -327,7 +328,7 @@ Examples
                             {
                                 Name = file.Name,
                                 FullPath = file.FullName,
-                                RelativePath = Path.GetRelativePath(Directory.GetCurrentDirectory(), file.FullName),
+                                RelativePath = Path.GetRelativePath(WorkspaceManager.CurrentWorkspace, file.FullName),
                                 IsDirectory = false,
                                 Size = file.Length,
                                 CreatedDate = file.CreationTimeUtc,
@@ -556,7 +557,7 @@ Examples
             {
                 Name = name,
                 FullPath = fullPath,
-                RelativePath = Path.GetRelativePath(Directory.GetCurrentDirectory(), fullPath),
+                RelativePath = Path.GetRelativePath(WorkspaceManager.CurrentWorkspace, fullPath),
                 IsDirectory = true,
                 HasError = true,
                 ErrorMessage = error,

--- a/Tools/ReadFileTool.cs
+++ b/Tools/ReadFileTool.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
+using Saturn.Core.Workspace;
 using Saturn.Tools.Core;
 using Saturn.Tools.Objects;
 
@@ -132,7 +133,7 @@ Examples:
             try
             {
                 ValidatePathSecurity(path);
-                var fullPath = Path.GetFullPath(path);
+                var fullPath = Path.GetFullPath(path, WorkspaceManager.CurrentWorkspace);
 
                 if (!File.Exists(fullPath))
                 {

--- a/Tools/SearchAndReplaceTool.cs
+++ b/Tools/SearchAndReplaceTool.cs
@@ -8,6 +8,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.Extensions.FileSystemGlobbing;
 using Microsoft.Extensions.FileSystemGlobbing.Abstractions;
+using Saturn.Core.Workspace;
 using Saturn.Tools.Core;
 using Saturn.Tools.Objects;
 
@@ -138,7 +139,7 @@ Safety features:
             var searchPattern = GetParameter<string>(parameters, "searchPattern");
             var replacement = GetParameter<string>(parameters, "replacement");
             var filePattern = GetParameter<string>(parameters, "filePattern");
-            var basePath = GetParameter<string>(parameters, "path", Directory.GetCurrentDirectory());
+            var basePath = GetParameter<string>(parameters, "path", WorkspaceManager.CurrentWorkspace);
             var useRegex = GetParameter<bool>(parameters, "regex", false);
             var caseSensitive = GetParameter<bool>(parameters, "caseSensitive", true);
             var wholeWord = GetParameter<bool>(parameters, "wholeWord", false);
@@ -377,7 +378,7 @@ Safety features:
             output.AppendLine("\nModified files:");
             foreach (var file in results.ProcessedFiles.Where(f => f.Modified))
             {
-                var relativePath = Path.GetRelativePath(Directory.GetCurrentDirectory(), file.Path);
+                var relativePath = Path.GetRelativePath(WorkspaceManager.CurrentWorkspace, file.Path);
                 output.AppendLine($"  {relativePath} ({file.ReplacementCount} replacements)");
             }
             
@@ -388,7 +389,7 @@ Safety features:
                 TotalReplacements = results.TotalReplacements,
                 Files = results.ProcessedFiles.Select(f => new
                 {
-                    Path = Path.GetRelativePath(Directory.GetCurrentDirectory(), f.Path),
+                    Path = Path.GetRelativePath(WorkspaceManager.CurrentWorkspace, f.Path),
                     Matches = f.MatchCount,
                     Replacements = f.ReplacementCount
                 }).ToList()
@@ -405,7 +406,7 @@ Safety features:
             
             foreach (var file in results.ProcessedFiles)
             {
-                var relativePath = Path.GetRelativePath(Directory.GetCurrentDirectory(), file.Path);
+                var relativePath = Path.GetRelativePath(WorkspaceManager.CurrentWorkspace, file.Path);
                 output.AppendLine($"\n{relativePath} ({file.MatchCount} matches):");
                 
                 if (!string.IsNullOrEmpty(file.Preview))
@@ -421,7 +422,7 @@ Safety features:
                 TotalMatches = results.TotalMatches,
                 Files = results.ProcessedFiles.Select(f => new
                 {
-                    Path = Path.GetRelativePath(Directory.GetCurrentDirectory(), f.Path),
+                    Path = Path.GetRelativePath(WorkspaceManager.CurrentWorkspace, f.Path),
                     Matches = f.MatchCount
                 }).ToList()
             };

--- a/Tools/Todo/TodoStore.cs
+++ b/Tools/Todo/TodoStore.cs
@@ -59,6 +59,22 @@ namespace Saturn.Tools.Todo
             }
         }
 
+        /// <summary>
+        /// Drops the cached repository and lists after a workspace switch so the
+        /// next access reopens chats.db under the new workspace.
+        /// </summary>
+        internal static void Reset()
+        {
+            var previous = _repository;
+            _repository = new Lazy<ChatHistoryRepository?>(CreateDefaultRepository);
+            if (previous.IsValueCreated)
+            {
+                previous.Value?.Dispose();
+            }
+            _lists.Clear();
+            _lastAccess.Clear();
+        }
+
         public static string CurrentKey()
         {
             var context = AgentContext.Current;

--- a/Tools/WriteFileTool.cs
+++ b/Tools/WriteFileTool.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Security;
 using System.Text;
 using System.Threading.Tasks;
+using Saturn.Core.Workspace;
 using Saturn.Tools.Core;
 
 namespace Saturn.Tools
@@ -111,7 +112,7 @@ Safety features:
             try
             {
                 ValidatePathSecurity(path);
-                var fullPath = Path.GetFullPath(path);
+                var fullPath = Path.GetFullPath(path, WorkspaceManager.CurrentWorkspace);
                 
                 var encoding = GetEncoding(encodingName);
                 var bytes = encoding.GetBytes(content);
@@ -184,7 +185,7 @@ Safety features:
         {
             PathSecurity.ValidateInsideWorkingDirectory(path);
 
-            var fullPath = Path.GetFullPath(path);
+            var fullPath = Path.GetFullPath(path, WorkspaceManager.CurrentWorkspace);
             var invalidChars = Path.GetInvalidFileNameChars();
             var fileName = Path.GetFileName(fullPath);
             if (fileName.IndexOfAny(invalidChars) >= 0)

--- a/UI/ChatInterface.cs
+++ b/UI/ChatInterface.cs
@@ -161,6 +161,7 @@ namespace Saturn.UI
                 new MenuBarItem("_Options", new MenuItem[]
                 {
                     new MenuItem("_Load Chat...", "", async () => await ShowLoadChatDialog()),
+                    new MenuItem("Switch _Workspace...", "", async () => await ShowWorkspaceSwitchDialogAsync()),
                     new MenuItem("_Clear Chat", "", () =>
                     {
                         if (chatView != null)
@@ -1619,31 +1620,7 @@ namespace Saturn.UI
 
         private string ExtractBaseSystemPrompt(string fullPrompt)
         {
-            if (string.IsNullOrWhiteSpace(fullPrompt))
-                return fullPrompt;
-            
-            var dirStartIndex = fullPrompt.IndexOf("\n<current_directory>");
-            var dirEndIndex = fullPrompt.IndexOf("</current_directory>\n");
-            if (dirStartIndex >= 0 && dirEndIndex > dirStartIndex)
-            {
-                fullPrompt = fullPrompt.Remove(dirStartIndex, dirEndIndex - dirStartIndex + "</current_directory>\n".Length);
-            }
-            
-            var rulesStartIndex = fullPrompt.IndexOf("\n<user_rules>");
-            var rulesEndIndex = fullPrompt.IndexOf("</user_rules>\n");
-            if (rulesStartIndex >= 0 && rulesEndIndex > rulesStartIndex)
-            {
-                fullPrompt = fullPrompt.Remove(rulesStartIndex, rulesEndIndex - rulesStartIndex + "</user_rules>\n".Length);
-            }
-
-            var skillsStartIndex = fullPrompt.IndexOf("\n<skills>");
-            var skillsEndIndex = fullPrompt.IndexOf("</skills>");
-            if (skillsStartIndex >= 0 && skillsEndIndex > skillsStartIndex)
-            {
-                fullPrompt = fullPrompt.Remove(skillsStartIndex, skillsEndIndex - skillsStartIndex + "</skills>".Length);
-            }
-
-            return fullPrompt.TrimEnd();
+            return SystemPrompt.ExtractBase(fullPrompt);
         }
 
         private string? BuildSkillsSection()
@@ -1696,7 +1673,7 @@ namespace Saturn.UI
             
             lastRulesCheckTime = now;
             
-            var rulesPath = Path.Combine(Environment.CurrentDirectory, ".saturn", "rules.md");
+            var rulesPath = Path.Combine(Saturn.Core.Workspace.WorkspaceManager.CurrentWorkspace, ".saturn", "rules.md");
             DateTime? currentModifiedTime = null;
             
             if (File.Exists(rulesPath))
@@ -1793,6 +1770,110 @@ namespace Saturn.UI
             chatView.Text = string.Join("\n", updatedLines);
             chatView.CursorPosition = currentPosition;
             chatView.TopRow = currentTopRow;
+        }
+
+        private async Task ShowWorkspaceSwitchDialogAsync()
+        {
+            if (isProcessing)
+            {
+                MessageBox.ErrorQuery("Switch Workspace", "A response is in progress. Cancel it or wait before switching workspace.", "OK");
+                return;
+            }
+
+            var agentStatuses = AgentManager.Instance.GetAllAgentStatuses();
+            if (agentStatuses.Any(a => !a.IsIdle))
+            {
+                var terminate = MessageBox.Query("Switch Workspace",
+                    "Sub-agents are still working. Terminate them and continue?", "Terminate & Continue", "Cancel");
+                if (terminate != 0)
+                {
+                    return;
+                }
+                AgentManager.Instance.TerminateAllAgents();
+            }
+
+            var config = await ConfigurationManager.LoadConfigurationAsync();
+            var currentWorkspace = Saturn.Core.Workspace.WorkspaceManager.CurrentWorkspace;
+            var dialog = new WorkspaceSwitchDialog(config?.RecentWorkspaces ?? new List<string>(), currentWorkspace);
+            Application.Run(dialog);
+
+            var selectedPath = dialog.SelectedPath;
+            if (string.IsNullOrWhiteSpace(selectedPath))
+            {
+                return;
+            }
+
+            string candidate;
+            try
+            {
+                candidate = Path.GetFullPath(selectedPath, currentWorkspace);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.ErrorQuery("Switch Workspace", $"Invalid path: {ex.Message}", "OK");
+                return;
+            }
+
+            if (!Directory.Exists(candidate))
+            {
+                MessageBox.ErrorQuery("Switch Workspace", $"Directory does not exist:\n{candidate}", "OK");
+                return;
+            }
+
+            if (string.Equals(candidate, currentWorkspace, StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            var confirm = MessageBox.Query("Switch Workspace",
+                $"Switch to {candidate}?\nThis starts a fresh session. Running background commands keep their old directory.",
+                "Switch", "Cancel");
+            if (confirm != 0)
+            {
+                return;
+            }
+
+            if (!Saturn.Core.GitManager.IsRepository(candidate))
+            {
+                var init = MessageBox.Query("Switch Workspace",
+                    $"{candidate} is not a git repository. Initialize one?", "Initialize", "Cancel");
+                if (init != 0)
+                {
+                    return;
+                }
+                var (initOk, initMessage) = await Saturn.Core.GitManager.InitializeRepository(candidate);
+                if (!initOk)
+                {
+                    MessageBox.ErrorQuery("Switch Workspace", initMessage, "OK");
+                    return;
+                }
+            }
+
+            var switched = Saturn.Core.Workspace.WorkspaceManager.TrySwitch(candidate);
+            if (!switched.Success)
+            {
+                MessageBox.ErrorQuery("Switch Workspace", switched.Error ?? "Unknown error", "OK");
+                return;
+            }
+
+            agent.ClearHistory();
+            agent.ReinitializeRepository();
+            Saturn.Tools.Todo.TodoStore.Reset();
+
+            cachedSystemPromptWithRules = null;
+            lastRulesCheckTime = null;
+            lastRulesModifiedTime = null;
+            await RecomposeSystemPromptAsync();
+
+            chatView.Text = GetWelcomeMessage();
+            chatView.CursorPosition = new Point(0, 0);
+            toolCallsView.Text = "No tool calls yet...\n";
+            UpdateAgentStatus("Ready");
+            UpdateConfigurationDisplay();
+            inputField.SetFocus();
+            Application.Refresh();
+
+            await ConfigurationManager.AddRecentWorkspaceAsync(switched.NormalizedPath!);
         }
 
         private async Task ShowLoadChatDialog()

--- a/UI/ChatInterface.cs
+++ b/UI/ChatInterface.cs
@@ -1820,7 +1820,7 @@ namespace Saturn.UI
                 return;
             }
 
-            if (string.Equals(candidate, currentWorkspace, StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(candidate, currentWorkspace, Saturn.Core.Workspace.WorkspaceManager.PathComparison))
             {
                 return;
             }

--- a/UI/Dialogs/WorkspaceSwitchDialog.cs
+++ b/UI/Dialogs/WorkspaceSwitchDialog.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Terminal.Gui;
+
+namespace Saturn.UI.Dialogs
+{
+    public class WorkspaceSwitchDialog : Dialog
+    {
+        private ListView _recentListView = null!;
+        private TextField _pathField = null!;
+        private readonly List<string> _recentWorkspaces;
+
+        public string? SelectedPath { get; private set; }
+
+        public WorkspaceSwitchDialog(IEnumerable<string> recentWorkspaces, string currentWorkspace)
+            : base("Switch Workspace", 70, 20)
+        {
+            _recentWorkspaces = recentWorkspaces
+                .Where(p => !string.Equals(p, currentWorkspace, StringComparison.OrdinalIgnoreCase))
+                .Where(Directory.Exists)
+                .ToList();
+
+            InitializeComponents(currentWorkspace);
+        }
+
+        private void InitializeComponents(string currentWorkspace)
+        {
+            var currentLabel = new Label($"Current: {currentWorkspace}")
+            {
+                X = 1,
+                Y = 1,
+                Width = Dim.Fill(1)
+            };
+            Add(currentLabel);
+
+            var recentLabel = new Label("Recent workspaces (Enter to pick):")
+            {
+                X = 1,
+                Y = 3
+            };
+            Add(recentLabel);
+
+            _recentListView = new ListView()
+            {
+                X = 1,
+                Y = 4,
+                Width = Dim.Fill(1),
+                Height = Dim.Fill(8)
+            };
+            _recentListView.SetSource(_recentWorkspaces);
+            _recentListView.SelectedItemChanged += args =>
+            {
+                if (args.Item >= 0 && args.Item < _recentWorkspaces.Count)
+                {
+                    _pathField.Text = _recentWorkspaces[args.Item];
+                }
+            };
+            _recentListView.OpenSelectedItem += args =>
+            {
+                if (args.Item >= 0 && args.Item < _recentWorkspaces.Count)
+                {
+                    SelectedPath = _recentWorkspaces[args.Item];
+                    Application.RequestStop();
+                }
+            };
+            Add(_recentListView);
+
+            var pathLabel = new Label("Directory path:")
+            {
+                X = 1,
+                Y = Pos.AnchorEnd(6)
+            };
+            Add(pathLabel);
+
+            _pathField = new TextField("")
+            {
+                X = 1,
+                Y = Pos.AnchorEnd(5),
+                Width = Dim.Fill(1)
+            };
+            if (_recentWorkspaces.Count > 0)
+            {
+                _pathField.Text = _recentWorkspaces[0];
+            }
+            Add(_pathField);
+
+            var switchButton = new Button("_Switch")
+            {
+                X = Pos.Center() - 10,
+                Y = Pos.AnchorEnd(3),
+                IsDefault = true
+            };
+            switchButton.Clicked += () =>
+            {
+                var path = _pathField.Text?.ToString()?.Trim();
+                if (string.IsNullOrWhiteSpace(path))
+                {
+                    MessageBox.ErrorQuery("Switch Workspace", "Enter a directory path.", "OK");
+                    return;
+                }
+                SelectedPath = path;
+                Application.RequestStop();
+            };
+            Add(switchButton);
+
+            var cancelButton = new Button("_Cancel")
+            {
+                X = Pos.Center() + 2,
+                Y = Pos.AnchorEnd(3)
+            };
+            cancelButton.Clicked += () =>
+            {
+                SelectedPath = null;
+                Application.RequestStop();
+            };
+            Add(cancelButton);
+        }
+    }
+}

--- a/UI/Dialogs/WorkspaceSwitchDialog.cs
+++ b/UI/Dialogs/WorkspaceSwitchDialog.cs
@@ -18,7 +18,7 @@ namespace Saturn.UI.Dialogs
             : base("Switch Workspace", 70, 20)
         {
             _recentWorkspaces = recentWorkspaces
-                .Where(p => !string.Equals(p, currentWorkspace, StringComparison.OrdinalIgnoreCase))
+                .Where(p => !string.Equals(p, currentWorkspace, Saturn.Core.Workspace.WorkspaceManager.PathComparison))
                 .Where(Directory.Exists)
                 .ToList();
 

--- a/UI/GitRepositoryPrompt.cs
+++ b/UI/GitRepositoryPrompt.cs
@@ -7,8 +7,9 @@ namespace Saturn.UI
 {
     public static class GitRepositoryPrompt
     {
-        public static Task<bool> ShowPrompt()
+        public static Task<bool> ShowPrompt(string? workspacePath = null)
         {
+            workspacePath ??= Environment.CurrentDirectory;
             var userChoice = false;
             var initializationComplete = false;
 
@@ -63,7 +64,7 @@ namespace Saturn.UI
                     }
                 };
 
-                var pathLabel = new Label($"Directory: {Environment.CurrentDirectory}")
+                var pathLabel = new Label($"Directory: {workspacePath}")
                 {
                     X = 2,
                     Y = 6,
@@ -134,7 +135,7 @@ namespace Saturn.UI
                     progressLabel.Text = "🔄 Initializing Git repository...";
                     Application.Refresh();
 
-                    var result = await Task.Run(() => GitManager.InitializeRepository());
+                    var result = await Task.Run(() => GitManager.InitializeRepository(workspacePath));
                     
                     if (result.success)
                     {

--- a/Web/ApiModels.cs
+++ b/Web/ApiModels.cs
@@ -54,6 +54,8 @@ namespace Saturn.Web
 
     public record SessionRenameRequest(string? Title);
 
+    public record WorkspaceSwitchRequest(string? Path, bool? InitGit);
+
     public record ProviderSwitchRequest(string Provider, Dictionary<string, string?>? Settings, string? Model);
 
     public record SearchProviderSwitchRequest(string? Provider, Dictionary<string, string?>? Settings);

--- a/Web/WebServer.cs
+++ b/Web/WebServer.cs
@@ -42,7 +42,7 @@ namespace Saturn.Web
         private readonly TaskStore _tasks = new();
         private readonly OrchestratorService _orchestrator;
         private readonly WebCommandApprovalService _approvals;
-        private readonly ChatHistoryRepository _history = new();
+        private ChatHistoryRepository _history = new();
         private readonly Saturn.Config.TaskSystemSettings _taskSettings = Saturn.Config.TaskSystemSettings.Load();
         private readonly TaskCoordinator _coordinator;
         private readonly TaskSchedulerService _scheduler;
@@ -233,7 +233,9 @@ namespace Saturn.Web
                         done = todos.Count(t => TaskStatuses.IsTerminal(t.Status))
                     },
                     orchestratorBusy = _orchestrator.IsBusy,
-                    pendingApprovals = _approvals.GetPending().Count
+                    pendingApprovals = _approvals.GetPending().Count,
+                    workspace = Saturn.Core.Workspace.WorkspaceManager.CurrentWorkspace,
+                    workspaceName = Saturn.Core.Workspace.WorkspaceManager.WorkspaceName
                 });
             });
 
@@ -1127,6 +1129,100 @@ namespace Saturn.Web
                     return Results.Conflict(new { error = "Orchestrator is busy; cancel the current run first" });
                 }
                 return Results.Ok(new { sessionId = id });
+            });
+
+            api.MapGet("/workspace", async () =>
+            {
+                var current = Saturn.Core.Workspace.WorkspaceManager.CurrentWorkspace;
+                var config = await Configuration.ConfigurationManager.LoadConfigurationAsync();
+                var recent = (config?.RecentWorkspaces ?? new List<string>())
+                    .Where(p => !string.Equals(p, current, StringComparison.OrdinalIgnoreCase))
+                    .Where(Directory.Exists)
+                    .Select(p => new
+                    {
+                        path = p,
+                        name = Path.GetFileName(Path.TrimEndingDirectorySeparator(p))
+                    })
+                    .ToList();
+                return Results.Ok(new
+                {
+                    current,
+                    name = Saturn.Core.Workspace.WorkspaceManager.WorkspaceName,
+                    isGitRepo = Saturn.Core.GitManager.IsRepository(current),
+                    recent
+                });
+            });
+
+            api.MapPost("/workspace/switch", async (WorkspaceSwitchRequest request) =>
+            {
+                if (string.IsNullOrWhiteSpace(request.Path))
+                {
+                    return Results.BadRequest(new { error = "path is required" });
+                }
+                if (_orchestrator.IsBusy)
+                {
+                    return Results.Conflict(new { error = "Orchestrator is busy; cancel the current run first" });
+                }
+                if (manager.GetAgentContexts().Any(c => c.CurrentTask != null))
+                {
+                    return Results.Conflict(new { error = "Sub-agents are still working; wait for or terminate them first" });
+                }
+                if (_approvals.GetPending().Count > 0)
+                {
+                    return Results.Conflict(new { error = "There are pending command approvals; resolve them first" });
+                }
+
+                string candidate;
+                try
+                {
+                    candidate = Path.GetFullPath(request.Path, Saturn.Core.Workspace.WorkspaceManager.CurrentWorkspace);
+                }
+                catch (Exception ex)
+                {
+                    return Results.BadRequest(new { error = $"Invalid path: {ex.Message}" });
+                }
+
+                if (!Directory.Exists(candidate))
+                {
+                    return Results.BadRequest(new { error = $"Directory does not exist: {candidate}" });
+                }
+
+                if (!Saturn.Core.GitManager.IsRepository(candidate))
+                {
+                    if (request.InitGit != true)
+                    {
+                        return Results.Ok(new { needsGitInit = true, path = candidate });
+                    }
+                    var (initOk, initMessage) = await Saturn.Core.GitManager.InitializeRepository(candidate);
+                    if (!initOk)
+                    {
+                        return Results.BadRequest(new { error = initMessage });
+                    }
+                }
+
+                var switched = Saturn.Core.Workspace.WorkspaceManager.TrySwitch(candidate);
+                if (!switched.Success)
+                {
+                    return Results.BadRequest(new { error = switched.Error });
+                }
+                var newPath = switched.NormalizedPath!;
+
+                // Close the old session against the old workspace's DB before any
+                // repositories are repointed, then rebuild everything path-bound.
+                _orchestrator.StartNewSession();
+                _rootAgent.ReinitializeRepository();
+                Saturn.Tools.Todo.TodoStore.Reset();
+                _tasks.SwitchWorkspace(newPath);
+                var oldHistory = _history;
+                _history = new ChatHistoryRepository();
+                oldHistory.Dispose();
+                await SystemPrompt.RecomposeAsync(_rootAgent);
+
+                var name = Saturn.Core.Workspace.WorkspaceManager.WorkspaceName;
+                _hub.Publish("workspace.changed", new { path = newPath, name });
+                await Configuration.ConfigurationManager.AddRecentWorkspaceAsync(newPath);
+
+                return Results.Ok(new { path = newPath, name });
             });
 
             api.MapPut("/sessions/{id}", async (string id, SessionRenameRequest request) =>

--- a/Web/WebServer.cs
+++ b/Web/WebServer.cs
@@ -38,6 +38,9 @@ namespace Saturn.Web
         // drive the agent API even if they can reach the port.
         private readonly string _apiToken = Convert.ToHexString(RandomNumberGenerator.GetBytes(32)).ToLowerInvariant();
 
+        // Guards the workspace-switch transition; see /workspace/switch.
+        private readonly SemaphoreSlim _workspaceSwitchGate = new(1, 1);
+
         private readonly EventHub _hub = new();
         private readonly TaskStore _tasks = new();
         private readonly OrchestratorService _orchestrator;
@@ -1159,70 +1162,84 @@ namespace Saturn.Web
                 {
                     return Results.BadRequest(new { error = "path is required" });
                 }
-                if (_orchestrator.IsBusy)
+                // Serialize switches: two interleaved transitions could dispose each
+                // other's repositories mid-rebuild. Busy checks run under the gate so
+                // a second request re-evaluates against the post-switch state.
+                if (!await _workspaceSwitchGate.WaitAsync(TimeSpan.Zero))
                 {
-                    return Results.Conflict(new { error = "Orchestrator is busy; cancel the current run first" });
+                    return Results.Conflict(new { error = "A workspace switch is already in progress" });
                 }
-                if (manager.GetAgentContexts().Any(c => c.CurrentTask != null))
-                {
-                    return Results.Conflict(new { error = "Sub-agents are still working; wait for or terminate them first" });
-                }
-                if (_approvals.GetPending().Count > 0)
-                {
-                    return Results.Conflict(new { error = "There are pending command approvals; resolve them first" });
-                }
-
-                string candidate;
                 try
                 {
-                    candidate = Path.GetFullPath(request.Path, Saturn.Core.Workspace.WorkspaceManager.CurrentWorkspace);
-                }
-                catch (Exception ex)
-                {
-                    return Results.BadRequest(new { error = $"Invalid path: {ex.Message}" });
-                }
-
-                if (!Directory.Exists(candidate))
-                {
-                    return Results.BadRequest(new { error = $"Directory does not exist: {candidate}" });
-                }
-
-                if (!Saturn.Core.GitManager.IsRepository(candidate))
-                {
-                    if (request.InitGit != true)
+                    if (_orchestrator.IsBusy)
                     {
-                        return Results.Ok(new { needsGitInit = true, path = candidate });
+                        return Results.Conflict(new { error = "Orchestrator is busy; cancel the current run first" });
                     }
-                    var (initOk, initMessage) = await Saturn.Core.GitManager.InitializeRepository(candidate);
-                    if (!initOk)
+                    if (manager.GetAgentContexts().Any(c => c.CurrentTask != null))
                     {
-                        return Results.BadRequest(new { error = initMessage });
+                        return Results.Conflict(new { error = "Sub-agents are still working; wait for or terminate them first" });
                     }
-                }
+                    if (_approvals.GetPending().Count > 0)
+                    {
+                        return Results.Conflict(new { error = "There are pending command approvals; resolve them first" });
+                    }
 
-                var switched = Saturn.Core.Workspace.WorkspaceManager.TrySwitch(candidate);
-                if (!switched.Success)
+                    string candidate;
+                    try
+                    {
+                        candidate = Path.GetFullPath(request.Path, Saturn.Core.Workspace.WorkspaceManager.CurrentWorkspace);
+                    }
+                    catch (Exception ex)
+                    {
+                        return Results.BadRequest(new { error = $"Invalid path: {ex.Message}" });
+                    }
+
+                    if (!Directory.Exists(candidate))
+                    {
+                        return Results.BadRequest(new { error = $"Directory does not exist: {candidate}" });
+                    }
+
+                    if (!Saturn.Core.GitManager.IsRepository(candidate))
+                    {
+                        if (request.InitGit != true)
+                        {
+                            return Results.Ok(new { needsGitInit = true, path = candidate });
+                        }
+                        var (initOk, initMessage) = await Saturn.Core.GitManager.InitializeRepository(candidate);
+                        if (!initOk)
+                        {
+                            return Results.BadRequest(new { error = initMessage });
+                        }
+                    }
+
+                    var switched = Saturn.Core.Workspace.WorkspaceManager.TrySwitch(candidate);
+                    if (!switched.Success)
+                    {
+                        return Results.BadRequest(new { error = switched.Error });
+                    }
+                    var newPath = switched.NormalizedPath!;
+
+                    // Close the old session against the old workspace's DB before any
+                    // repositories are repointed, then rebuild everything path-bound.
+                    _orchestrator.StartNewSession();
+                    _rootAgent.ReinitializeRepository();
+                    Saturn.Tools.Todo.TodoStore.Reset();
+                    _tasks.SwitchWorkspace(newPath);
+                    var oldHistory = _history;
+                    _history = new ChatHistoryRepository();
+                    oldHistory.Dispose();
+                    await SystemPrompt.RecomposeAsync(_rootAgent);
+
+                    var name = Saturn.Core.Workspace.WorkspaceManager.WorkspaceName;
+                    _hub.Publish("workspace.changed", new { path = newPath, name });
+                    await Configuration.ConfigurationManager.AddRecentWorkspaceAsync(newPath);
+
+                    return Results.Ok(new { path = newPath, name });
+                }
+                finally
                 {
-                    return Results.BadRequest(new { error = switched.Error });
+                    _workspaceSwitchGate.Release();
                 }
-                var newPath = switched.NormalizedPath!;
-
-                // Close the old session against the old workspace's DB before any
-                // repositories are repointed, then rebuild everything path-bound.
-                _orchestrator.StartNewSession();
-                _rootAgent.ReinitializeRepository();
-                Saturn.Tools.Todo.TodoStore.Reset();
-                _tasks.SwitchWorkspace(newPath);
-                var oldHistory = _history;
-                _history = new ChatHistoryRepository();
-                oldHistory.Dispose();
-                await SystemPrompt.RecomposeAsync(_rootAgent);
-
-                var name = Saturn.Core.Workspace.WorkspaceManager.WorkspaceName;
-                _hub.Publish("workspace.changed", new { path = newPath, name });
-                await Configuration.ConfigurationManager.AddRecentWorkspaceAsync(newPath);
-
-                return Results.Ok(new { path = newPath, name });
             });
 
             api.MapPut("/sessions/{id}", async (string id, SessionRenameRequest request) =>

--- a/Web/wwwroot/app.js
+++ b/Web/wwwroot/app.js
@@ -369,6 +369,10 @@ async function loadOverview() {
 
   $("#provider-chip").textContent = `${o.provider} · ${o.model}`;
   $("#model-chip").textContent = o.model || "no model";
+  if (o.workspaceName) {
+    $("#workspace-chip").textContent = `⌂ ${o.workspaceName}`;
+    $("#workspace-chip").title = `${o.workspace} — click to switch workspace`;
+  }
   state.uptimeBase = o.uptimeSeconds;
   state.uptimeAt = Date.now();
 
@@ -1283,6 +1287,79 @@ $("#chat-new").addEventListener("click", async () => {
     await loadChatSessions();
   } catch (err) {
     toast(`<b>Error:</b> ${esc(err.message)}`);
+  }
+});
+
+/* ---------- workspace switching ---------- */
+
+async function openWorkspaceModal() {
+  let info;
+  try {
+    info = await api.get("/workspace");
+  } catch (err) {
+    toast(`<b>Workspace:</b> ${esc(err.message)}`);
+    return;
+  }
+  const recentHtml = info.recent.length
+    ? `<label class="field" style="margin-top:10px"><span>Recent workspaces</span></label>
+       <div class="ws-recent">${info.recent
+         .map((r) => `<button type="button" class="btn sm ws-recent-item" data-path="${esc(r.path)}" title="${esc(r.path)}">${esc(r.name)}</button>`)
+         .join("")}</div>`
+    : "";
+  openModal("Switch workspace", `
+    <p class="hint">Current: <b>${esc(info.current)}</b>${info.isGitRepo ? "" : " · not a git repo"}</p>
+    <label class="field"><span>Directory</span>
+      <input class="input" id="ws-path" style="width:100%" placeholder="C:\\path\\to\\project"></label>
+    ${recentHtml}
+    <p class="hint" style="margin-top:10px">Switching starts a fresh session against the new workspace.
+      Running background commands keep their old directory.</p>
+    <div class="field-row" style="margin-top:12px">
+      <button class="btn primary" id="ws-switch">Switch &amp; start fresh session</button>
+    </div>
+    <p class="hint" id="ws-status"></p>
+  `);
+  let initGit = false;
+  $("#modal-body").querySelectorAll(".ws-recent-item").forEach((b) =>
+    b.addEventListener("click", () => {
+      $("#ws-path").value = b.dataset.path;
+      initGit = false;
+      $("#ws-switch").textContent = "Switch & start fresh session";
+      $("#ws-status").textContent = "";
+    }));
+  $("#ws-path").addEventListener("input", () => {
+    initGit = false;
+    $("#ws-switch").textContent = "Switch & start fresh session";
+  });
+  $("#ws-switch").addEventListener("click", async () => {
+    const path = $("#ws-path").value.trim();
+    if (!path) {
+      $("#ws-status").textContent = "Enter a directory path.";
+      return;
+    }
+    $("#ws-switch").disabled = true;
+    try {
+      const r = await api.post("/workspace/switch", { path, initGit });
+      if (r && r.needsGitInit) {
+        initGit = true;
+        $("#ws-status").innerHTML = `<b>${esc(r.path)}</b> is not a git repository. Click again to initialize one and switch.`;
+        $("#ws-switch").textContent = "Initialize git & switch";
+        $("#ws-switch").disabled = false;
+        return;
+      }
+      closeModal();
+    } catch (err) {
+      $("#ws-status").textContent = err.message;
+      $("#ws-switch").disabled = false;
+    }
+  });
+  $("#ws-path").focus();
+}
+
+$("#workspace-chip").addEventListener("click", openWorkspaceModal);
+$("#workspace-chip").addEventListener("keydown", (e) => {
+  if (e.key === "Enter" || e.key === " ") {
+    e.preventDefault();
+    openWorkspaceModal();
   }
 });
 
@@ -2601,6 +2678,25 @@ function connectEvents() {
 
   es.addEventListener("skills.changed", () => {
     if (state.view === "settings") loadSkillsPanel().catch(() => {});
+  });
+
+  es.addEventListener("workspace.changed", (e) => {
+    const d = JSON.parse(e.data);
+    $("#workspace-chip").textContent = `⌂ ${d.name}`;
+    $("#workspace-chip").title = `${d.path} — click to switch workspace`;
+    toast(`Workspace: <b>${esc(d.name)}</b>`);
+    logActivity(`workspace switched to <b>${esc(d.name)}</b>`);
+    loadOverview().catch(() => {});
+    if (state.view === "orchestrator") loadChatSessions().catch(() => {});
+    if (state.view === "sessions") loadSessions().catch(() => {});
+    if (state.view === "work") {
+      loadTodos().catch(() => {});
+      loadWakes().catch(() => {});
+    }
+    if (state.view === "settings") {
+      loadSettings().catch(() => {});
+      loadSkillsPanel().catch(() => {});
+    }
   });
 
   es.addEventListener("provider.changed", (e) => {

--- a/Web/wwwroot/index.html
+++ b/Web/wwwroot/index.html
@@ -56,6 +56,7 @@
           <span id="conn-label">connecting</span>
         </div>
         <div class="provider-chip" id="provider-chip">—</div>
+        <div class="provider-chip workspace-chip" id="workspace-chip" role="button" tabindex="0" title="Switch workspace">—</div>
       </div>
     </aside>
 

--- a/Web/wwwroot/styles.css
+++ b/Web/wwwroot/styles.css
@@ -182,7 +182,8 @@ input, textarea, select { font: inherit; color: inherit; }
 .conn-dot.on { background: var(--ok); box-shadow: 0 0 8px #7dd69266; animation: breathe 3s ease-in-out infinite; }
 .provider-chip { font-family: var(--font-mono); font-size: 11px; color: var(--dim); padding: 0 2px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .workspace-chip { cursor: pointer; }
-.workspace-chip:hover { color: var(--fg); }
+.workspace-chip:hover { color: var(--text); }
+.workspace-chip:focus-visible { color: var(--text); outline: 1px solid var(--border-strong); outline-offset: 2px; }
 .ws-recent { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; }
 
 .main { flex: 1; display: flex; flex-direction: column; min-width: 0; }

--- a/Web/wwwroot/styles.css
+++ b/Web/wwwroot/styles.css
@@ -181,6 +181,9 @@ input, textarea, select { font: inherit; color: inherit; }
 }
 .conn-dot.on { background: var(--ok); box-shadow: 0 0 8px #7dd69266; animation: breathe 3s ease-in-out infinite; }
 .provider-chip { font-family: var(--font-mono); font-size: 11px; color: var(--dim); padding: 0 2px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.workspace-chip { cursor: pointer; }
+.workspace-chip:hover { color: var(--fg); }
+.ws-recent { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; }
 
 .main { flex: 1; display: flex; flex-direction: column; min-width: 0; }
 


### PR DESCRIPTION
﻿The workspace was implicitly the process CWD at launch, so working on a different project meant relaunching Saturn from that directory. This adds a central WorkspaceManager plus a "--workspace" CLI flag, a workspace chip/modal in the web panel and an Options > Switch Workspace dialog in the TUI.

Switching confirms first, is denied while a run/sub-agent/approval is in flight, starts a fresh session against the new workspace's .saturn databases, and rebuilds the system prompt. Recent workspaces are persisted in agent-config.json.

Also fixes WithProtectedSecrets dropping EnableSkills on save, and a race between ClearHistory's async session flush and repository disposal.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workspace switching from the desktop menu and web interface.
  * Choose from recent workspaces or enter a directory manually.
  * Recent workspaces are saved, deduplicated, and limited to the 10 most recent.
  * Workspace status is now visible in the web interface with live updates.
  * Git repositories can be initialized when switching to a new workspace.

* **Bug Fixes**
  * File, Git, task, chat, rules, and skills operations now consistently use the active workspace.
  * Switching workspaces refreshes chat context and workspace-specific data safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->